### PR TITLE
スタンプピッカーの検索周り

### DIFF
--- a/src/components/Main/StampPicker/StampPicker.vue
+++ b/src/components/Main/StampPicker/StampPicker.vue
@@ -10,6 +10,7 @@
         @input="setQuery"
         :placeholder="placeholder"
         disable-ime
+        focus-on-mount
       />
       <!--
       <stamp-picker-effect-toggle-button

--- a/src/components/Main/StampPicker/StampPicker.vue
+++ b/src/components/Main/StampPicker/StampPicker.vue
@@ -9,6 +9,7 @@
         :text="textFilterState.query"
         @input="setQuery"
         :placeholder="placeholder"
+        disable-ime
       />
       <!--
       <stamp-picker-effect-toggle-button

--- a/src/components/UI/FilterInput.vue
+++ b/src/components/UI/FilterInput.vue
@@ -2,6 +2,7 @@
   <div :class="$style.container" :style="styles.container">
     <icon mdi name="search" :size="18" :class="$style.icon" />
     <input
+      ref="inputRef"
       :class="$style.input"
       :style="styles.input"
       :value="text"
@@ -15,10 +16,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from '@vue/composition-api'
+import { defineComponent, reactive, ref, onMounted } from '@vue/composition-api'
 import Icon from '@/components/UI/Icon.vue'
 import { makeStyles } from '@/lib/styles'
 import useInput from '@/use/input'
+import { isTouchDevice } from '@/lib/util/browser'
 
 const useStyles = (props: { onSecondary: boolean; disableIme: boolean }) =>
   reactive({
@@ -59,12 +61,23 @@ export default defineComponent({
     disableIme: {
       type: Boolean,
       default: false
+    },
+    focusOnMount: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props, context) {
     const styles = useStyles(props)
     const { onInput } = useInput(context)
-    return { styles, onInput }
+
+    const inputRef = ref<HTMLInputElement>(null)
+    onMounted(() => {
+      if (!props.focusOnMount || isTouchDevice()) return
+      inputRef.value?.focus()
+    })
+
+    return { styles, inputRef, onInput }
   }
 })
 </script>

--- a/src/components/UI/FilterInput.vue
+++ b/src/components/UI/FilterInput.vue
@@ -7,6 +7,7 @@
       :value="text"
       :placeholder="placeholder"
       :autocapitalize="autocapitalize"
+      :inputmode="disableIme ? 'url' : undefined"
       @input="onInput"
       type="text"
     />
@@ -19,7 +20,7 @@ import Icon from '@/components/UI/Icon.vue'
 import { makeStyles } from '@/lib/styles'
 import useInput from '@/use/input'
 
-const useStyles = (props: { onSecondary: boolean }) =>
+const useStyles = (props: { onSecondary: boolean; disableIme: boolean }) =>
   reactive({
     container: makeStyles(theme => ({
       background: props.onSecondary
@@ -28,7 +29,8 @@ const useStyles = (props: { onSecondary: boolean }) =>
       color: theme.ui.secondary
     })),
     input: makeStyles(theme => ({
-      color: theme.ui.primary
+      color: theme.ui.primary,
+      imeMode: props.disableIme ? 'disabled' : undefined
     }))
   })
 
@@ -53,6 +55,10 @@ export default defineComponent({
     autocapitalize: {
       type: String,
       default: 'off'
+    },
+    disableIme: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props, context) {


### PR DESCRIPTION
- タッチ端末以外ではスタンプピッカーを開いたときに検索欄にフォーカスするように close #640
- 検索欄でIMEをデフォルトで無効にするように refs #414 

よろしくお願いします
