### PR TITLE
fix #375

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
@@ -98,6 +98,7 @@ export default defineComponent({
 .fileNameInner {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .fileSize {
   grid-area: size;

--- a/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
@@ -7,9 +7,11 @@
     <div :class="$style.icon">
       <icon mdi :name="fileIconName" :size="32" />
     </div>
-    <span :class="$style.fileName">
-      {{ fileMeta.name }}
-    </span>
+    <div :class="$style.fileName">
+      <span :class="$style.fileNameInner">
+        {{ fileMeta.name }}
+      </span>
+    </div>
     <span :class="$style.fileSize" :style="styles.fileSize">{{
       fileSize
     }}</span>
@@ -68,9 +70,9 @@ export default defineComponent({
   display: grid;
   width: 100%;
   grid-template:
-    'icon ...  name ... dl' 20px
-    'icon ...  size ... dl' 16px
-    /36px 16px auto 1fr 24px;
+    'icon ... name ... dl' 20px
+    'icon ... size ... dl' 16px
+    / 36px 16px auto 1fr 24px;
   gap: 4px 0;
   padding: 12px 16px;
 }
@@ -87,9 +89,15 @@ export default defineComponent({
   grid-area: dl;
 }
 .fileName {
-  grid-area: name;
   display: flex;
   align-items: center;
+  grid-area: name;
+  overflow: hidden;
+}
+// flexに直接text-overflow: ellipsisをつけるとバグるため
+.fileNameInner {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .fileSize {
   grid-area: size;

--- a/src/components/Main/Modal/FileModal/FileModalContentHeader.vue
+++ b/src/components/Main/Modal/FileModal/FileModalContentHeader.vue
@@ -1,10 +1,6 @@
 <template>
   <div :class="$style.container">
-    <file-description
-      :file-id="props.fileId"
-      :is-white="props.isWhite"
-      :class="$style.description"
-    />
+    <file-description :file-id="props.fileId" :is-white="props.isWhite" />
     <div :class="$style.close">
       <close-button
         @click="onClickClear"
@@ -54,12 +50,8 @@ export default defineComponent({
   display: flex;
   justify-content: space-between;
 }
-.description,
-.close {
-  align-items: center;
-}
 .close {
   display: flex;
-  cursor: pointer;
+  align-items: center;
 }
 </style>

--- a/src/components/Main/Modal/FileModal/FileModalContentHeader.vue
+++ b/src/components/Main/Modal/FileModal/FileModalContentHeader.vue
@@ -57,7 +57,6 @@ export default defineComponent({
 .description,
 .close {
   align-items: center;
-  height: 40px;
 }
 .close {
   display: flex;

--- a/src/components/UI/FileDescription.vue
+++ b/src/components/UI/FileDescription.vue
@@ -71,16 +71,15 @@ export default defineComponent({
   display: grid;
   width: 100%;
   grid-template:
-    'icon ... name ... dl' 20px
-    'icon ... size ... dl' 16px
-    /36px 16px auto 1fr 24px;
+    'icon ... name ... dl' minmax(min-content, 20px)
+    'icon ... size ... dl' minmax(min-content, 16px)
+    / 36px 16px auto 1fr 24px;
   padding: 0 16px;
 }
 .icon,
 .dl {
   display: flex;
   align-items: center;
-  height: 40px;
 }
 .icon {
   grid-area: icon;
@@ -91,8 +90,9 @@ export default defineComponent({
 }
 .fileName {
   grid-area: name;
-  display: flex;
-  align-items: center;
+  min-width: 0;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 .fileSize {
   grid-area: size;


### PR DESCRIPTION
ファイルモーダルでファイル名を改行するようにしました
![image](https://user-images.githubusercontent.com/49056869/80061763-15174f00-856d-11ea-8c28-ff36c4516b03.png)

メッセージ一覧での表示では「…」で省略表示するようにしました
(今はファイル名すべてを…にしてますが、拡張子だけは常に表示するようにしたほうが親切かもしれない)
![image](https://user-images.githubusercontent.com/49056869/80061810-2ceed300-856d-11ea-8372-883305b28db6.png)

あと、ファイルモーダルで「X」ボタンの周りも`cursor:pointer`がついてたけど実際に閉じる当たり判定がなかったので外しておきました

よろしくお願いします

close #375 
