### PR TITLE
fix: アップロード画像のサムネイルが元画像を読み込んでいる

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, reactive } from '@vue/composition-api'
+import { defineComponent, reactive } from '@vue/composition-api'
 import { makeStyles } from '@/lib/styles'
 import useFileMeta from '@/use/fileMeta'
 

--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -5,7 +5,7 @@
     :class="$style.largeContainer"
     :style="styles.container"
   >
-    <img draggable="false" :alt="fileMeta.name" :src="imagePath" />
+    <img draggable="false" :alt="fileMeta.name" :src="fileThumbnailPath" />
   </router-link>
   <router-link
     v-else
@@ -13,7 +13,7 @@
     :class="$style.container"
     :style="styles.container"
   >
-    <img draggable="false" :alt="fileMeta.name" :src="imagePath" />
+    <img draggable="false" :alt="fileMeta.name" :src="fileThumbnailPath" />
   </router-link>
 </template>
 
@@ -43,14 +43,11 @@ export default defineComponent({
   },
   setup(props, context) {
     const styles = useStyles()
-    const { fileMeta, fileLink, fileRawPath, fileThumbnailPath } = useFileMeta(
+    const { fileMeta, fileLink, fileThumbnailPath } = useFileMeta(
       props,
       context
     )
-    const imagePath = computed(() =>
-      props.isLarge ? fileRawPath.value : fileThumbnailPath.value
-    )
-    return { imagePath, styles, fileLink, fileMeta }
+    return { fileThumbnailPath, styles, fileLink, fileMeta }
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -19,7 +19,6 @@
 
 <script lang="ts">
 import { defineComponent, computed, reactive } from '@vue/composition-api'
-import { buildFilePath } from '@/lib/apis'
 import { makeStyles } from '@/lib/styles'
 import useFileMeta from '@/use/fileMeta'
 
@@ -44,9 +43,12 @@ export default defineComponent({
   },
   setup(props, context) {
     const styles = useStyles()
-    const { fileMeta, fileLink, fileRawPath } = useFileMeta(props, context)
+    const { fileMeta, fileLink, fileRawPath, fileThumbnailPath } = useFileMeta(
+      props,
+      context
+    )
     const imagePath = computed(() =>
-      props.isLarge ? buildFilePath(props.fileId) : fileRawPath.value
+      props.isLarge ? fileRawPath.value : fileThumbnailPath.value
     )
     return { imagePath, styles, fileLink, fileMeta }
   }

--- a/src/use/fileMeta.ts
+++ b/src/use/fileMeta.ts
@@ -1,6 +1,6 @@
 import { computed, SetupContext } from '@vue/composition-api'
 import store from '@/store'
-import { buildFilePath } from '@/lib/apis'
+import { buildFilePath, buildFileThumbnailPath } from '@/lib/apis'
 import { mimeToFileType, prettifyFileSize } from '@/lib/util/file'
 import useFileLink from '@/use/fileLink'
 
@@ -14,6 +14,11 @@ const useFileMeta = (props: { fileId: string }, context: SetupContext) => {
   )
   const fileRawPath = computed(() =>
     fileMeta.value ? buildFilePath(fileMeta.value.id) : ''
+  )
+  const fileThumbnailPath = computed(() =>
+    fileMeta.value && fileMeta.value.thumbnail != null
+      ? buildFileThumbnailPath(fileMeta.value.id)
+      : ''
   )
   const fileType = computed(() =>
     fileMeta.value ? mimeToFileType(fileMeta.value.mime) : 'file'
@@ -35,6 +40,7 @@ const useFileMeta = (props: { fileId: string }, context: SetupContext) => {
     fileMeta,
     fileLink,
     fileRawPath,
+    fileThumbnailPath,
     fileType,
     fileSize,
     fileIconName,


### PR DESCRIPTION
現状`props.isLarge`がtrueの場合、意図的に元画像を表示するようにされてますが、サムネイル画像を大きく表示しても問題ない気がしてます。