### PR TITLE
アクティビティの説明の変更 / アイコンホバーでアイコン名が出ちゃうのを修正

### DIFF
--- a/src/components/Main/Navigation/NavigationContent/Activity.vue
+++ b/src/components/Main/Navigation/NavigationContent/Activity.vue
@@ -10,7 +10,7 @@
       />
       <toggle-button
         :class="$style.button"
-        title="同じチャンネルでも複数のメッセージを表示する"
+        title="同じチャンネルでは一つしかメッセージを表示しない"
         icon-name="comment-multiple-outline"
         icon-mdi
         :value="isPerChannel"

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -10,7 +10,6 @@
     v-on="context.listeners"
     role="img"
   >
-    <title>{{ name }}</title>
     <path :d="getMdiPath(name)" />
   </svg>
   <component


### PR DESCRIPTION
- アクティビティの説明の変更
- アイコンホバーでアイコン名が出ちゃうのを修正

![image](https://user-images.githubusercontent.com/49056869/80707919-baaa5f80-8b25-11ea-8c7a-fa9aad9fd96f.png)

よろしくお願いします
