### PR TITLE
メッセージの編集をするとアクティビティで同じチャンネルの投稿が複数表示されてしまっていた

### DIFF
--- a/src/store/domain/mutations.ts
+++ b/src/store/domain/mutations.ts
@@ -28,8 +28,8 @@ export const mutations = defineMutations<S>()({
       const sameChannelActivity =
         state.activityTimelineChannelMap[activity.channelId]
       if (sameChannelActivity) {
-        const sameChannelActivityIndex = state.activityTimeline.indexOf(
-          sameChannelActivity
+        const sameChannelActivityIndex = state.activityTimeline.findIndex(
+          a => a.id === sameChannelActivity.id
         )
         state.activityTimeline.splice(sameChannelActivityIndex, 1)
       }


### PR DESCRIPTION
参照同じだし大丈夫かって`indexOf`で書いてたのが原因です…(編集しない限りは同一なので)

よろしくお願いします
