### PR TITLE
自分&自分を含んだグループへのメンションの表示 fix #641

### DIFF
--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -1052,4 +1052,16 @@ html[data-is-dark-theme] {
       background-color: rgba(0, 0, 0, 0.1);
     }
   }
+
+  .message-user-link,
+  .message-channel-link,
+  .message-group-link {
+    cursor: pointer;
+    color: #005BAC;
+    font-weight: bold;
+  }
+  .message-user-link-highlight,
+  .message-group-link-highlight {
+    background-color: #FAFFAD;
+  }
 }


### PR DESCRIPTION
色のテーマ適用は #603 に

![image](https://user-images.githubusercontent.com/49056869/80785188-63a29a00-8bba-11ea-998a-af2d5b71a25a.png)
![image](https://user-images.githubusercontent.com/49056869/80785198-6a311180-8bba-11ea-87a9-769f52e54328.png)

とりあえず表示を変えました

よろしくお願いします
