### PR TITLE
モバイル時にナビゲーションをタップで扱う

### DIFF
--- a/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
@@ -5,6 +5,7 @@
         :class="$style.navigationButton"
         :style="styles.navigationButton"
         v-if="isMobile"
+        @click="openNav"
       >
         <icon name="traQ" />
       </button>
@@ -21,6 +22,7 @@ import { defineComponent, reactive } from '@vue/composition-api'
 import { makeStyles } from '@/lib/styles'
 import Icon from '@/components/UI/Icon.vue'
 import useIsMobile from '@/use/isMobile'
+import useNavigationController from '@/use/navigationController'
 
 const useStyles = () =>
   reactive({
@@ -42,9 +44,11 @@ export default defineComponent({
   setup(props, context) {
     const styles = useStyles()
     const { isMobile } = useIsMobile()
+    const { openNav } = useNavigationController()
     return {
       styles,
-      isMobile
+      isMobile,
+      openNav
     }
   }
 })

--- a/src/store/ui/mainView/getters.ts
+++ b/src/store/ui/mainView/getters.ts
@@ -10,6 +10,14 @@ export const getters = defineGetters<S>()({
       MainViewComponentState.SidebarShown
     )
   },
+  isNavOpen(state: S) {
+    return (
+      state.currentMainViewComponentState === MainViewComponentState.NavShown
+    )
+  },
+  isNoComponentOpen(state: S) {
+    return state.currentMainViewComponentState === MainViewComponentState.Hidden
+  },
   headerStyle(state: S): HeaderStyle {
     if (
       state.layout === 'split-reverse' &&

--- a/src/use/navigationController.ts
+++ b/src/use/navigationController.ts
@@ -1,19 +1,27 @@
 import store from '@/store'
 import { MainViewComponentState } from '@/store/ui/mainView/state'
 
+/**
+ * モバイル用にナビゲーションの開閉を行う
+ */
 const useNavigation = () => {
   const openNav = () => {
+    if (
+      !store.getters.ui.isMobile ||
+      !store.getters.ui.mainView.isNoComponentOpen
+    ) {
+      return
+    }
     store.commit.ui.mainView.setMainViewComponentState(
-      store.getters.ui.isMobile
-        ? MainViewComponentState.NavAppearingAuto
-        : MainViewComponentState.NavShown
+      MainViewComponentState.NavAppearingAuto
     )
   }
   const closeNav = () => {
+    if (!store.getters.ui.isMobile || !store.getters.ui.mainView.isNavOpen) {
+      return
+    }
     store.commit.ui.mainView.setMainViewComponentState(
-      store.getters.ui.isMobile
-        ? MainViewComponentState.NavDisappearingAuto
-        : MainViewComponentState.Hidden
+      MainViewComponentState.NavDisappearingAuto
     )
   }
   return { openNav, closeNav }

--- a/src/use/navigationController.ts
+++ b/src/use/navigationController.ts
@@ -1,0 +1,22 @@
+import store from '@/store'
+import { MainViewComponentState } from '@/store/ui/mainView/state'
+
+const useNavigation = () => {
+  const openNav = () => {
+    store.commit.ui.mainView.setMainViewComponentState(
+      store.getters.ui.isMobile
+        ? MainViewComponentState.NavAppearingAuto
+        : MainViewComponentState.NavShown
+    )
+  }
+  const closeNav = () => {
+    store.commit.ui.mainView.setMainViewComponentState(
+      store.getters.ui.isMobile
+        ? MainViewComponentState.NavDisappearingAuto
+        : MainViewComponentState.Hidden
+    )
+  }
+  return { openNav, closeNav }
+}
+
+export default useNavigation

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -105,8 +105,6 @@ export default defineComponent({
       isSidebarAppeared,
       isSidebarCompletelyAppeared,
       isMainViewActive,
-      openSidebar: animateOpenSidebar,
-      closeSidebar: animateCloseSidebar,
       currentActiveDrawer
     } = useMainViewLayout(navWidth, sidebarWidth)
 

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -13,12 +13,13 @@
     @touchcancel="touchendHandler"
   >
     <div :class="$style.homeContainer" :style="styles.homeContainer">
-      <navigation v-show="showNav" :class="$style.navigationWrapper" />
+      <navigation v-show="shouldShowNav" :class="$style.navigationWrapper" />
       <main-view-frame
         :is-active="isMainViewActive"
         :hide-outer="hideOuter"
         :dim-inner="isSidebarCompletelyAppeared"
         :style="styles.mainViewWrapper"
+        @click.native.capture="onClickMainViewFrame"
       >
         <main-view :class="$style.mainViewWrapper" />
       </main-view-frame>
@@ -49,7 +50,9 @@ import { defineComponent, reactive, computed, Ref } from '@vue/composition-api'
 import { setupWebSocket } from '@/lib/websocket'
 import { connectFirebase } from '@/lib/firebase'
 import { makeStyles } from '@/lib/styles'
+
 import useIsMobile from '@/use/isMobile'
+import useNavigationController from '@/use/navigationController'
 import MainView from '@/components/Main/MainView/MainView.vue'
 import MainViewFrame from '@/components/Main/MainView/MainViewFrame.vue'
 import Navigation from '@/components/Main/Navigation/Navigation.vue'
@@ -109,7 +112,8 @@ export default defineComponent({
     } = useMainViewLayout(navWidth, sidebarWidth)
 
     const { isMobile } = useIsMobile()
-    const showNav = computed(() => !isMobile.value || isNavAppeared.value)
+    const shouldShowNav = computed(() => !isMobile.value || isNavAppeared.value)
+    const { closeNav } = useNavigationController()
     const hideOuter = computed(
       () => isMobile.value && isNavCompletelyAppeared.value
     )
@@ -122,6 +126,14 @@ export default defineComponent({
 
     const styles = useStyles(mainViewPosition, sidebarPosition)
 
+    const onClickMainViewFrame = (e: MouseEvent) => {
+      if (!isMobile.value || !isNavCompletelyAppeared.value) {
+        return
+      }
+      e.stopPropagation()
+      closeNav()
+    }
+
     return {
       touchstartHandler,
       touchmoveHandler,
@@ -129,13 +141,15 @@ export default defineComponent({
 
       routeWatcherState,
 
-      showNav,
+      shouldShowNav,
       hideOuter,
       isNavCompletelyAppeared,
       isSidebarCompletelyAppeared,
       isSidebarAppeared,
       isMainViewActive,
       isMobile,
+
+      onClickMainViewFrame,
 
       targetPortalName,
       styles,

--- a/src/views/use/mainViewLayout.ts
+++ b/src/views/use/mainViewLayout.ts
@@ -84,7 +84,11 @@ const useMainViewLayout = (navWidth: number, sidebarWidth: number) => {
   // state machine hooks
   watch(mState, newState => {
     if (!store.getters.ui.isMobile) return
-    if (newState === MainViewComponentState.SidebarAppearingAuto) {
+    if (newState === MainViewComponentState.NavAppearingAuto) {
+      openNav()
+    } else if (newState === MainViewComponentState.NavDisappearingAuto) {
+      closeNav()
+    } else if (newState === MainViewComponentState.SidebarAppearingAuto) {
       openSidebar()
     } else if (newState === MainViewComponentState.SidebarDisappearingAuto) {
       closeSidebar()

--- a/src/views/use/routeWatcher.ts
+++ b/src/views/use/routeWatcher.ts
@@ -1,6 +1,7 @@
 import { SetupContext, computed, reactive, watch } from '@vue/composition-api'
 import store from '@/store'
 import { RouteName } from '@/router'
+import useNavigationController from '@/use/navigationController'
 import useChannelPath from '@/use/channelPath'
 import useViewTitle from './viewTitle'
 
@@ -9,6 +10,7 @@ type Views = 'none' | 'main' | 'not-found'
 const useRouteWacher = (context: SetupContext) => {
   const { channelPathToId, channelIdToPathString } = useChannelPath()
   const { changeViewTitle } = useViewTitle()
+  const { closeNav } = useNavigationController()
 
   const state = reactive({
     currentRouteName: computed(() => context.root.$route.name ?? ''),
@@ -157,6 +159,7 @@ const useRouteWacher = (context: SetupContext) => {
     }
 
     state.isInitialView = false
+    closeNav()
   }
 
   const routeWatcher = watch(


### PR DESCRIPTION
- ヘッダのボタンタップで開く
- ルート移動・メイン部分タップで閉じる
