### PR TITLE
router

### DIFF
--- a/src/components/Main/Modal/ModalContainer.vue
+++ b/src/components/Main/Modal/ModalContainer.vue
@@ -1,0 +1,96 @@
+<template>
+  <div v-if="modalState.shouldShowModal" :class="$style.container">
+    <div :class="$style.modal" :style="styles.modal">
+      <pre>
+        {{ modalState.current }}
+      </pre>
+      <div :style="{ display: 'flex' }">
+        <button :style="{ padding: '16px' }" @click="onClick">
+          push modal
+        </button>
+        <button :style="{ padding: '16px' }" @click="onClickPop">
+          pop modal
+        </button>
+        <button :style="{ padding: '16px' }" @click="onClickClear">
+          clear modal
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, reactive } from '@vue/composition-api'
+import store from '@/store'
+import { makeStyles } from '@/lib/styles'
+
+const useModal = () => {
+  const state = reactive({
+    shouldShowModal: computed(() => store.getters.ui.modal.shouldShowModal),
+    current: computed(() =>
+      JSON.stringify(store.state.ui.modal.modalState, null, 4)
+    )
+  })
+  window.addEventListener('popstate', event => {
+    // history.stateとstoreの同期をとる
+    if (event.state?.modalState) {
+      store.commit.ui.modal.setState(event.state.modalState)
+    } else {
+      store.commit.ui.modal.setState([])
+    }
+  })
+
+  return {
+    modalState: state
+  }
+}
+
+const useStyles = () =>
+  reactive({
+    modal: makeStyles(theme => ({
+      color: theme.ui.primary,
+      background: theme.background.primary
+    }))
+  })
+
+export default defineComponent({
+  name: 'ModalContainer',
+  setup() {
+    const { modalState } = useModal()
+    const styles = useStyles()
+    const onClick = () =>
+      store.dispatch.ui.modal.pushModal({
+        type: 'user',
+        id: 'test'
+      })
+    const onClickPop = () => store.dispatch.ui.modal.popModal()
+    const onClickClear = () => store.dispatch.ui.modal.clearModal()
+    return {
+      modalState,
+      styles,
+      onClick,
+      onClickPop,
+      onClickClear
+    }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.15);
+}
+.modal {
+  border-radius: 4px;
+  padding: 32px;
+}
+</style>

--- a/src/components/Main/Navigation/ChannelList/ChannelList.vue
+++ b/src/components/Main/Navigation/ChannelList/ChannelList.vue
@@ -19,7 +19,8 @@ import {
   computed,
   reactive,
   set,
-  toRefs
+  toRefs,
+  SetupContext
 } from '@vue/composition-api'
 import store from '@/store'
 import { ChannelId } from '@/types/entity-ids'
@@ -65,8 +66,8 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props: Props) {
-    const { onChannelSelect } = useChannelSelect()
+  setup(props: Props, context: SetupContext) {
+    const { onChannelSelect } = useChannelSelect(context)
     const { channelFoldingState, onChannelFoldingToggle } = useChannelFolding()
     return {
       props,

--- a/src/components/Main/Navigation/NavigationContent/ActivityElement.vue
+++ b/src/components/Main/Navigation/NavigationContent/ActivityElement.vue
@@ -69,7 +69,7 @@ export default defineComponent({
       )
     })
     const styles = useStyles()
-    const { onChannelSelect } = useChannelSelect()
+    const { onChannelSelect } = useChannelSelect(context)
     return {
       props,
       state,

--- a/src/components/UI/UserIcon.vue
+++ b/src/components/UI/UserIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.container" :style="styles.container">
+  <div @click="onClick" :class="$style.container" :style="styles.container">
     <!-- TODO: Badge -->
   </div>
 </template>
@@ -9,10 +9,11 @@ import { defineComponent, SetupContext, reactive } from '@vue/composition-api'
 import { makeStyles } from '@/lib/styles'
 import api, { BASE_PATH, User } from '@/lib/api'
 import { UserId } from '@/types/entity-ids'
+import store from '@/store'
 
 type IconSize = 42 | 36 | 28 | 20
 
-type Props = { userId: UserId; size: IconSize }
+type Props = { userId: UserId; size: IconSize; preventModal: boolean }
 
 export default defineComponent({
   name: 'UserIcon',
@@ -24,6 +25,10 @@ export default defineComponent({
     size: {
       type: Number,
       default: 36 as IconSize
+    },
+    preventModal: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props: Props, context: SetupContext) {
@@ -35,9 +40,18 @@ export default defineComponent({
         backgroundImage: `url(${BASE_PATH}/users/${props.userId}/icon)`
       }))
     })
+    const onClick = () => {
+      if (!props.preventModal) {
+        store.dispatch.ui.modal.pushModal({
+          type: 'user',
+          id: props.userId
+        })
+      }
+    }
     return {
       props,
-      styles
+      styles,
+      onClick
     }
   }
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,28 +3,48 @@ import VueRouter, { RouteConfig } from 'vue-router'
 
 Vue.use(VueRouter)
 
+export enum RouteName {
+  Index = 'index',
+  Channel = 'channel',
+  User = 'user',
+  Message = 'message',
+  Login = 'login',
+  NotFound = 'not-found'
+}
+
+export const constructChannelPath = (channel: string) => `/channels/${channel}`
+
 const routes = [
   {
     path: '/',
-    name: 'index',
+    name: RouteName.Index,
     component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
   },
   {
-    path: '/channels/:channel(.*)',
+    path: constructChannelPath(':channel(.*)'),
+    name: RouteName.Channel,
     component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
   },
   {
     path: '/users/:user',
+    name: RouteName.User,
     component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
   },
   {
     path: '/messages/:message',
+    name: RouteName.Message,
     component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
   },
   {
     path: '/login',
-    name: 'login',
+    name: RouteName.Login,
     component: () => import(/* webpackChunkName: "login" */ '@/views/Login.vue')
+  },
+  {
+    path: '*',
+    name: RouteName.NotFound,
+    component: () =>
+      import(/* webpackChunkName: "NotFound" */ '@/views/NotFound.vue')
   }
 ]
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,8 +6,20 @@ Vue.use(VueRouter)
 const routes = [
   {
     path: '/',
-    name: 'home',
-    component: () => import(/* webpackChunkname: "Home" */ '@/views/Home.vue')
+    name: 'index',
+    component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
+  },
+  {
+    path: '/channels/:channel(.*)',
+    component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
+  },
+  {
+    path: '/users/:user',
+    component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
+  },
+  {
+    path: '/messages/:message',
+    component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
   },
   {
     path: '/login',

--- a/src/store/ui/index.ts
+++ b/src/store/ui/index.ts
@@ -6,6 +6,7 @@ import { actions } from './actions'
 import { mainView } from './mainView'
 import { messageContextMenu } from './messageContextMenu'
 import { stampPicker } from './stampPicker'
+import { modal } from './modal'
 
 export const ui = defineModule({
   namespaced: true,
@@ -16,6 +17,7 @@ export const ui = defineModule({
   modules: {
     mainView,
     stampPicker,
-    messageContextMenu
+    messageContextMenu,
+    modal
   }
 })

--- a/src/store/ui/modal/actions.ts
+++ b/src/store/ui/modal/actions.ts
@@ -1,0 +1,30 @@
+import { defineActions } from 'direct-vuex'
+import { moduleActionContext } from '@/store'
+import { ModalState } from './state'
+import { modal } from './index'
+
+export const modalActionContext = (context: any) =>
+  moduleActionContext(context, modal)
+
+export const actions = defineActions({
+  pushModal: (context, modalState: ModalState) => {
+    const { commit, state } = modalActionContext(context)
+    history.pushState(
+      {
+        modalState: [...state.modalState, modalState]
+      },
+      ''
+    )
+    commit.setState(history.state.modalState)
+  },
+  popModal: () => {
+    history.back()
+  },
+  clearModal: context => {
+    const { state, dispatch } = modalActionContext(context)
+    const length = state.modalState.length
+    for (let i = 0; i < length; i++) {
+      dispatch.popModal()
+    }
+  }
+})

--- a/src/store/ui/modal/getters.ts
+++ b/src/store/ui/modal/getters.ts
@@ -1,0 +1,8 @@
+import { defineGetters } from 'direct-vuex'
+import { S } from './state'
+
+export const getters = defineGetters<S>()({
+  shouldShowModal(state) {
+    return state.modalState.length > 0
+  }
+})

--- a/src/store/ui/modal/index.ts
+++ b/src/store/ui/modal/index.ts
@@ -1,0 +1,13 @@
+import { defineModule } from 'direct-vuex'
+import { state } from './state'
+import { getters } from './getters'
+import { mutations } from './mutations'
+import { actions } from './actions'
+
+export const modal = defineModule({
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+})

--- a/src/store/ui/modal/mutations.ts
+++ b/src/store/ui/modal/mutations.ts
@@ -1,0 +1,12 @@
+import { defineMutations } from 'direct-vuex'
+import { S, ModalState } from './state'
+
+export const mutations = defineMutations<S>()({
+  setState: (state, modalStates: ModalState[]) => {
+    state.modalState = modalStates
+  },
+  pushState: (state, modalState: ModalState) => {
+    state.modalState = [...state.modalState, modalState]
+  },
+  popState: state => state.modalState.splice(1)
+})

--- a/src/store/ui/modal/state.ts
+++ b/src/store/ui/modal/state.ts
@@ -1,0 +1,22 @@
+import { UserId } from '@/types/entity-ids'
+
+type ModalStateType = 'user' | 'group'
+
+export type ModalState = UserModalState
+
+interface BaseModalState {
+  type: ModalStateType
+}
+
+interface UserModalState extends BaseModalState {
+  type: 'user'
+  id: UserId
+}
+
+export interface S {
+  modalState: ModalState[]
+}
+
+export const state: S = {
+  modalState: []
+}

--- a/src/use/channelPath.ts
+++ b/src/use/channelPath.ts
@@ -1,0 +1,46 @@
+import { ChannelTree, ChannelTreeNode } from '@/store/domain/channelTree/state'
+import { ChannelId } from '@/types/entity-ids'
+import { Channel } from '@/lib/api'
+
+const useChannelPath = () => {
+  const channelPathToId = (
+    separatedPath: string[],
+    channelTree: ChannelTree | ChannelTreeNode
+  ): string => {
+    if (separatedPath.length === 0) {
+      throw 'channelPathToId: Empty path'
+    }
+
+    const nextTree = channelTree.children.find(
+      child => child.name === separatedPath[0]
+    )
+    if (!nextTree) {
+      throw `channelPathToId: No channel: ${separatedPath[0]}`
+    }
+    if (separatedPath.length === 1) {
+      return nextTree.id
+    }
+
+    return channelPathToId(separatedPath.slice(1), nextTree)
+  }
+
+  const channelIdToPath = (
+    id: ChannelId,
+    channelEntities: Record<ChannelId, Channel>
+  ): string[] => {
+    if (!(id in channelEntities)) {
+      throw `channelIdToPath: No channel: ${id}`
+    }
+    const channel = channelEntities[id]
+    if (channel.parentId === '' || !channel.parentId) {
+      return [channel.name ?? '']
+    }
+    return [
+      ...channelIdToPath(channel.parentId, channelEntities),
+      channel.name ?? ''
+    ]
+  }
+  return { channelPathToId, channelIdToPath }
+}
+
+export default useChannelPath

--- a/src/use/channelSelect.ts
+++ b/src/use/channelSelect.ts
@@ -1,15 +1,28 @@
-import api from '@/lib/api'
+import { SetupContext } from '@vue/composition-api'
 import store from '@/store'
+import useChannelPath from '@/use/channelPath'
 import { ChannelId } from '@/types/entity-ids'
+import { constructChannelPath } from '@/router'
 
-const useChannelSelect = () => {
+const useChannelSelect = (context: SetupContext) => {
+  const { channelIdToPath } = useChannelPath()
+
   const onChannelSelect = (id: ChannelId) => {
-    store.dispatch.domain.messagesView.changeCurrentChannel(id)
-
     // 未読を除去する
     // TODO: 新着メッセージ基準設定などの処理
     if (id in store.state.domain.me.unreadChannelsSet) {
       store.dispatch.domain.me.readChannel({ channelId: id })
+    }
+
+    // チャンネル遷移
+    if (id === store.state.domain.messagesView.currentChannelId) {
+      return
+    }
+    try {
+      const channelPath = channelIdToPath(id, store.state.entities.channels)
+      context.root.$router.push(constructChannelPath(channelPath.join('/')))
+    } catch {
+      console.error('Invalid Channel')
     }
   }
   return {

--- a/src/use/channelSelect.ts
+++ b/src/use/channelSelect.ts
@@ -22,7 +22,7 @@ const useChannelSelect = (context: SetupContext) => {
       const channelPath = channelIdToPath(id, store.state.entities.channels)
       context.root.$router.push(constructChannelPath(channelPath.join('/')))
     } catch {
-      console.error('Invalid Channel')
+      throw 'Invalid Channel'
     }
   }
   return {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -19,6 +19,7 @@
         <main-view-controller :isActive="isNavAppeared" />
       </div>
     </div>
+    <modal-container />
   </div>
   <div v-else></div>
 </template>
@@ -30,10 +31,12 @@ import {
   computed,
   reactive,
   watchEffect,
+  watch,
   onMounted
 } from '@vue/composition-api'
 import MainViewController from '@/components/Main/MainView/MainViewController.vue'
 import Navigation from '@/components/Main/Navigation/Navigation.vue'
+import ModalContainer from '@/components/Main/Modal/ModalContainer.vue'
 import store from '@/store'
 import { RouteName, constructChannelPath } from '@/router'
 import useChannelPath from '@/use/channelPath'
@@ -103,6 +106,7 @@ export default defineComponent({
   components: {
     Navigation,
     MainViewController,
+    ModalContainer,
     NotFound: () =>
       import(/* webpackChunkName: "NotFound" */ '@/views/NotFound.vue')
   },
@@ -136,7 +140,6 @@ export default defineComponent({
     })
 
     const { routeWatcherState, routeWatcher } = useRouteWacher(context)
-
     return {
       touchstartHandler,
       touchmoveHandler,

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -17,12 +17,29 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, onMounted } from '@vue/composition-api'
+import {
+  defineComponent,
+  SetupContext,
+  computed,
+  watchEffect,
+  onMounted
+} from '@vue/composition-api'
 import MainViewController from '@/components/Main/MainView/MainViewController.vue'
 import Navigation from '@/components/Main/Navigation/Navigation.vue'
 import store from '@/store'
 import useSwipeDetector from '@/use/swipeDetector'
 import useSwipeDrawer from '@/use/swipeDrawer'
+
+const useRouteChangeWacher = (context: SetupContext) => {
+  const channelParam = computed(() => context.root.$route.params['channel'])
+  const messageParam = computed(() => context.root.$route.params['message'])
+  const userParam = computed(() => context.root.$route.params['user'])
+  return watchEffect(() => {
+    console.log(channelParam.value)
+    console.log(messageParam.value)
+    console.log(userParam.value)
+  })
+}
 
 export default defineComponent({
   name: 'Home',
@@ -30,7 +47,7 @@ export default defineComponent({
     Navigation,
     MainViewController
   },
-  setup() {
+  setup(_, context: SetupContext) {
     const {
       swipeDetectorState,
       touchmoveHandler,
@@ -58,6 +75,7 @@ export default defineComponent({
       store.dispatch.entities.fetchStamps()
       store.dispatch.entities.fetchUserGroups()
     })
+    const watcher = useRouteChangeWacher(context)
 
     return {
       touchstartHandler,

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,55 @@
+<template>
+  <div :class="$style.container" :style="style.container">
+    <h1>
+      Not Found
+    </h1>
+    <div v-if="props.routeName && props.routeParam">
+      {{ props.routeName }} {{ props.routeParam }} is not found on traQ!
+    </div>
+    <div v-else>Path {{ $route.path }} is not found on traQ!</div>
+    <router-link to="/">back</router-link>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive } from '@vue/composition-api'
+import { makeStyles } from '@/lib/styles'
+
+type Props = {
+  routeName?: string
+  routeParam?: string
+}
+
+const useStyle = () =>
+  reactive({
+    container: makeStyles(theme => ({
+      color: theme.ui.primary
+    }))
+  })
+
+export default defineComponent({
+  name: 'NotFound',
+  props: {
+    routeName: {
+      type: String,
+      required: false
+    },
+    routeParam: {
+      type: String,
+      required: false
+    }
+  },
+  setup(props: Props) {
+    return {
+      props,
+      style: useStyle()
+    }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  padding: 1rem;
+}
+</style>

--- a/src/views/use/viewTitle.ts
+++ b/src/views/use/viewTitle.ts
@@ -1,0 +1,8 @@
+const useViewTitle = () => {
+  const changeViewTitle = (title: string) => {
+    document.title = `${title} - traQ`
+  }
+  return { changeViewTitle }
+}
+
+export default useViewTitle


### PR DESCRIPTION
## 実装したもの
- `channels/:channel`でチャンネル表示
- `store/ui/modal`でモーダル表示
- 404表示
  - マッチしないパス
  - 存在しないチャンネル

## 実装してないもの
- ユーザー・メッセージのパス

## 実装の概要
### パス
- `$route.params`を、`router-view`でマウントされるコンポーネントそれぞれが監視する
- `Main`についてはチャンネル(など)がなかった場合、`NotFound`を表示する
  - パスを保ったまま404表示をするため

### モーダル
- モーダルの状態スタックを`history.state`と`store.state.ui.modal.modalState`の2箇所に保持する
  - `history.state`はリアクティブにできないため
  - これらはモーダルの状態追加時と`popstate`発生時(戻る/進む)に同期を取る
- モーダルの生成で`history.pushState`して、モーダルの破棄で`history.back()`する