### PR TITLE
WSの再接続

### DIFF
--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -1,0 +1,158 @@
+import { WebSocketCommand } from '.'
+
+export interface Options {
+  maxReconnectionDelay: number
+  minReconnectionDelay: number
+  connectionTimeout: number
+}
+
+const defaultOptions: Options = {
+  maxReconnectionDelay: 10000,
+  minReconnectionDelay: 1000,
+  connectionTimeout: 4000
+}
+
+interface EventMap {
+  message: CustomEvent<any>
+  reconnect: Event
+}
+type EventListener<T extends keyof EventMap> = (ev: EventMap[T]) => any
+
+const wait = (ms: number) => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve()
+    }, ms)
+  })
+}
+
+export default class AutoReconnectWebSocket {
+  _ws?: WebSocket
+  eventTarget: EventTarget
+
+  readonly url: string
+  readonly protocols: string | string[] | undefined
+  readonly options: Options
+
+  sendQueue = new Map<WebSocketCommand, string[]>()
+  isInitialized = false
+  reconnecting = false
+
+  constructor(
+    url: string,
+    protocols: string | string[] | undefined,
+    options: Readonly<Partial<Options>>
+  ) {
+    this.url = url
+    this.protocols = protocols
+    this.options = { ...options, ...defaultOptions }
+
+    this.eventTarget = new EventTarget()
+  }
+
+  get isOpen() {
+    return this._ws?.readyState === WebSocket.OPEN
+  }
+
+  _sendCommand(commands: readonly [WebSocketCommand, ...string[]]) {
+    this._ws!.send(commands.join(':'))
+  }
+
+  sendCommand(...commands: readonly [WebSocketCommand, ...string[]]) {
+    if (this.isOpen) {
+      this._sendCommand(commands)
+    } else {
+      this.sendQueue.set(commands[0], commands.slice(1))
+    }
+  }
+
+  _getDelay(count: number) {
+    const { minReconnectionDelay, maxReconnectionDelay } = this.options
+    return Math.min(minReconnectionDelay * 1.3 ** count, maxReconnectionDelay)
+  }
+
+  _setupWs() {
+    return new Promise(resolve => {
+      this._ws = new WebSocket(this.url, this.protocols)
+
+      this._ws.addEventListener(
+        'open',
+        () => {
+          resolve()
+          if (this.isInitialized) {
+            this.eventTarget.dispatchEvent(new Event('reconnect'))
+          } else {
+            this.isInitialized = true
+          }
+
+          this.sendQueue.forEach((args, command) => {
+            this._sendCommand([command, ...args])
+          })
+          this.sendQueue.clear()
+        },
+        { once: true }
+      )
+      this._ws.addEventListener(
+        'error',
+        () => {
+          resolve()
+        },
+        { once: true }
+      )
+
+      this._ws.addEventListener('message', e => {
+        this.eventTarget.dispatchEvent(
+          new CustomEvent('message', { detail: e.data })
+        )
+      })
+
+      this._ws.addEventListener(
+        'close',
+        () => {
+          this.reconnect()
+        },
+        { once: true }
+      )
+    })
+  }
+
+  addEventListener<T extends keyof EventMap>(
+    type: T,
+    listener: EventListener<T>,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    this.eventTarget.addEventListener(type, listener as any, options)
+  }
+  removeEventListener<T extends keyof EventMap>(
+    type: T,
+    listener: EventListener<T>,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    this.eventTarget.removeEventListener(type, listener as any, options)
+  }
+
+  connect() {
+    this._setupWs()
+  }
+
+  async reconnect() {
+    if (this.reconnecting) return
+    this.reconnecting = true
+
+    let count = 1
+    while (true) {
+      const delay = this._getDelay(count)
+      await wait(delay)
+
+      if (this.isOpen) break
+
+      await this._setupWs()
+
+      if (this.isOpen) break
+
+      count++
+    }
+
+    this.reconnecting = false
+  }
+}

--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -47,7 +47,8 @@ export default class AutoReconnectWebSocket {
     this.protocols = protocols
     this.options = { ...options, ...defaultOptions }
 
-    this.eventTarget = new EventTarget()
+    // SafariでEventTargetのコンストラクタ使えないので`<span>`で代用
+    this.eventTarget = document.createElement('span')
   }
 
   get isOpen() {

--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -60,10 +60,9 @@ export default class AutoReconnectWebSocket {
   }
 
   sendCommand(...commands: readonly [WebSocketCommand, ...string[]]) {
+    this.sendQueue.set(commands[0], commands.slice(1))
     if (this.isOpen) {
       this._sendCommand(commands)
-    } else {
-      this.sendQueue.set(commands[0], commands.slice(1))
     }
   }
 
@@ -89,7 +88,6 @@ export default class AutoReconnectWebSocket {
           this.sendQueue.forEach((args, command) => {
             this._sendCommand([command, ...args])
           })
-          this.sendQueue.clear()
         },
         { once: true }
       )

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -1,22 +1,25 @@
 import { WEBSOCKET_ENDPOINT } from '@/lib/apis'
 import { onReceive } from './receive'
+import AutoReconnectWebSocket from './AutoReconnectWebSocket'
 
 const absoluteWebsocketEndpoint = new URL(WEBSOCKET_ENDPOINT, document.baseURI)
 absoluteWebsocketEndpoint.protocol =
   window.location.protocol === 'https:' ? 'wss' : 'ws'
 
-export let ws: WebSocket | undefined
-export let wsConnectionPromise: Promise<void> | undefined
+export const ws = new AutoReconnectWebSocket(
+  absoluteWebsocketEndpoint.href,
+  undefined,
+  {
+    maxReconnectionDelay: 3000,
+    minReconnectionDelay: 1000
+  }
+)
 
 export const setupWebSocket = () => {
-  ws = new WebSocket(absoluteWebsocketEndpoint.href)
-  wsConnectionPromise = new Promise(resolve => {
-    ws!.addEventListener('open', () => {
-      resolve()
-    })
-  })
+  ws.connect()
+
   ws.addEventListener('message', event => {
-    onReceive(event.data)
+    onReceive(event.detail)
   })
 }
 

--- a/src/lib/websocket/send.ts
+++ b/src/lib/websocket/send.ts
@@ -1,21 +1,8 @@
-import { ws, wsConnectionPromise } from './index'
+import { ws } from './index'
 import { ChannelViewState, WebRTCUserStateSessions } from '@traptitech/traq'
 import { ChannelId } from '@/types/entity-ids'
 
-type WebSocketCommand = 'viewstate' | 'rtcstate' | 'timeline_streaming'
-
-const sendWebSocket = async (
-  ...command: readonly [WebSocketCommand, ...string[]]
-): Promise<void> => {
-  if (ws === undefined) {
-    throw new Error('WebSocket is not connected')
-  }
-  await wsConnectionPromise
-  if (ws.readyState === ws.CLOSED || ws.readyState === ws.CLOSING) {
-    throw new Error('WebSocket is already in CLOSING or CLOSED state.')
-  }
-  ws.send(command.join(':'))
-}
+export type WebSocketCommand = 'viewstate' | 'rtcstate' | 'timeline_streaming'
 
 const VIEWSTATE_COMMAND = 'viewstate'
 
@@ -27,11 +14,11 @@ type ChangeViewStateFunction = {
 export const changeViewState: ChangeViewStateFunction = (
   channelId: ChannelId | null,
   viewState?: ChannelViewState
-): Promise<void> => {
+) => {
   if (channelId === null) {
-    return sendWebSocket(VIEWSTATE_COMMAND, '')
+    ws.sendCommand(VIEWSTATE_COMMAND, '')
   } else {
-    return sendWebSocket(VIEWSTATE_COMMAND, channelId, viewState!)
+    ws.sendCommand(VIEWSTATE_COMMAND, channelId, viewState!)
   }
 }
 
@@ -42,9 +29,9 @@ export const changeRTCState = (
   states: WebRTCUserStateSessions[]
 ) => {
   if (states.length === 0) {
-    return sendWebSocket(RTCSTATE_COMMAND, channelId, '')
+    ws.sendCommand(RTCSTATE_COMMAND, channelId, '')
   }
-  return sendWebSocket(
+  ws.sendCommand(
     RTCSTATE_COMMAND,
     channelId,
     ...states.flatMap(s => [s.state, s.sessionId]),
@@ -57,7 +44,7 @@ const TIMELINE_STREAMING_COMMAND = 'timeline_streaming'
 type TimelineStreamingType = 'on' | 'off' | 'true' | 'false'
 
 const changeTimelineStreamingState = (type: TimelineStreamingType) => {
-  return sendWebSocket(TIMELINE_STREAMING_COMMAND, type)
+  return ws.sendCommand(TIMELINE_STREAMING_COMMAND, type)
 }
 
 export const setTimelineStreamingState = (type: boolean) => {


### PR DESCRIPTION
- 自動再接続
- 再接続時
  - 状態再送信(重複している場合は最新のもののみ)
  - 再取得処理(一部)

を実装しました

SafariでEventTargetのコンストラクタ使えないので`<span>`で代用してます
https://caniuse.com/#feat=mdn-api_eventtarget_eventtarget

よろしくお願いします

