### PR TITLE
ログインのリダイレクト処理 close #370 close #440

### DIFF
--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -67,6 +67,7 @@ import useLogin from './use/login'
 import store from '@/store'
 import { makeStyles } from '@/lib/styles'
 import { isIOSApp } from '@/lib/util/browser'
+import useRedirectParam from './use/redirectParam'
 import AuthenticateInput from './AuthenticateInput.vue'
 import AuthenticateHeader from './AuthenticateHeader.vue'
 import AuthenticateButtonPrimary from './AuthenticateButtonPrimary.vue'
@@ -92,8 +93,11 @@ export default defineComponent({
     AuthenticateButtonSecondary,
     AuthenticateSeparator
   },
-  setup() {
-    const { loginState, login, loginExternal, setName, setPass } = useLogin()
+  setup(_, context) {
+    const redirectState = useRedirectParam(context)
+    const { loginState, login, loginExternal, setName, setPass } = useLogin(
+      redirectState
+    )
     const styles = useStyles()
     const isIOS = isIOSApp()
     const state = reactive({

--- a/src/components/Authenticate/use/redirectParam.ts
+++ b/src/components/Authenticate/use/redirectParam.ts
@@ -1,0 +1,28 @@
+import { SetupContext, computed, reactive } from '@vue/composition-api'
+import { getStringParam } from '@/lib/util/params'
+
+export interface RedirectState {
+  /**
+   * リダイレクト先
+   * 外部の場合はhttp～、内部の場合は/～
+   */
+  redirectUrl?: string
+  /**
+   * 内部へのリダイレクトかどうか
+   */
+  isInternal?: boolean
+}
+
+const useRedirectParam = (context: SetupContext) => {
+  const state: RedirectState = reactive({
+    redirectUrl: computed(() => {
+      const redirect = getStringParam(context.root.$route.query.redirect)
+      return redirect ? redirect : undefined
+    }),
+    isInternal: computed(() => state.redirectUrl?.startsWith('/') ?? false)
+  })
+
+  return state
+}
+
+export default useRedirectParam

--- a/src/lib/util/params.ts
+++ b/src/lib/util/params.ts
@@ -1,0 +1,8 @@
+export const getStringParam = (
+  param: string | Array<string | null>
+): string | undefined => {
+  if (Array.isArray(param)) {
+    return param[0] === null ? undefined : param[0]
+  }
+  return param
+}

--- a/src/router/pipeline.ts
+++ b/src/router/pipeline.ts
@@ -1,0 +1,10 @@
+/**
+ * pipelineにリダイレクトが必要な場合リダイレクトする
+ * リダイレクトした場合はtrueを返す
+ */
+export const redirectToPipelineIfNeeded = () => {
+  // TODO: だし分け
+  // pipeline側でリダイレクト先は制限されている
+  location.href = `/pipeline${location.search}`
+  return true
+}

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -7,12 +7,70 @@ import {
   defineComponent,
   onMounted,
   reactive,
-  PropType
+  PropType,
+  computed,
+  watch,
+  SetupContext
 } from '@vue/composition-api'
 import store from '@/store'
 import AuthenticateMainView from '@/components/Authenticate/AuthenticateMainView.vue'
+import { redirectToPipelineIfNeeded } from '@/router/pipeline'
+import { RouteName } from '@/router'
+import { getStringParam } from '@/lib/util/params'
 
 export type PageType = 'login' | 'password-reset' | 'registration' | 'consent'
+
+const usePageSwitch = (props: { type: PageType }, context: SetupContext) => {
+  const state = reactive({
+    show: false
+  })
+
+  const isConsent = computed(() => props.type === 'consent')
+
+  onMounted(() => {
+    watch(
+      () => props.type,
+      async () => {
+        let isLoggedIn = false
+        try {
+          await store.dispatch.domain.me.fetchMe()
+          isLoggedIn = true
+        } catch {}
+
+        if (isConsent.value) {
+          if (isLoggedIn) {
+            state.show = true
+            return
+          }
+
+          // OAuth認可画面に入る前にログインさせる
+          // ログインしたら戻ってくる
+          context.root.$router.replace({
+            name: RouteName.Login,
+            query: { redirect: `${location.pathname}${location.search}` }
+          })
+          return
+        }
+
+        if (isLoggedIn) {
+          // ログインしている場合でredirパラメータがついてる場合は
+          // pipelineへのリダイレクトをする
+          // pipelineへのリダイレクトをしなくていい環境では
+          // トップへリダイレクトする
+          const redirect = getStringParam(context.root.$route.query.redirect)
+          const redirected = redirect && redirectToPipelineIfNeeded()
+          if (!redirected) {
+            context.root.$router.replace('/')
+          }
+          return
+        }
+
+        state.show = true
+      }
+    )
+  })
+  return state
+}
 
 export default defineComponent({
   name: 'Auth',
@@ -25,25 +83,9 @@ export default defineComponent({
   components: {
     AuthenticateMainView
   },
-  setup(props) {
-    const state = reactive({
-      show: false
-    })
-    onMounted(async () => {
-      let isLoggedIn = false
-      try {
-        await store.dispatch.domain.me.fetchMe()
-        isLoggedIn = true
-      } catch {}
+  setup(props, context) {
+    const state = usePageSwitch(props, context)
 
-      const isConsent = props.type === 'consent'
-
-      if ((isLoggedIn && isConsent) || (!isLoggedIn && !isConsent)) {
-        state.show = true
-      } else {
-        location.href = '/'
-      }
-    })
     return { state }
   }
 })

--- a/src/views/use/initialFetch.ts
+++ b/src/views/use/initialFetch.ts
@@ -35,7 +35,10 @@ const useInitialFetch = (context: SetupContext) => {
       try {
         await store.dispatch.domain.me.fetchMe()
       } catch {
-        context.root.$router.replace({ name: RouteName.Login })
+        context.root.$router.replace({
+          name: RouteName.Login,
+          query: { redirect: `${location.pathname}${location.search}` }
+        })
         reject()
         return
       }


### PR DESCRIPTION
以下のリダイレクトを実装しました

## リダイレクト
### login状態
`/login` => `/`
`/login?redirect=～` => `/pipeline?redirect=～`
`/consent`

### loginしていない状態
`/` => `/login` => `/`
`/～` => `/login` => `/～`
`/login?redirect`＝～ => `/pipeline?redirect=～`
`/consent?～` => `/login` => `/consent?～`

## TODO
- pipelineのだし分け
- 外部ログインを利用した際の内部リダイレクト(例: `/channels/random` => `/login` => `/api/auth/${name}` => `/` => `/channels/random`)

よろしくお願いします
