### PR TITLE
MessagePanel周りの変更

### DIFF
--- a/src/components/UI/MessagePanel/RenderContent.vue
+++ b/src/components/UI/MessagePanel/RenderContent.vue
@@ -21,7 +21,7 @@
 <script lang="ts">
 import { defineComponent, reactive, computed } from '@vue/composition-api'
 import { makeStyles } from '@/lib/styles'
-import { embeddingExtractor } from '@/lib/embeddingExtractor'
+import { embeddingReplacer } from '@/lib/embeddingExtractor'
 import { renderInline } from '@/lib/markdown'
 import Icon from '@/components/UI/Icon.vue'
 
@@ -44,7 +44,7 @@ export default defineComponent({
       }))
     })
 
-    const extracted = computed(() => embeddingExtractor(props.content))
+    const extracted = computed(() => embeddingReplacer(props.content))
     const hasFile = computed(() =>
       extracted.value.embeddings.some(e => e.type === 'file')
     )

--- a/src/components/UI/MessagePanel/RenderContent.vue
+++ b/src/components/UI/MessagePanel/RenderContent.vue
@@ -11,7 +11,10 @@
       mdi
       :size="20"
     />
-    <span :class="$style.content" v-html="renderedContent" />
+    <span
+      :class="[$style.content, 'markdown-inline-body']"
+      v-html="renderedContent"
+    />
   </div>
 </template>
 

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -1079,4 +1079,10 @@ html[data-is-dark-theme] {
       }
     }
   }
+
+  .message-emoji {
+    &.large, &.ex-large {
+      font-size: 24px;
+    }
+  }
 }

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -1065,3 +1065,18 @@ html[data-is-dark-theme] {
     background-color: #FAFFAD;
   }
 }
+
+.markdown-inline-body {
+  .spoiler {
+    color: transparent;
+    background-color: black;
+    user-select: none;
+    cursor: pointer;
+
+    &:not([shown]) {
+      * {
+        visibility: hidden;
+      }
+    }
+  }
+}

--- a/tests/unit/embeddingReplacer.spec.ts
+++ b/tests/unit/embeddingReplacer.spec.ts
@@ -1,4 +1,4 @@
-import { embeddingExtractor } from '@/lib/embeddingExtractor'
+import { embeddingReplacer } from '@/lib/embeddingExtractor'
 
 const basePath = `https://example.com`
 const regexp = RegExp(
@@ -6,19 +6,18 @@ const regexp = RegExp(
   'g'
 )
 
-const extractor = (message: string) => embeddingExtractor(message, regexp)
+const extractor = (message: string) => embeddingReplacer(message, regexp)
 
 const id1 = 'e97518db-ebb8-450f-9b4a-273234e68491'
 const id2 = 'd7461966-e5d3-4c6d-9538-7c8605f45a1e'
 const path1 = `${basePath}/files/${id1}`
-const path2 = `${basePath}/files/${id2}`
+const path2 = `${basePath}/messages/${id2}`
 
 describe('embeddingExtractor', () => {
   it('can extract a file from url', () => {
     const message = `${path1}`
     const result = extractor(message)
     expect(result).toEqual({
-      rawText: message,
       text: '',
       embeddings: [
         {
@@ -33,10 +32,10 @@ describe('embeddingExtractor', () => {
 
   it('can extract a file from text with url in middle of it', () => {
     const message = `file ${path1} is file`
+    const replacedMessage = `file [[添付ファイル]] is file`
     const result = extractor(message)
     expect(result).toEqual({
-      rawText: message,
-      text: message,
+      text: replacedMessage,
       embeddings: [
         {
           type: 'file',
@@ -49,11 +48,11 @@ describe('embeddingExtractor', () => {
   })
 
   it('can extract files from text with url in middle of it', () => {
-    const message = `file ${path1} and ${path2} are file`
+    const message = `file ${path1} and ${path2} are file and message`
+    const replacedMessage = `file [[添付ファイル]] and [[添付メッセージ]] are file and message`
     const result = extractor(message)
     expect(result).toEqual({
-      rawText: message,
-      text: message,
+      text: replacedMessage,
       embeddings: [
         {
           type: 'file',
@@ -62,7 +61,7 @@ describe('embeddingExtractor', () => {
           endIndex: 5 + path1.length
         },
         {
-          type: 'file',
+          type: 'message',
           id: id2,
           startIndex: 5 + path1.length + 5,
           endIndex: 5 + path1.length + 5 + path2.length
@@ -76,7 +75,6 @@ describe('embeddingExtractor', () => {
     const message = `${noAttachMessage}${path1}`
     const result = extractor(message)
     expect(result).toEqual({
-      rawText: message,
       text: noAttachMessage,
       embeddings: [
         {


### PR DESCRIPTION
MessagePanelでspoilerが見えてる fix #696
![image](https://user-images.githubusercontent.com/49056869/80816580-b99f2e00-8c0a-11ea-9264-4f4fb95fde39.png)

MessagePanelでサイズエフェクトの無効化 close #690 (`.small`だけ有効です)
![image](https://user-images.githubusercontent.com/49056869/80816593-c02da580-8c0a-11ea-9dfe-5e8375f90ae6.png)

MessagePanelで埋め込みURLを置換するように close #686 
![image](https://user-images.githubusercontent.com/49056869/80816537-a8eeb800-8c0a-11ea-9c4a-d204ec796b1d.png)

よろしくお願いします
