### PR TITLE
ログイン周りの出し分け

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, watchEffect } from '@vue/composition-api'
+import {
+  computed,
+  defineComponent,
+  onBeforeMount,
+  watchEffect
+} from '@vue/composition-api'
 import store from './store'
 import { throttle } from 'lodash-es'
 import { makeStyles } from '@/lib/styles'
@@ -76,6 +81,10 @@ export default defineComponent({
     useEcoModeObserver()
 
     const scrollbarStyle = useScrollbarStyle()
+
+    onBeforeMount(async () => {
+      await store.dispatch.app.fetchVersionInfo()
+    })
 
     return {
       isMobile,

--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -17,6 +17,7 @@
       />
       <a
         href="https://portal.trap.jp/reset-password"
+        v-show="state.showPasswordResetLink"
         :class="$style.forgotPassword"
         :style="styles.forgotPassword"
       >
@@ -92,7 +93,20 @@ export default defineComponent({
     const { loginState, login, loginExternal, setName, setPass } = useLogin()
     const styles = useStyles()
     const isIOS = isIOSApp()
-    return { loginState, styles, setName, setPass, login, loginExternal, isIOS }
+    const state = reactive({
+      // 簡易的にhost名で分岐させてる
+      showPasswordResetLink: location.host === 'q.trap.jp'
+    })
+    return {
+      state,
+      loginState,
+      styles,
+      setName,
+      setPass,
+      login,
+      loginExternal,
+      isIOS
+    }
   }
 })
 </script>

--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -30,18 +30,19 @@
     <div :class="$style.buttons">
       <authenticate-button-primary label="ログイン" />
     </div>
-    <!-- TODO: /versionの結果によってここを出し分ける -->
-    <template v-if="!isIOS">
+    <template v-if="!isIOS && externalLogin.length > 0">
       <authenticate-separator label="または" :class="$style.separator" />
       <div :class="$style.exLoginButtons">
         <authenticate-button-secondary
           :class="$style.exLoginButton"
+          v-show="externalLogin.includes('traQ')"
           label="traP"
           icon-name="traQ"
           @click="loginExternal('traq')"
         />
         <authenticate-button-secondary
           :class="$style.exLoginButton"
+          v-show="externalLogin.includes('google')"
           label="Google"
           icon-mdi
           icon-name="google"
@@ -49,6 +50,7 @@
         />
         <authenticate-button-secondary
           :class="$style.exLoginButton"
+          v-show="externalLogin.includes('github')"
           label="GitHub"
           icon-mdi
           icon-name="github"
@@ -60,8 +62,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from '@vue/composition-api'
+import { computed, defineComponent, reactive } from '@vue/composition-api'
 import useLogin from './use/login'
+import store from '@/store'
 import { makeStyles } from '@/lib/styles'
 import { isIOSApp } from '@/lib/util/browser'
 import AuthenticateInput from './AuthenticateInput.vue'
@@ -97,6 +100,10 @@ export default defineComponent({
       // 簡易的にhost名で分岐させてる
       showPasswordResetLink: location.host === 'q.trap.jp'
     })
+    const externalLogin = computed(
+      () => store.state.app.version.flags.externalLogin
+    )
+
     return {
       state,
       loginState,
@@ -105,7 +112,8 @@ export default defineComponent({
       setPass,
       login,
       loginExternal,
-      isIOS
+      isIOS,
+      externalLogin
     }
   }
 })

--- a/src/components/Main/Modal/UserModal/ProfileTab/Accounts.vue
+++ b/src/components/Main/Modal/UserModal/ProfileTab/Accounts.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <profile-header text="アカウント" />
-    <p :class="$style.p">
+    <p v-if="showWikiPageLink" :class="$style.p">
       <circle-icon
         name="book"
         mdi
@@ -58,6 +58,7 @@ export default defineComponent({
       () => store.getters.app.themeSettings.currentTheme.background.primary
     )
 
+    const showWikiPageLink = computed(() => location.host === 'q.trap.jp') // 簡易的にhost名で分岐させてる
     const wikiPageName = computed(() => {
       if (props.bot) {
         return `bot/${props.name.replace(/^BOT_/, '')}`
@@ -73,6 +74,7 @@ export default defineComponent({
     return {
       iconColor,
       iconBackgroundColor,
+      showWikiPageLink,
       wikiPageName,
       wikiPageLink,
       twitterLink
@@ -89,7 +91,6 @@ export default defineComponent({
 .p {
   margin: 8px 0;
 }
-
 .icon {
   margin-right: 4px;
   vertical-align: bottom;

--- a/src/store/app/actions.ts
+++ b/src/store/app/actions.ts
@@ -1,8 +1,15 @@
 import { defineActions } from 'direct-vuex'
 import { moduleActionContext } from '@/store'
 import { app } from './index'
+import apis from '@/lib/apis'
 
 export const appActionContext = (context: any) =>
   moduleActionContext(context, app)
 
-export const actions = defineActions({})
+export const actions = defineActions({
+  async fetchVersionInfo(context) {
+    const { commit } = appActionContext(context)
+    const res = await apis.getServerVersion()
+    commit.setVersion(res.data)
+  }
+})

--- a/src/store/app/mutations.ts
+++ b/src/store/app/mutations.ts
@@ -1,5 +1,6 @@
 import { defineMutations } from 'direct-vuex'
 import { S } from './state'
+import { Version } from '@traptitech/traq'
 
 export const mutations = defineMutations<S>()({
   setLoaded(state: S, loaded: boolean) {
@@ -10,6 +11,9 @@ export const mutations = defineMutations<S>()({
   },
   setInitialFetchCompleted(state: S) {
     state.initialFetchCompleted = true
+  },
+  setVersion(state: S, version: Version) {
+    state.version = version
   }
   // TODO: テーマの変更
 })

--- a/src/store/app/state.ts
+++ b/src/store/app/state.ts
@@ -1,11 +1,15 @@
+import { Version } from '@traptitech/traq'
+
 export interface S {
   loaded: boolean
   componentLoaded: boolean
   initialFetchCompleted: boolean
+  version: Version
 }
 
 export const state: S = {
   loaded: false,
   componentLoaded: false,
-  initialFetchCompleted: false
+  initialFetchCompleted: false,
+  version: {}
 }

--- a/src/store/app/state.ts
+++ b/src/store/app/state.ts
@@ -11,5 +11,11 @@ export const state: S = {
   loaded: false,
   componentLoaded: false,
   initialFetchCompleted: false,
-  version: {}
+  version: {
+    version: '',
+    revision: '',
+    flags: {
+      externalLogin: []
+    }
+  }
 }


### PR DESCRIPTION
+ `store.state.app`に`version`状態を追加
+ `App.vue`の`onBeforeMount`で/versionをfetchするように
+ ログイン画面の外部ログインを有効なものだけ表示するように変更
+ パスワードリセットリンクを簡易的にhostが`q.trap.jp`の時のみ表示するように変更