### PR TITLE
fix 675

### DIFF
--- a/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
@@ -119,6 +119,8 @@ $currentChannelSize: 1.5rem;
 
 .container {
   height: 100%;
+  word-break: keep-all;
+  white-space: nowrap;
 }
 .ancestor {
   font-size: $ancestorSize;

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -69,10 +69,13 @@ export default defineComponent({
 .header {
   display: inline-flex;
   align-items: center;
+  min-width: 0;
 }
 
 .displayName {
   font-weight: bold;
+  word-break: keep-all;
+  white-space: nowrap;
 }
 
 .badge {
@@ -82,6 +85,11 @@ export default defineComponent({
 .name {
   margin-left: 4px;
   font-size: 0.8rem;
+
+  word-break: keep-all;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .date {


### PR DESCRIPTION
### ユーザー名が長いときにメッセージヘッダーの表示がくずれていた fix #675 
  - before
![image](https://user-images.githubusercontent.com/49056869/80859235-01b96180-8c9a-11ea-8c90-9eb9461c38a8.png)
(右側が切れているのは画面から飛び出ている)

  - after
![image](https://user-images.githubusercontent.com/49056869/80859232-f82ff980-8c99-11ea-9e08-c326638e4a0c.png)

### ヘッダーのチャンネル名が改行されることがあった
  - before
![image](https://user-images.githubusercontent.com/49056869/80859243-0d0c8d00-8c9a-11ea-9702-6ecda2ce5ff1.png)
  - after
![image](https://user-images.githubusercontent.com/49056869/80859254-201f5d00-8c9a-11ea-83ef-2dad5a08a62c.png)

よろしくお願いします
