### PR TITLE
ログインリクエストが二重に送信されていた fix #377

### DIFF
--- a/src/components/Authenticate/ConsentForm/ConsentForm.vue
+++ b/src/components/Authenticate/ConsentForm/ConsentForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :style="styles.container">
+  <div>
     <authenticate-header :class="$style.header" title="OAuth認可" />
     <client-description
       v-if="state.client"

--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Enterキーでログインするため -->
   <form @submit.prevent="login">
     <authenticate-header :class="$style.header" />
     <authenticate-input
@@ -26,7 +27,7 @@
       <span v-if="loginState.error">{{ loginState.error }}</span>
     </div>
     <div :class="$style.buttons">
-      <authenticate-button-primary label="ログイン" @click="login" />
+      <authenticate-button-primary label="ログイン" />
     </div>
     <!-- TODO: /versionの結果によってここを出し分ける -->
     <template v-if="!isIOS">


### PR DESCRIPTION
`<form>`の`onsubmit`と`<button>`の`onclick`の両方でリクエストが飛んでるみたいだったので`<form>`のほうを取り除きました
`<form>`を使ってる理由があったら逆にします

よろしくお願いします

close #377