### PR TITLE
fix #221 学年グループに所属していないユーザーがユーザー一覧に表示されていない

### DIFF
--- a/src/components/Main/Navigation/NavigationContent/Users.vue
+++ b/src/components/Main/Navigation/NavigationContent/Users.vue
@@ -50,18 +50,36 @@ const useListByGradeName = () => {
       return []
     }
     const userGradeEntries: Record<string, User[]> = {}
+    const categorized = new Set<string>()
+
+    // 学年グループ
     for (const group of userGroups.value) {
-      userGradeEntries[group?.name ?? ''] = (
-        group?.members?.map(member => users.value[member.id]) ?? []
-      )
+      const member = (group.members.map(member => users.value[member.id]) ?? [])
         .filter(user => !!user)
         .sort((u1, u2) => compareString(u1.name, u2.name))
+      userGradeEntries[group.name] = member
+
+      member.map(user => user.id).forEach(id => categorized.add(id))
     }
 
-    // 学年なので逆順
-    return Object.entries(userGradeEntries).sort((e1, e2) =>
-      compareString(e1[0], e2[0], true)
-    )
+    // BOTグループ
+    const bots = Object.values(users.value)
+      .filter(user => user.bot)
+      .sort((u1, u2) => compareString(u1.name, u2.name))
+    bots.map(user => user.id).forEach(id => categorized.add(id))
+
+    return [
+      ...Object.entries(userGradeEntries).sort(
+        (e1, e2) => compareString(e1[0], e2[0], true) // 学年なので逆順
+      ),
+      [
+        'Others',
+        Object.values(users.value)
+          .filter(user => !categorized.has(user.id))
+          .sort((u1, u2) => compareString(u1.name, u2.name))
+      ],
+      ['BOT', bots]
+    ]
   })
   return listByGradeName
 }

--- a/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :class="$style.container">
     <div :class="$style.displayName" :style="styles.displayName">
       {{ props.user.displayName }}
     </div>
@@ -43,10 +43,19 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
+.container {
+  min-width: 0;
+}
 .displayName {
   font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .name {
   font-size: 0.875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
BOTユーザーは`BOT`グループ、どこにも属していないユーザーは`Others`グループで纏めるようにしました。
学年グループ, Others, BOTの順番で表示されます。
<img width="240" alt="スクリーンショット 2020-04-05 13 21 31" src="https://user-images.githubusercontent.com/30363887/78466785-afd7f700-7740-11ea-8e0b-3b4bc886b171.png">
<img width="233" alt="スクリーンショット 2020-04-05 13 21 39" src="https://user-images.githubusercontent.com/30363887/78466788-b5354180-7740-11ea-9b33-cfec3fa38680.png">
