### PR TITLE
サービス一覧のスタイルの微修正

### DIFF
--- a/src/components/Main/Navigation/AppList.vue
+++ b/src/components/Main/Navigation/AppList.vue
@@ -37,6 +37,7 @@ const useStyles = () =>
   reactive({
     container: makeStyles((theme, common) => ({
       filter: common.dropShadow.default,
+      color: theme.ui.primary,
       background: theme.background.primary
     }))
   })

--- a/src/components/Main/Navigation/AppListItem.vue
+++ b/src/components/Main/Navigation/AppListItem.vue
@@ -64,6 +64,7 @@ export default defineComponent({
   margin: 4px;
 }
 .label {
+  text-align: center;
   font-size: 1rem;
 }
 </style>


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/80784186-225cbb00-8bb7-11ea-8c6c-db2e6a237bcb.png)

 - after
![image](https://user-images.githubusercontent.com/49056869/80784195-27ba0580-8bb7-11ea-9590-6404ed41974e.png)

サービス名の改行時の表示と「サービス」の文字色の修正をしました
よろしくお願いします
