### PR TITLE
MessageScrollerのスクロールアンカリングを有効化

### DIFF
--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -212,7 +212,6 @@ export default defineComponent({
 .root {
   height: 100%;
   overflow-y: scroll;
-  overflow-anchor: none;
   padding: 12px 0;
 }
 


### PR DESCRIPTION
画像読み込み・メッセージジャンプなどに問題がなさそうだったのでスクロールアンカリングを有効にしました

展開前

![スクリーンショット 2020-05-03 11 25 12](https://user-images.githubusercontent.com/5803399/80897151-cddd4b00-8d30-11ea-8529-05aacebef13b.png)

展開後before
![スクリーンショット 2020-05-03 11 25 19](https://user-images.githubusercontent.com/5803399/80897152-cfa70e80-8d30-11ea-9ce6-4002e8b91850.png)

展開後after
![スクリーンショット 2020-05-03 11 25 28](https://user-images.githubusercontent.com/5803399/80897153-d0d83b80-8d30-11ea-9001-56c6d8bec348.png)

refs #731﻿
