### PR TITLE
fix #623

### DIFF
--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -7,6 +7,7 @@
     placeholder="メッセージを送信"
     rows="1"
     @input="onInput"
+    @compositionupdate.native="onCompositionUpdate"
     @before-input.native="onBeforeInput"
     @keydown.native="onKeyDown"
     @keyup.native="onKeyUp"
@@ -99,10 +100,17 @@ export default defineComponent({
       context.emit('input', value)
     }
 
-    const textareaAutosizeRef = ref<{ $el: HTMLTextAreaElement }>()
+    const textareaAutosizeRef = ref<{
+      $el: HTMLTextAreaElement
+      resize: () => void
+    }>()
     const textareaRef = computed(() => textareaAutosizeRef.value?.$el)
 
     const { insertLineBreak } = useLineBreak(props, textareaRef, context)
+
+    const onCompositionUpdate = () => {
+      textareaAutosizeRef.value?.resize()
+    }
 
     const { onBeforeInput, onKeyDown, onKeyUp } = useSendKeyWatcher(
       context,
@@ -115,6 +123,7 @@ export default defineComponent({
     return {
       styles,
       onInput,
+      onCompositionUpdate,
       onBeforeInput,
       onKeyDown,
       onKeyUp,


### PR DESCRIPTION
変換中の文字が左端の1文字だと高さ反映されないんですが、2文字から反映されます(これは`traQ_R`とたぶん同じ仕様です)

よろしくお願いします
