### PR TITLE
fix make-dist

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -115,5 +115,5 @@ module.exports = {
   productionSourceMap: false,
 
   // CI上ではthread数を制限
-  parallel: process.env.CI ? +process.env.CIRCLE_NODE_TOTAL : true
+  parallel: process.env.CIRCLECI ? +process.env.CIRCLE_NODE_TOTAL : true
 }


### PR DESCRIPTION
> Invalid options in vue.config.js: child "parallel" fails because ["parallel" must be a boolean, "parallel" must be a number]