### PR TITLE
サムネイルが存在しない時に`files/{fileID}`を使うように

### DIFF
--- a/src/use/fileMeta.ts
+++ b/src/use/fileMeta.ts
@@ -18,7 +18,7 @@ const useFileMeta = (props: { fileId: string }, context: SetupContext) => {
   const fileThumbnailPath = computed(() =>
     fileMeta.value && fileMeta.value.thumbnail !== null
       ? buildFileThumbnailPath(fileMeta.value.id)
-      : ''
+      : fileRawPath.value
   )
   const fileType = computed(() =>
     fileMeta.value ? mimeToFileType(fileMeta.value.mime) : 'file'


### PR DESCRIPTION
サムネイルが存在しない時は、代わりに`files/{fileID}`を使うようにしました。
close #524