### PR TITLE
WebSocketの自動再接続

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15477,6 +15477,11 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "reconnecting-websocket": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "idb-keyval": "^3.2.0",
     "lodash-es": "^4.17.15",
     "portal-vue": "^2.1.7",
+    "reconnecting-websocket": "^4.4.0",
     "shvl": "^2.0.0",
     "skyway-js": "^2.0.5",
     "v-click-outside": "^3.0.1",


### PR DESCRIPTION
とりあえず、https://github.com/pladaria/reconnecting-websocket を導入してWebSocketの自動再接続を実装しましたが、再接続時の状態再送信・リロード処理は実装してません。