### PR TITLE
提案: propsをsetupで返すように

### DIFF
--- a/src/components/Main/MainView/MainViewComponentSelector.vue
+++ b/src/components/Main/MainView/MainViewComponentSelector.vue
@@ -1,9 +1,9 @@
 <template>
   <messages-view
-    v-if="viewInfo && viewInfo.type === 'messages'"
+    v-if="props.viewInfo && props.viewInfo.type === 'messages'"
     :channelId="channelId"
   />
-  <qall-view v-else-if="viewInfo && viewInfo.type === 'qall'" />
+  <qall-view v-else-if="props.viewInfo && props.viewInfo.type === 'qall'" />
   <div :class="$style.none" v-else></div>
 </template>
 
@@ -17,7 +17,7 @@ import MessagesView from '@/components/Main/MainView/MessagesView.vue'
 import QallView from '@/components/Main/MainView/QallView.vue'
 
 type Props = {
-  viewType?: ViewInformation
+  viewInfo?: ViewInformation
 }
 
 export default defineComponent({
@@ -30,6 +30,7 @@ export default defineComponent({
     const channelId = computed(() => store.state.app.currentChannelId)
 
     return {
+      props,
       channelId
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49056869/76193568-aafa5300-6227-11ea-8bb8-1af8cbdfb937.png)

![image](https://user-images.githubusercontent.com/49056869/76193555-a170eb00-6227-11ea-8cb8-90036ed868e3.png)

`setup`で`props`を返すようにしてそれを参照するようにすると補完が効くようになるのでそっちに統一するようにしませんか？という提案です
前者みたいになってしまうと型が悲しいことになるので

関連:
- https://github.com/vuejs/vetur/blob/master/docs/interpolation.md#type-checking-with-jsdocs
- https://github.com/vuejs/vetur/blob/master/server/src/modes/script/componentInfo.ts (読んだけどデバッグ出力できなくてわかんなかった)

あと、Propsの型と値が不整合してるの直してます

