### PR TITLE
ダウンロードボタンが機能していなかった問題を修正

### DIFF
--- a/src/use/fileLink.ts
+++ b/src/use/fileLink.ts
@@ -8,7 +8,7 @@ const useFileLink = (props: { fileId: FileId }, context: SetupContext) => {
     context.root.$router.push(fileLink.value)
   }
   const onFileDownloadLinkClick = () => {
-    context.root.$router.push(buildFilePath(props.fileId))
+    window.open(buildFilePath(props.fileId), '_blank')
   }
   return { fileLink, onFileLinkClick, onFileDownloadLinkClick }
 }


### PR DESCRIPTION
`onFileDownloadLinkClick`で/api/v3/files/~~~へvue-routerでpushしてしまうと、NotFoundページに遷移してしまうため、window.openで新しいタブで開くように変更