### PR TITLE
サイドバーのトピックがはみ出さないように

### DIFF
--- a/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
+++ b/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
@@ -80,8 +80,9 @@ export default defineComponent({
 .content {
   width: 100%;
   white-space: pre-line;
-  overflow: auto;
+  word-break: keep-all;
   overflow-wrap: break-word;
+  min-width: 0;
   &[data-is-empty] {
     opacity: 0.5;
   }

--- a/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
+++ b/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
@@ -80,6 +80,8 @@ export default defineComponent({
 .content {
   width: 100%;
   white-space: pre-line;
+  overflow: auto;
+  overflow-wrap: break-word;
   &[data-is-empty] {
     opacity: 0.5;
   }


### PR DESCRIPTION
fix #560

チャンネルトピックとクリップフォルダの説明の表示部分です
よろしくお願いします

before

![スクリーンショット 2020-05-01 19 10 23](https://user-images.githubusercontent.com/28436261/80798816-379a0f80-8be0-11ea-900d-72d55b574142.png)
![スクリーンショット 2020-05-01 19 10 12](https://user-images.githubusercontent.com/28436261/80798818-3a950000-8be0-11ea-8754-5c6bc109001f.png)

after

![スクリーンショット 2020-05-01 19 09 06](https://user-images.githubusercontent.com/28436261/80798835-47195880-8be0-11ea-8005-ebc5aa7a537e.png)
![スクリーンショット 2020-05-01 19 09 24](https://user-images.githubusercontent.com/28436261/80798841-4aacdf80-8be0-11ea-82b3-bf8d7649a3a9.png)
