### PR TITLE
ユーザーアイコンスタンプの新記法に対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2059,9 +2059,9 @@
       }
     },
     "@traptitech/traq-markdown-it": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@traptitech/traq-markdown-it/-/traq-markdown-it-2.0.1.tgz",
-      "integrity": "sha512-xZVvWkLV0JCPCzODD17lmUHI4Dp/m4VIOG8vZ67l0qi/EOLv8cG3TjsXM+ynRsMhEG/4aSxKpy7cT98mOeybuA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@traptitech/traq-markdown-it/-/traq-markdown-it-2.1.0.tgz",
+      "integrity": "sha512-kT+xq/z3iaX8+NX0dnKhHCmHDiPZu85XvMI04dIjBACAyG8NZzZp8eU6lLwiY2MzMLdnQX9cBnc2BfqBcItmVw==",
       "requires": {
         "@traptitech/markdown-it-katex": "^3.2.2",
         "@traptitech/markdown-it-spoiler": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@mdi/js": "^5.1.45",
     "@traptitech/traq": "3.0.0-21",
-    "@traptitech/traq-markdown-it": "^2.0.1",
+    "@traptitech/traq-markdown-it": "^2.1.0",
     "@vue/composition-api": "^0.5.0",
     "autosize": "^4.0.2",
     "core-js": "^3.6.5",

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,5 +1,8 @@
 import MarkdownIt, { Store } from '@traptitech/traq-markdown-it'
 import store from '@/store'
+import useChannelPath from '@/use/channelPath'
+
+const { channelIdToPath } = useChannelPath()
 
 const storeProvider: Store = {
   getUser(id) {
@@ -9,19 +12,7 @@ const storeProvider: Store = {
     return store.state.entities.channels[id]
   },
   getChannelPath(id) {
-    let current = this.getChannel(id)
-    if (!current) return ''
-
-    let path = current.name
-    let next = this.getChannel(current.parentId ?? '')
-    if (!next) return path
-
-    while (next) {
-      path = next.name + '/' + path
-      current = next
-      next = this.getChannel(current.parentId ?? '')
-    }
-    return path
+    return channelIdToPath(id).join('/')
   },
   getUserGroup(id) {
     return store.state.entities.userGroups[id]


### PR DESCRIPTION
`:ユーザー名:`を廃止して`:@ユーザー名:`を実装しました

- 互換性維持のために`:ユーザー名:`は残したほうがよかったりしますか？

よろしくお願いします
