### PR TITLE
ユーザーモーダルのユーザーアイコンに背景色を設定

### DIFF
--- a/src/components/Main/Modal/UserModal/UserModal.vue
+++ b/src/components/Main/Modal/UserModal/UserModal.vue
@@ -50,7 +50,8 @@ const useStyles = (iconSize: number, isMobile: Ref<boolean>) =>
     })),
     icon: makeStyles(theme => ({
       marginTop: `${-iconSize / 2}px`,
-      borderColor: theme.background.secondary
+      borderColor: theme.background.secondary,
+      backgroundColor: theme.background.secondary
     }))
   })
 


### PR DESCRIPTION
refs #210 

ボーダーと同じ色を適用するようにしました
![image](https://user-images.githubusercontent.com/50443000/78335310-5947ad00-75c8-11ea-9a12-31c5a35da5b9.png)
