### PR TITLE
添付ファイルのビデオのpreloadを無効化

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
@@ -3,7 +3,13 @@
     <div :class="$style.overlay" :style="styles.overlay">
       <message-file-list-item-content :file-id="fileId" is-white />
     </div>
-    <video controls draggable="false" :alt="fileMeta.name" :src="fileRawPath" />
+    <video
+      controls
+      preload="none"
+      draggable="false"
+      :alt="fileMeta.name"
+      :src="fileRawPath"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
チャンネルを開くだけで添付ファイルのビデオのダウンロードが発生していたので、再生ボタンを押すまで読み込みを抑制させました。