### PR TITLE
クリップ表示のビュー追加まで

### DIFF
--- a/src/components/Main/MainView/ChannelView/Header.vue
+++ b/src/components/Main/MainView/ChannelView/Header.vue
@@ -34,7 +34,6 @@ import {
 import { ChannelId } from '@/types/entity-ids'
 import { makeStyles } from '@/lib/styles'
 import Icon from '@/components/UI/Icon.vue'
-import useIsMobile from '@/use/isMobile'
 import usePopupMenu from './use/popupMenu'
 import useChannelState from './use/channelState'
 import useStarChannel from './use/starChannel'
@@ -89,7 +88,6 @@ export default defineComponent({
     const { openNotificationModal } = useNotificationModal(props)
     const { openChannelCreateModal } = useChannelCreateModal(props)
     const styles = useStyles()
-    const { isMobile } = useIsMobile()
     const { copyLink } = useCopy(context)
     return {
       isPopupMenuShown,
@@ -102,8 +100,7 @@ export default defineComponent({
       copyLink,
       togglePopupMenu,
       closePopupMenu,
-      targetPortalName,
-      isMobile
+      targetPortalName
     }
   }
 })

--- a/src/components/Main/MainView/ClipsHeader/ClipsHeader.vue
+++ b/src/components/Main/MainView/ClipsHeader/ClipsHeader.vue
@@ -1,0 +1,94 @@
+<template>
+  <main-view-header>
+    <template #header>
+      <main-view-header-title
+        :title="clipFolderName"
+        icon-mdi
+        icon-name="bookmark"
+      />
+    </template>
+    <template #tools>
+      <!-- TODO: クリップフォルダの編集 -->
+    </template>
+  </main-view-header>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  reactive,
+  PropType,
+  computed
+} from '@vue/composition-api'
+import store from '@/store'
+import { ClipFolderId } from '@/types/entity-ids'
+import { makeStyles } from '@/lib/styles'
+import Icon from '@/components/UI/Icon.vue'
+import MainViewHeader from '@/components/Main/MainView/MainViewHeader/MainViewHeader.vue'
+import MainViewHeaderTitle from '@/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue'
+
+const useStyles = () =>
+  reactive({
+    container: makeStyles(theme => ({
+      background: theme.background.primary,
+      color: theme.ui.primary,
+      borderBottom: `2px solid ${theme.ui.tertiary}`
+    })),
+    navigationButton: makeStyles(theme => ({
+      color: theme.ui.primary
+    }))
+  })
+
+export default defineComponent({
+  name: 'ChannelViewHeader',
+  components: {
+    Icon,
+    MainViewHeader,
+    MainViewHeaderTitle
+  },
+  props: {
+    clipFolderId: {
+      type: String as PropType<ClipFolderId>,
+      required: true
+    }
+  },
+  setup(props, context) {
+    const styles = useStyles()
+    const clipFolderName = computed(
+      () => store.state.entities.clipFolders[props.clipFolderId]?.name ?? ''
+    )
+    return {
+      styles,
+      clipFolderName
+    }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+  padding: 16px;
+}
+.headerContainer {
+  display: flex;
+}
+.navigationButton {
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+}
+.tools {
+  flex-shrink: 0;
+}
+.toolsMenu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 999;
+}
+</style>

--- a/src/components/Main/MainView/ClipsHeader/ClipsHeader.vue
+++ b/src/components/Main/MainView/ClipsHeader/ClipsHeader.vue
@@ -64,31 +64,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss" module>
-.container {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 100%;
-  padding: 16px;
-}
-.headerContainer {
-  display: flex;
-}
-.navigationButton {
-  display: flex;
-  align-items: center;
-  margin-right: 8px;
-}
-.tools {
-  flex-shrink: 0;
-}
-.toolsMenu {
-  position: absolute;
-  right: 0;
-  top: 100%;
-  z-index: 999;
-}
-</style>

--- a/src/components/Main/MainView/ClipsView/ClipsView.vue
+++ b/src/components/Main/MainView/ClipsView/ClipsView.vue
@@ -1,0 +1,56 @@
+<template>
+  <div ref="containerRef" :class="$style.container" :style="styles.container">
+    くりっぷ {{ clipFolder }}
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  reactive,
+  computed,
+  PropType
+} from '@vue/composition-api'
+import { ClipFolderId } from '@/types/entity-ids'
+import store from '@/store'
+import { makeStyles } from '@/lib/styles'
+
+const useStyles = () =>
+  reactive({
+    container: makeStyles(theme => ({
+      background: theme.background.primary,
+      color: theme.ui.primary
+    }))
+  })
+
+export default defineComponent({
+  name: 'ClipsView',
+  props: {
+    clipFolderId: { type: String as PropType<ClipFolderId>, required: true }
+  },
+  components: {},
+  setup(props) {
+    const messageIds = computed(
+      () => store.state.domain.messagesView.messageIds
+    )
+    const clipFolder = computed(
+      () => store.state.entities.clipFolders?.[props.clipFolderId]
+    )
+
+    const styles = useStyles()
+
+    return {
+      messageIds,
+      clipFolder,
+      styles
+    }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/src/components/Main/MainView/MainView.vue
+++ b/src/components/Main/MainView/MainView.vue
@@ -19,6 +19,7 @@
       </div>
       <portal-target name="sidebar-opener" :class="$style.hidden" />
       <main-view-component-selector
+        v-if="state.secondary"
         :class="[$style.componentContainer, $style.secondary]"
         :view-info="state.secondary"
       />

--- a/src/components/Main/MainView/MainViewComponentSelector.vue
+++ b/src/components/Main/MainView/MainViewComponentSelector.vue
@@ -1,10 +1,14 @@
 <template>
   <channel-view
     :class="$style.messagesView"
-    v-if="viewInfo && viewInfo.type === 'channel'"
+    v-if="viewInfo.type === 'channel' && channelId"
     :channel-id="channelId"
   />
-  <qall-view v-else-if="viewInfo && viewInfo.type === 'qall'" />
+  <clips-view
+    :class="$style.messagesView"
+    v-else-if="viewInfo.type === 'clips' && clipFolderId"
+    :clip-folder-id="clipFolderId"
+  />
   <div :class="$style.none" v-else></div>
 </template>
 
@@ -13,21 +17,28 @@ import { defineComponent, computed, PropType } from '@vue/composition-api'
 import store from '@/store'
 import { ViewInformation } from '@/store/ui/mainView/state'
 import ChannelView from '@/components/Main/MainView/ChannelView/ChannelView.vue'
-import QallView from '@/components/Main/MainView/QallView/QallView.vue'
+import ClipsView from '@/components/Main/MainView/ClipsView/ClipsView.vue'
 
 export default defineComponent({
   name: 'MainViewComponentSelector',
-  components: { ChannelView, QallView },
+  components: { ChannelView, ClipsView },
   props: {
-    viewInfo: Object as PropType<ViewInformation>
+    viewInfo: {
+      type: Object as PropType<ViewInformation>,
+      required: true
+    }
   },
   setup(props) {
     const channelId = computed(
       () => store.state.domain.messagesView.currentChannelId
     )
+    const clipFolderId = computed(
+      () => store.state.domain.messagesView.currentClipFolderId
+    )
 
     return {
-      channelId
+      channelId,
+      clipFolderId
     }
   }
 })

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
@@ -7,7 +7,6 @@
 
 <script lang="ts">
 import { defineComponent, reactive } from '@vue/composition-api'
-
 import { makeStyles } from '@/lib/styles'
 import Icon from '@/components/UI/Icon.vue'
 
@@ -17,7 +16,7 @@ const useStyles = () =>
   })
 
 export default defineComponent({
-  name: '',
+  name: 'MainViewHeaderTitle',
   components: { Icon },
   props: {
     iconMdi: {

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
@@ -1,0 +1,52 @@
+<template>
+  <div :class="$style.container" :style="styles.container">
+    <icon :class="$style.icon" :name="iconName" :mdi="iconMdi" />
+    <h1 :class="$style.title">{{ title }}</h1>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive } from '@vue/composition-api'
+
+import { makeStyles } from '@/lib/styles'
+import Icon from '@/components/UI/Icon.vue'
+
+const useStyles = () =>
+  reactive({
+    container: makeStyles(theme => ({}))
+  })
+
+export default defineComponent({
+  name: '',
+  components: { Icon },
+  props: {
+    iconMdi: {
+      type: Boolean,
+      defualt: false
+    },
+    iconName: String,
+    title: { type: String, required: true }
+  },
+  setup() {
+    const styles = useStyles()
+    return { styles }
+  }
+})
+</script>
+
+<style lang="scss" module>
+$titleSize: 1.5rem;
+
+.container {
+  display: flex;
+  align-items: center;
+}
+
+.icon {
+  margin-right: 8px;
+}
+
+.title {
+  font-size: $titleSize;
+}
+</style>

--- a/src/components/Main/MainView/MainViewHeaderSelector.vue
+++ b/src/components/Main/MainView/MainViewHeaderSelector.vue
@@ -1,8 +1,11 @@
 <template>
   <channel-view-header
-    :class="$style.messagesView"
-    v-if="viewInfo && viewInfo.type === 'channel'"
+    v-if="viewInfo.type === 'channel'"
     :channel-id="channelId"
+  />
+  <clips-header
+    v-else-if="viewInfo.type === 'clips'"
+    :clip-folder-id="viewInfo.clipFolderId"
   />
   <div :class="$style.none" v-else></div>
 </template>
@@ -12,10 +15,11 @@ import { defineComponent, computed, PropType } from '@vue/composition-api'
 import store from '@/store'
 import { ViewInformation } from '@/store/ui/mainView/state'
 import ChannelViewHeader from '@/components/Main/MainView/ChannelView/Header.vue'
+import ClipsHeader from '@/components/Main/MainView/ClipsHeader/ClipsHeader.vue'
 
 export default defineComponent({
   name: 'MainViewHeaderSelector',
-  components: { ChannelViewHeader },
+  components: { ChannelViewHeader, ClipsHeader },
   props: {
     viewInfo: Object as PropType<ViewInformation>
   },

--- a/src/components/Main/Navigation/NavigationContent/ClipFolders.vue
+++ b/src/components/Main/Navigation/NavigationContent/ClipFolders.vue
@@ -1,8 +1,10 @@
 <template>
   <div :class="$style.container">
+    <!--
     <navigation-content-container subtitle="すべてのクリップ">
       <empty-state>Not Implemented</empty-state>
     </navigation-content-container>
+    -->
     <navigation-content-container subtitle="クリップフォルダ">
       <div v-for="clipFolder in clipFolders" :key="clipFolder.id">
         <clip-folders-element

--- a/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
+++ b/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
@@ -1,15 +1,25 @@
 <template>
-  <div :class="$style.container" :style="styles.container">
+  <router-link
+    :to="clipFolderPath"
+    :class="$style.container"
+    :style="styles.container"
+  >
     <icon name="bookmark" mdi :class="$style.icon" />
     {{ clipFolder.name }}
-  </div>
+  </router-link>
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, PropType } from '@vue/composition-api'
+import {
+  defineComponent,
+  reactive,
+  PropType,
+  computed
+} from '@vue/composition-api'
 import { makeStyles } from '@/lib/styles'
 import { ClipFolder } from '@traptitech/traq'
 import Icon from '@/components/UI/Icon.vue'
+import { constructClipFoldersPath } from '@/router'
 
 const useStyles = () =>
   reactive({
@@ -29,9 +39,12 @@ export default defineComponent({
       required: true
     }
   },
-  setup() {
+  setup(props) {
     const styles = useStyles()
-    return { styles }
+    const clipFolderPath = computed(() =>
+      constructClipFoldersPath(props.clipFolder.id)
+    )
+    return { styles, clipFolderPath }
   }
 })
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ export enum RouteName {
   User = 'user',
   Message = 'message',
   File = 'File',
+  ClipFolders = 'clip-folders',
   Login = 'login',
   Registration = 'registration',
   ResetPassword = 'reset-password',
@@ -17,6 +18,8 @@ export enum RouteName {
 }
 
 export const constructChannelPath = (channel: string) => `/channels/${channel}`
+export const constructClipFoldersPath = (channel: string) =>
+  `/clip-folders/${channel}`
 
 const routes = [
   {
@@ -42,6 +45,11 @@ const routes = [
   {
     path: '/files/:id',
     name: RouteName.File,
+    component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
+  },
+  {
+    path: '/clip-folders/:id',
+    name: RouteName.ClipFolders,
     component: () => import(/* webpackChunkname: "Main" */ '@/views/Main.vue')
   },
   {

--- a/src/store/domain/messagesView/mutations.ts
+++ b/src/store/domain/messagesView/mutations.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { defineMutations } from 'direct-vuex'
-import { ChannelId, MessageId, UserId } from '@/types/entity-ids'
+import { ChannelId, MessageId, UserId, ClipFolderId } from '@/types/entity-ids'
 import { S, LoadingDirection } from './state'
 import { Embedding } from '@/lib/embeddingExtractor'
 import { Pin, ChannelViewer } from '@traptitech/traq'
@@ -8,6 +8,15 @@ import { Pin, ChannelViewer } from '@traptitech/traq'
 export const mutations = defineMutations<S>()({
   setCurrentChannelId(state, currentChannelId: ChannelId) {
     state.currentChannelId = currentChannelId
+  },
+  setCurrentClipFolderId(state, currentClipFolderId: ClipFolderId) {
+    state.currentClipFolderId = currentClipFolderId
+  },
+  unsetCurrentChannelId(state) {
+    state.currentChannelId = undefined
+  },
+  unsetCurrentClipFolderId(state) {
+    state.currentClipFolderId = undefined
   },
   setMessageIds(state, messageIds: MessageId[]) {
     state.messageIds = messageIds

--- a/src/store/domain/messagesView/state.ts
+++ b/src/store/domain/messagesView/state.ts
@@ -1,11 +1,17 @@
 import { Embedding } from '@/lib/embeddingExtractor'
-import { MessageId, ChannelId, UserId } from '@/types/entity-ids'
+import { MessageId, ChannelId, UserId, ClipFolderId } from '@/types/entity-ids'
 import { Pin, ChannelViewer } from '@traptitech/traq'
 
 export type LoadingDirection = 'former' | 'latter' | 'around' | 'latest'
 
 export interface S {
-  currentChannelId: ChannelId
+  // FIXME: 分離
+
+  /** 現在のチャンネルID、日時ベースのフェッチを行う */
+  currentChannelId?: ChannelId
+
+  /** 現在のクリップフォルダID、オフセットベースのフェッチを行う */
+  currentClipFolderId?: ClipFolderId
 
   /** 現在表示対象になっている全てのメッセージID */
   messageIds: MessageId[]
@@ -53,7 +59,8 @@ export interface S {
 }
 
 export const state: S = {
-  currentChannelId: '',
+  currentChannelId: undefined,
+  currentClipFolderId: undefined,
   messageIds: [],
   pinnedMessages: [],
   currentOffset: 0,

--- a/src/store/entities/actions.ts
+++ b/src/store/entities/actions.ts
@@ -3,7 +3,13 @@ import { moduleActionContext } from '@/store'
 import { entities } from './index'
 import apis from '@/lib/apis'
 import { reduceToRecord } from '@/lib/util/record'
-import { FileId, TagId, MessageId, ChannelId } from '@/types/entity-ids'
+import {
+  FileId,
+  TagId,
+  MessageId,
+  ChannelId,
+  ClipFolderId
+} from '@/types/entity-ids'
 
 // TODO: リクエストパラメータの型置き場
 interface GetMessagesParams {
@@ -136,5 +142,11 @@ export const actions = defineActions({
     const { commit } = entitiesActionContext(context)
     const res = await apis.getClipFolders()
     commit.setClipFolders(reduceToRecord(res.data, 'id'))
+  },
+  async fetchClipFolder(context, id: ClipFolderId) {
+    const { commit } = entitiesActionContext(context)
+    const res = await apis.getClipFolder(id)
+    commit.addClipFolder({ id, entity: res.data })
+    return res.data
   }
 })

--- a/src/store/entities/mutations.ts
+++ b/src/store/entities/mutations.ts
@@ -78,6 +78,7 @@ export const mutations = defineMutations<S>()({
   addWebhook: addMutation('webhooks'),
   addFileMetaData: addMutation('fileMetaData'),
   addTags: addMutation('tags'),
+  addClipFolder: addMutation('clipFolders'),
 
   deleteUser: deleteMutation('users'),
   deleteMessage: deleteMutation('messages'),

--- a/src/store/ui/mainView/actions.ts
+++ b/src/store/ui/mainView/actions.ts
@@ -1,8 +1,32 @@
 import { defineActions } from 'direct-vuex'
 import { moduleActionContext } from '@/store'
 import { mainView } from './index'
+import { ClipFolderId, ChannelId, MessageId } from '@/types/entity-ids'
 
 export const mainViewActionContext = (context: any) =>
   moduleActionContext(context, mainView)
 
-export const actions = defineActions({})
+export const actions = defineActions({
+  changePrimaryViewToChannel(
+    context,
+    payload: { channelId: ChannelId; entryMessageId?: MessageId }
+  ) {
+    const { commit, rootDispatch } = mainViewActionContext(context)
+    commit.setPrimaryView({
+      type: 'channel',
+      channelId: payload.channelId
+    })
+    rootDispatch.domain.messagesView.changeCurrentChannel(payload)
+  },
+  changePrimaryViewToClip(
+    context,
+    { clipFolderId }: { clipFolderId: ClipFolderId }
+  ) {
+    const { commit, rootDispatch } = mainViewActionContext(context)
+    commit.setPrimaryView({
+      type: 'clips',
+      clipFolderId
+    })
+    rootDispatch.domain.messagesView.changeCurrentClipFolder(clipFolderId)
+  }
+})

--- a/src/store/ui/mainView/state.ts
+++ b/src/store/ui/mainView/state.ts
@@ -1,17 +1,24 @@
-export type ViewType = 'channel' | 'qall'
+import { ClipFolderId, ChannelId } from '@/types/entity-ids'
+
+export type ViewType = 'channel' | 'qall' | 'clips'
 export interface ViewInformationBase {
   type: ViewType
 }
-export type ViewInformation = ChannelView | QallView
+export type ViewInformation = ChannelView | QallView | ClipsView
 
 export type LayoutType = 'single' | 'split' | 'split-reverse'
 
 export interface ChannelView extends ViewInformationBase {
   type: 'channel'
+  /** まだ使われていない */
+  channelId: ChannelId
 }
-
 export interface QallView extends ViewInformationBase {
   type: 'qall'
+}
+export interface ClipsView extends ViewInformationBase {
+  type: 'clips'
+  clipFolderId: ClipFolderId
 }
 
 /**
@@ -50,9 +57,8 @@ export const state: S = {
   isSidebarOpen: false,
   currentMainViewComponentState: MainViewComponentState.Hidden,
   primaryView: {
-    type: 'channel'
+    type: 'channel',
+    channelId: ''
   },
-  secondaryView: {
-    type: 'qall'
-  }
+  secondaryView: undefined
 }

--- a/src/use/channelSubscriptionState.ts
+++ b/src/use/channelSubscriptionState.ts
@@ -8,10 +8,11 @@ const useChannelSubscriptionState = () => {
   )
   const currentChannelSubscription = computed(
     () =>
-      store.state.domain.me.subscriptionMap[currentChannelId.value] ??
+      store.state.domain.me.subscriptionMap[currentChannelId.value ?? ''] ??
       ChannelSubscribeLevel.none
   )
   const changeSubscriptionLevel = (level: ChannelSubscribeLevel) => {
+    if (!currentChannelId.value) return
     store.dispatch.domain.me.changeSubscriptionLevel({
       channelId: currentChannelId.value,
       subscriptionLevel: level

--- a/src/use/currentChannelPath.ts
+++ b/src/use/currentChannelPath.ts
@@ -5,7 +5,9 @@ import store from '@/store'
 const useCurrentChannelPath = () => {
   const { channelIdToPathString } = useChannelPath()
   const currentChannelPathString = computed(() =>
-    channelIdToPathString(store.state.domain.messagesView.currentChannelId)
+    store.state.domain.messagesView.currentChannelId
+      ? channelIdToPathString(store.state.domain.messagesView.currentChannelId)
+      : ''
   )
   return { currentChannelPathString }
 }

--- a/src/views/use/initialFetch.ts
+++ b/src/views/use/initialFetch.ts
@@ -21,6 +21,7 @@ const useInitialFetch = (context: SetupContext) => {
     store.commit.app.setInitialFetchCompleted()
     store.dispatch.domain.stampCategory.constructStampCategories()
     store.dispatch.entities.fetchStampPalettes()
+    store.dispatch.entities.fetchClipFolders()
     store.dispatch.domain.fetchChannelActivity()
     store.dispatch.domain.fetchOnlineUsers()
     store.dispatch.domain.me.fetchUnreadChannels()

--- a/src/views/use/routeWatcher.ts
+++ b/src/views/use/routeWatcher.ts
@@ -29,6 +29,7 @@ const useRouteWacher = (context: SetupContext) => {
     })
     return
   }
+
   const onRouteChangedToChannel = () => {
     if (store.state.domain.channelTree.channelTree.children.length === 0) {
       // まだチャンネルツリーが構築されていない
@@ -39,7 +40,7 @@ const useRouteWacher = (context: SetupContext) => {
         state.channelParam.split('/'),
         store.state.domain.channelTree.channelTree
       )
-      store.dispatch.domain.messagesView.changeCurrentChannel({
+      store.dispatch.ui.mainView.changePrimaryViewToChannel({
         channelId: id
       })
     } catch (e) {
@@ -49,6 +50,23 @@ const useRouteWacher = (context: SetupContext) => {
     changeViewTitle(`#${state.channelParam}`)
     state.view = 'main'
   }
+
+  const onRouteChangedToClipFolders = async () => {
+    const id = state.idParam
+    const clipSymbol = '🖇 '
+    try {
+      const clipFolder =
+        store.state.entities.clipFolders[id] ??
+        (await store.dispatch.entities.fetchClipFolder(id))
+      changeViewTitle(`${clipSymbol}${clipFolder.name}`)
+    } catch {
+      state.view = 'not-found'
+      return
+    }
+    store.dispatch.ui.mainView.changePrimaryViewToClip({ clipFolderId: id })
+    state.view = 'main'
+  }
+
   const onRouteChangedToFile = async () => {
     if (store.state.domain.channelTree.channelTree.children.length === 0) {
       // まだチャンネルツリーが構築されていない
@@ -66,7 +84,7 @@ const useRouteWacher = (context: SetupContext) => {
       return
     }
     const channelPath = channelIdToPathString(file.channelId)
-    store.dispatch.domain.messagesView.changeCurrentChannel({
+    store.dispatch.ui.mainView.changePrimaryViewToChannel({
       channelId: file.channelId
     })
     const modalPayload = {
@@ -78,6 +96,7 @@ const useRouteWacher = (context: SetupContext) => {
     changeViewTitle(`#${channelPath} - ${file.name}`)
     state.view = 'main'
   }
+
   const onRouteChangedToMessage = async () => {
     if (store.state.domain.channelTree.channelTree.children.length === 0) {
       return
@@ -106,6 +125,8 @@ const useRouteWacher = (context: SetupContext) => {
       await onRouteChangedToIndex()
     } else if (routeName === RouteName.Channel) {
       onRouteChangedToChannel()
+    } else if (routeName === RouteName.ClipFolders) {
+      onRouteChangedToClipFolders()
     } else if (routeName === RouteName.File) {
       await onRouteChangedToFile()
     } else if (routeName === RouteName.Message) {

--- a/src/views/use/routeWatcher.ts
+++ b/src/views/use/routeWatcher.ts
@@ -53,12 +53,11 @@ const useRouteWacher = (context: SetupContext) => {
 
   const onRouteChangedToClipFolders = async () => {
     const id = state.idParam
-    const clipSymbol = '🖇 '
     try {
       const clipFolder =
         store.state.entities.clipFolders[id] ??
         (await store.dispatch.entities.fetchClipFolder(id))
-      changeViewTitle(`${clipSymbol}${clipFolder.name}`)
+      changeViewTitle(clipFolder.name)
     } catch {
       state.view = 'not-found'
       return


### PR DESCRIPTION
- ClipsViewを追加しました
- viewの切替は`ui.mainView`の下のアクションを使います
  - 現在は既存の実装と共存させてあります
  - チャンネルIDはまだstoreに依存していますが、MainViewStateにも同時に持っているのでそこから投げる形にします（そのうち

MessageScrollerのリファクタを挟むのでいったん出します