### PR TITLE
reduceToRecordの高速化とbrowserslistrcの変更

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,2 @@
-> 1%
-last 2 versions
+> 1% in JP and last 2 versions
+not ie > 0

--- a/src/store/entities/actions.ts
+++ b/src/store/entities/actions.ts
@@ -13,7 +13,7 @@ const reduceToRecord = <T>(array: T[], key: keyof T) =>
   array.reduce((acc, cur) => {
     const ck = cur[key]
     if (typeof ck !== 'string') return acc
-    return { ...acc, [ck]: cur }
+    return Object.assign(acc, { [ck]: cur })
   }, {} as Record<string, T>)
 
 // TODO: リクエストパラメータの型置き場


### PR DESCRIPTION
- reduceToRecordの高速化
  - `fetchStamps`をすると遅かったみたいなので
  - たぶんオブジェクトのコピーとGCが大量に走っちゃってたせい
- browserslistrcをtraQ_Rと同じに

よろしくお願いします