### PR TITLE
グループモーダルとタグモーダルでsuspendedなユーザーを非表示に

### DIFF
--- a/src/components/Main/Modal/GroupModal/GroupModal.vue
+++ b/src/components/Main/Modal/GroupModal/GroupModal.vue
@@ -36,7 +36,10 @@ export default defineComponent({
     const group = computed(() => store.state.entities.userGroups[props.groupId])
     const groupName = computed(() => group.value?.name)
     const groupMember = computed(
-      () => group.value?.members.map(member => member.id) ?? []
+      () =>
+        group.value?.members
+          .map(member => member.id)
+          .filter(id => store.state.entities.users[id]) ?? []
     )
     return { groupName, groupMember }
   }

--- a/src/components/Main/Modal/GroupModal/GroupModal.vue
+++ b/src/components/Main/Modal/GroupModal/GroupModal.vue
@@ -19,6 +19,7 @@ import { defineComponent, computed } from '@vue/composition-api'
 import store from '@/store'
 import ModalFrame from '../Common/ModalFrame.vue'
 import UserListItem from '../Common/UserListItem.vue'
+import { UserAccountState } from '@traptitech/traq'
 
 export default defineComponent({
   name: 'GroupModal',
@@ -38,8 +39,12 @@ export default defineComponent({
     const groupMember = computed(
       () =>
         group.value?.members
-          .map(member => member.id)
-          .filter(id => store.state.entities.users[id]) ?? []
+          .filter(
+            member =>
+              store.state.entities.users[member.id]?.state ===
+              UserAccountState.active
+          )
+          .map(member => member.id) ?? []
     )
     return { groupName, groupMember }
   }

--- a/src/components/Main/Modal/TagModal/TagModal.vue
+++ b/src/components/Main/Modal/TagModal/TagModal.vue
@@ -37,7 +37,9 @@ export default defineComponent({
     store.dispatch.entities.fetchTag(props.tagId)
     const tag = computed(() => store.state.entities.tags[props.tagId])
     const tagName = computed(() => tag.value?.tag)
-    const taggedUsers = computed(() => tag.value?.users ?? [])
+    const taggedUsers = computed(
+      () => tag.value?.users.filter(id => store.state.entities.users[id]) ?? []
+    )
     return { tagName, taggedUsers }
   }
 })

--- a/src/components/Main/Modal/TagModal/TagModal.vue
+++ b/src/components/Main/Modal/TagModal/TagModal.vue
@@ -20,6 +20,7 @@ import { defineComponent, computed } from '@vue/composition-api'
 import store from '@/store'
 import ModalFrame from '../Common/ModalFrame.vue'
 import UserListItem from '../Common/UserListItem.vue'
+import { UserAccountState } from '@traptitech/traq'
 
 export default defineComponent({
   name: 'TagModal',
@@ -38,7 +39,11 @@ export default defineComponent({
     const tag = computed(() => store.state.entities.tags[props.tagId])
     const tagName = computed(() => tag.value?.tag)
     const taggedUsers = computed(
-      () => tag.value?.users.filter(id => store.state.entities.users[id]) ?? []
+      () =>
+        tag.value?.users.filter(
+          user =>
+            store.state.entities.users[user]?.state === UserAccountState.active
+        ) ?? []
     )
     return { tagName, taggedUsers }
   }


### PR DESCRIPTION
fix #655 

タグモーダルのほうもユーザーが歯抜けになっていたので合わせて修正しました (タグのほうはdev環境で見当たらなかったのでスクショがないです)
よろしくお願いします

before

![スクリーンショット 2020-05-02 0 48 33](https://user-images.githubusercontent.com/28436261/80818768-c02fa480-8c0e-11ea-9526-4d3ead9e9885.png)

after

![スクリーンショット 2020-05-02 0 48 52](https://user-images.githubusercontent.com/28436261/80818789-c4f45880-8c0e-11ea-83d6-4f80c15fafbf.png)