### PR TITLE
register fcm device token on iOS

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -74,6 +74,14 @@ interface NotificationPayload {
 }
 
 export const connectFirebase = async () => {
+  if (isIOSApp()) {
+    // iOSはNotificationがないため、先にFCMトークンを登録する
+    const token = window.iOSToken
+    if (token && token !== 'No Token') {
+      apis.registerFCMDevice({ token })
+    }
+  }
+
   if (Notification?.permission === 'default') {
     const permission = await Notification.requestPermission()
     if (permission === 'granted') {
@@ -141,12 +149,5 @@ export const connectFirebase = async () => {
 
     const token = await messaging.getToken()
     apis.registerFCMDevice({ token })
-  }
-
-  if (isIOSApp()) {
-    const token = window.iOSToken
-    if (token && token !== 'No Token') {
-      apis.registerFCMDevice({ token })
-    }
   }
 }


### PR DESCRIPTION
`Notification`がなくてFCMトークンを登録できていなかったっぽいので登録処理を上に動かしました
それ以降の処理は`Notification`がなくてスルーされるので安全なはず

close #672