### PR TITLE
eslintの一部をCIではerrorでローカルではwarnにするように

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
-const isStrict = process.env.CI === 'true' || process.env.NODE_ENV === 'production'
+const isStrict =
+  process.env.CI === 'true' || process.env.NODE_ENV === 'production'
 
 module.exports = {
   root: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const isStrict = process.env.CI === 'true' || process.env.NODE_ENV === 'production'
+
 module.exports = {
   root: true,
   env: {
@@ -13,11 +15,11 @@ module.exports = {
   ],
   plugins: ['unused-imports'],
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-console': isStrict ? 'error' : 'warn',
+    'no-debugger': isStrict ? 'error' : 'warn',
     'no-fallthrough': 'error',
     '@typescript-eslint/no-unused-vars': 'off',
-    'unused-imports/no-unused-imports-ts': 'warn',
+    'unused-imports/no-unused-imports-ts': isStrict ? 'error' : 'warn',
     'unused-imports/no-unused-vars-ts': 'off'
   },
   overrides: [

--- a/src/components/UI/VirtualScroller.vue
+++ b/src/components/UI/VirtualScroller.vue
@@ -209,7 +209,6 @@ export default defineComponent({
       let pageIndices = new Set()
       for (let i = 0; i < children.length; i++) {
         const { scrollHeight } = children[i]
-        console.log(scrollHeight)
         const index = Number(children[i].getAttribute('data-index'))
         if (!index) continue
         Vue.set(state.itemHeights, index, scrollHeight)


### PR DESCRIPTION
`warn`だとCIのチェックをすり抜けちゃうので
`no-console`とかもローカルで`off`だとCI後に気づきそうなので

よろしくお願いします
