### PR TITLE
フォントのジャギーの対処とリファクタ

### DIFF
--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -127,7 +127,7 @@ export default defineComponent({
 }
 .forgotPassword {
   @include color-ui-secondary;
-  @include font-size-extra-small;
+  @include caption-size;
   display: block;
   margin-top: 16px;
 }

--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -127,7 +127,7 @@ export default defineComponent({
 }
 .forgotPassword {
   @include color-ui-secondary;
-  @include caption-size;
+  @include size-caption;
   display: block;
   margin-top: 16px;
 }

--- a/src/components/Authenticate/LoginForm.vue
+++ b/src/components/Authenticate/LoginForm.vue
@@ -127,9 +127,9 @@ export default defineComponent({
 }
 .forgotPassword {
   @include color-ui-secondary;
+  @include font-size-extra-small;
   display: block;
   margin-top: 16px;
-  font-size: 0.75rem;
 }
 .buttons {
   display: flex;

--- a/src/components/Authenticate/RegistrationForm.vue
+++ b/src/components/Authenticate/RegistrationForm.vue
@@ -60,7 +60,7 @@ export default defineComponent({
 }
 .forgotPassword {
   @include color-ui-secondary;
-  @include caption-size;
+  @include size-caption;
   display: block;
   margin-top: 16px;
 }

--- a/src/components/Authenticate/RegistrationForm.vue
+++ b/src/components/Authenticate/RegistrationForm.vue
@@ -60,9 +60,9 @@ export default defineComponent({
 }
 .forgotPassword {
   @include color-ui-secondary;
+  @include font-size-extra-small;
   display: block;
   margin-top: 16px;
-  font-size: 0.75rem;
 }
 .buttons {
   display: flex;

--- a/src/components/Authenticate/RegistrationForm.vue
+++ b/src/components/Authenticate/RegistrationForm.vue
@@ -60,7 +60,7 @@ export default defineComponent({
 }
 .forgotPassword {
   @include color-ui-secondary;
-  @include font-size-extra-small;
+  @include caption-size;
   display: block;
   margin-top: 16px;
 }

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarEdit.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarEdit.vue
@@ -45,8 +45,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$editButtonText: 0.8rem;
-
 .container {
   display: flex;
   flex-direction: column;
@@ -54,9 +52,9 @@ $editButtonText: 0.8rem;
 }
 
 .content {
+  @include font-size-small;
   bottom: 0;
   display: flex;
-  font-size: $editButtonText;
   justify-content: center;
   flex-shrink: 0;
   cursor: pointer;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarEdit.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarEdit.vue
@@ -52,7 +52,7 @@ export default defineComponent({
 }
 
 .content {
-  @include body2-size;
+  @include size-body2;
   bottom: 0;
   display: flex;
   justify-content: center;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarEdit.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarEdit.vue
@@ -52,7 +52,7 @@ export default defineComponent({
 }
 
 .content {
-  @include font-size-small;
+  @include body2-size;
   bottom: 0;
   display: flex;
   justify-content: center;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
@@ -30,11 +30,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$headerSize: 1.25rem;
-
 .container {
+  @include font-size-extra-large;
   height: 100%;
-  font-size: $headerSize;
 }
 
 .channelHash {

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
@@ -31,7 +31,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include h2-size;
+  @include size-h2;
   height: 100%;
 }
 

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
@@ -31,7 +31,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-extra-large;
+  @include h2-size;
   height: 100%;
 }
 

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
@@ -49,12 +49,12 @@ export default defineComponent({
 }
 
 .displayName {
-  @include font-size-regular;
+  @include body1-size;
   font-weight: bold;
   margin-left: 8px;
 }
 
 .text {
-  @include font-size-regular;
+  @include body1-size;
 }
 </style>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
@@ -49,12 +49,12 @@ export default defineComponent({
 }
 
 .displayName {
-  @include body1-size;
+  @include size-body1;
   font-weight: bold;
   margin-left: 8px;
 }
 
 .text {
-  @include body1-size;
+  @include size-body1;
 }
 </style>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
@@ -33,9 +33,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$displayNameSize: 1rem;
-$textSize: 1rem;
-
 .container {
   display: block;
   width: 256px;
@@ -52,12 +49,12 @@ $textSize: 1rem;
 }
 
 .displayName {
-  font-size: $displayNameSize;
+  @include font-size-regular;
   font-weight: bold;
   margin-left: 8px;
 }
 
 .text {
-  font-size: $textSize;
+  @include font-size-regular;
 }
 </style>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationContent.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationContent.vue
@@ -37,7 +37,8 @@
             :class="$style.text"
             @click="toggleChildren"
           >
-            子チャンネルを全て表示(+{{ propst.children.length - 3 }})
+            <div>子チャンネルを全て表示</div>
+            <div>(+{{ propst.children.length - 3 }})</div>
           </div>
         </div>
       </div>
@@ -54,7 +55,8 @@
           :class="$style.text"
           @click="toggleSiblings"
         >
-          兄弟チャンネルを全て表示(+{{ propst.siblings.length - 3 }})
+          <div>兄弟チャンネルを全て表示</div>
+          <div>(+{{ propst.siblings.length - 3 }})</div>
         </div>
       </div>
     </div>
@@ -138,8 +140,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$textSize: 0.95rem;
-
 .channel {
   margin-left: 4px;
   padding-left: 12px;
@@ -157,7 +157,11 @@ $textSize: 0.95rem;
 }
 
 .text {
-  font-size: $textSize;
+  @include color-ui-secondary;
+  @include background-secondary;
+  @include font-size-slightly-small;
+  border-radius: 8px;
+  text-align: center;
   cursor: pointer;
 }
 </style>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationContent.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationContent.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 .text {
   @include color-ui-secondary;
   @include background-secondary;
-  @include body2-size;
+  @include size-body2;
   border-radius: 8px;
   text-align: center;
   cursor: pointer;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationContent.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationContent.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 .text {
   @include color-ui-secondary;
   @include background-secondary;
-  @include font-size-slightly-small;
+  @include body2-size;
   border-radius: 8px;
   text-align: center;
   cursor: pointer;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
@@ -52,11 +52,8 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$channelNameSize: 1.125rem;
-$topiclSize: 0.875rem;
-
 .channelNameContainer {
-  font-size: $channelNameSize;
+  @include font-size-large;
 }
 
 .channelHash {
@@ -65,8 +62,8 @@ $topiclSize: 0.875rem;
 }
 
 .topic {
+  @include font-size-slightly-small;
   font-weight: normal;
-  font-size: $topiclSize;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .channelNameContainer {
-  @include h3-size;
+  @include size-h3;
 }
 
 .channelHash {
@@ -62,7 +62,7 @@ export default defineComponent({
 }
 
 .topic {
-  @include body2-size;
+  @include size-body2;
   font-weight: normal;
   display: -webkit-box;
   -webkit-line-clamp: 3;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .channelNameContainer {
-  @include font-size-large;
+  @include h3-size;
 }
 
 .channelHash {
@@ -62,7 +62,7 @@ export default defineComponent({
 }
 
 .topic {
-  @include font-size-slightly-small;
+  @include body2-size;
   font-weight: normal;
   display: -webkit-box;
   -webkit-line-clamp: 3;

--- a/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
@@ -114,16 +114,13 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$ancestorSize: 1rem;
-$currentChannelSize: 1.5rem;
-
 .container {
   height: 100%;
   word-break: keep-all;
   white-space: nowrap;
 }
 .ancestor {
-  font-size: $ancestorSize;
+  @include font-size-regular;
   opacity: 0.5;
   cursor: pointer;
   &:hover {
@@ -131,22 +128,22 @@ $currentChannelSize: 1.5rem;
   }
 }
 .ancestorSeparator {
-  font-size: $ancestorSize;
+  @include font-size-regular;
   opacity: 0.5;
   margin: 0 0.125rem;
   user-select: none;
 }
 .current {
-  font-size: $currentChannelSize;
+  @include font-size-tremendous-large;
   margin: 0 0.125rem;
 }
 .currentHash {
-  font-size: $currentChannelSize;
+  @include font-size-tremendous-large;
   user-select: none;
   margin-right: 0.125rem;
 }
 .ancestorHash {
-  font-size: $currentChannelSize;
+  @include font-size-tremendous-large;
   opacity: 0.5;
   margin-right: 0.125rem;
   user-select: none;

--- a/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
@@ -120,7 +120,7 @@ export default defineComponent({
   white-space: nowrap;
 }
 .ancestor {
-  @include font-size-regular;
+  @include body1-size;
   opacity: 0.5;
   cursor: pointer;
   &:hover {
@@ -128,22 +128,22 @@ export default defineComponent({
   }
 }
 .ancestorSeparator {
-  @include font-size-regular;
+  @include body1-size;
   opacity: 0.5;
   margin: 0 0.125rem;
   user-select: none;
 }
 .current {
-  @include font-size-tremendous-large;
+  @include h1-size;
   margin: 0 0.125rem;
 }
 .currentHash {
-  @include font-size-tremendous-large;
+  @include h1-size;
   user-select: none;
   margin-right: 0.125rem;
 }
 .ancestorHash {
-  @include font-size-tremendous-large;
+  @include h1-size;
   opacity: 0.5;
   margin-right: 0.125rem;
   user-select: none;

--- a/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
@@ -120,7 +120,7 @@ export default defineComponent({
   white-space: nowrap;
 }
 .ancestor {
-  @include body1-size;
+  @include size-body1;
   opacity: 0.5;
   cursor: pointer;
   &:hover {
@@ -128,22 +128,22 @@ export default defineComponent({
   }
 }
 .ancestorSeparator {
-  @include body1-size;
+  @include size-body1;
   opacity: 0.5;
   margin: 0 0.125rem;
   user-select: none;
 }
 .current {
-  @include h1-size;
+  @include size-h1;
   margin: 0 0.125rem;
 }
 .currentHash {
-  @include h1-size;
+  @include size-h1;
   user-select: none;
   margin-right: 0.125rem;
 }
 .ancestorHash {
-  @include h1-size;
+  @include size-h1;
   opacity: 0.5;
   margin-right: 0.125rem;
   user-select: none;

--- a/src/components/Main/MainView/ChannelView/HeaderTopic.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderTopic.vue
@@ -60,8 +60,8 @@ export default defineComponent({
   }
 }
 .topic {
+  @include font-size-slightly-small;
   width: 100%;
-  font-size: 0.875rem;
   font-weight: normal;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Main/MainView/ChannelView/HeaderTopic.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderTopic.vue
@@ -60,7 +60,7 @@ export default defineComponent({
   }
 }
 .topic {
-  @include font-size-slightly-small;
+  @include body2-size;
   width: 100%;
   font-weight: normal;
   overflow: hidden;

--- a/src/components/Main/MainView/ChannelView/HeaderTopic.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderTopic.vue
@@ -60,7 +60,7 @@ export default defineComponent({
   }
 }
 .topic {
-  @include body2-size;
+  @include size-body2;
   width: 100%;
   font-weight: normal;
   overflow: hidden;

--- a/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
+++ b/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   flex-shrink: 0;
 }
 .header {
-  @include font-size-extra-large;
+  @include h2-size;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
+++ b/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
@@ -41,8 +41,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$headerSize: 1.25rem;
-
 .container {
   height: 100%;
   width: calc(100% - 32px);
@@ -54,10 +52,10 @@ $headerSize: 1.25rem;
   flex-shrink: 0;
 }
 .header {
+  @include font-size-large;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  font-size: $headerSize;
 }
 </style>

--- a/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
+++ b/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   flex-shrink: 0;
 }
 .header {
-  @include font-size-large;
+  @include font-size-extra-large;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
+++ b/src/components/Main/MainView/ClipsSidebar/ClipsSidebarHeader.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   flex-shrink: 0;
 }
 .header {
-  @include h2-size;
+  @include size-h2;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
+++ b/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
@@ -29,8 +29,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$headerSize: 1.25rem;
-
 .container {
   height: 100%;
   width: calc(100% - 32px);
@@ -42,10 +40,10 @@ $headerSize: 1.25rem;
   flex-shrink: 0;
 }
 .header {
+  @include font-size-large;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  font-size: $headerSize;
 }
 </style>

--- a/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
+++ b/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
@@ -40,7 +40,7 @@ export default defineComponent({
   flex-shrink: 0;
 }
 .header {
-  @include font-size-extra-large;
+  @include h2-size;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
+++ b/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
@@ -40,7 +40,7 @@ export default defineComponent({
   flex-shrink: 0;
 }
 .header {
-  @include h2-size;
+  @include size-h2;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
+++ b/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
@@ -40,7 +40,7 @@ export default defineComponent({
   flex-shrink: 0;
 }
 .header {
-  @include font-size-large;
+  @include font-size-extra-large;
   width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
@@ -49,6 +49,6 @@ export default defineComponent({
 }
 
 .title {
-  @include font-size-tremendous-large;
+  @include h1-size;
 }
 </style>

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
@@ -39,8 +39,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$titleSize: 1.5rem;
-
 .container {
   display: flex;
   align-items: center;
@@ -51,6 +49,6 @@ $titleSize: 1.5rem;
 }
 
 .title {
-  font-size: $titleSize;
+  @include font-size-tremendous-large;
 }
 </style>

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
@@ -49,6 +49,6 @@ export default defineComponent({
 }
 
 .title {
-  @include h1-size;
+  @include size-h1;
 }
 </style>

--- a/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
+++ b/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
@@ -55,8 +55,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$headerSize: 1rem;
-
 .container {
   display: flex;
   flex-direction: column;
@@ -85,7 +83,7 @@ $headerSize: 1rem;
 }
 
 .headerTitle {
+  @include font-size-regular;
   font-weight: bold;
-  font-size: $headerSize;
 }
 </style>

--- a/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
+++ b/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 }
 
 .headerTitle {
-  @include body1-size;
+  @include size-body1;
   font-weight: bold;
 }
 </style>

--- a/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
+++ b/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 }
 
 .headerTitle {
-  @include font-size-regular;
+  @include body1-size;
   font-weight: bold;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/GradeBadge.vue
+++ b/src/components/Main/MainView/MessageElement/GradeBadge.vue
@@ -50,10 +50,10 @@ export default defineComponent({
 
 <style lang="scss" module>
 .body {
+  @include font-size-slightly-small;
   display: inline-flex;
   align-items: center;
   font-weight: bold;
-  font-size: 14px;
   border-radius: 4px;
   padding: 0 4px;
 }

--- a/src/components/Main/MainView/MessageElement/GradeBadge.vue
+++ b/src/components/Main/MainView/MessageElement/GradeBadge.vue
@@ -50,7 +50,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .body {
-  @include body2-size;
+  @include size-body2;
   display: inline-flex;
   align-items: center;
   font-weight: bold;

--- a/src/components/Main/MainView/MessageElement/GradeBadge.vue
+++ b/src/components/Main/MainView/MessageElement/GradeBadge.vue
@@ -50,7 +50,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .body {
-  @include font-size-slightly-small;
+  @include body2-size;
   display: inline-flex;
   align-items: center;
   font-weight: bold;

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 }
 
 .name {
-  @include font-size-small;
+  @include body2-size;
   margin-left: 4px;
 
   word-break: keep-all;
@@ -93,7 +93,7 @@ export default defineComponent({
 }
 
 .date {
-  @include font-size-extra-small;
+  @include caption-size;
   margin-left: 4px;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -83,8 +83,8 @@ export default defineComponent({
 }
 
 .name {
+  @include font-size-small;
   margin-left: 4px;
-  font-size: 0.8rem;
 
   word-break: keep-all;
   white-space: nowrap;
@@ -93,7 +93,7 @@ export default defineComponent({
 }
 
 .date {
+  @include font-size-extra-small;
   margin-left: 4px;
-  font-size: 0.75rem;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 }
 
 .name {
-  @include body2-size;
+  @include size-body2;
   margin-left: 4px;
 
   word-break: keep-all;
@@ -93,7 +93,7 @@ export default defineComponent({
 }
 
 .date {
-  @include caption-size;
+  @include size-caption;
   margin-left: 4px;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -116,7 +116,7 @@ export default defineComponent({
 }
 
 .messageContents {
-  @include font-size-slightly-small;
+  @include body2-size;
   grid-area: message-contents;
   padding-top: 4px;
   padding-left: 8px;
@@ -134,7 +134,7 @@ export default defineComponent({
   }
 }
 .footer {
-  @include font-size-slightly-small;
+  @include body2-size;
   grid-area: footer;
   padding-left: 8px;
   align-self: end;

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -116,7 +116,7 @@ export default defineComponent({
 }
 
 .messageContents {
-  @include body2-size;
+  @include size-body2;
   grid-area: message-contents;
   padding-top: 4px;
   padding-left: 8px;
@@ -134,7 +134,7 @@ export default defineComponent({
   }
 }
 .footer {
-  @include body2-size;
+  @include size-body2;
   grid-area: footer;
   padding-left: 8px;
   align-self: end;

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -116,11 +116,11 @@ export default defineComponent({
 }
 
 .messageContents {
+  @include font-size-slightly-small;
   grid-area: message-contents;
   padding-top: 4px;
   padding-left: 8px;
   min-width: 0;
-  font-size: 0.875rem;
 }
 
 .content {
@@ -134,9 +134,9 @@ export default defineComponent({
   }
 }
 .footer {
+  @include font-size-slightly-small;
   grid-area: footer;
   padding-left: 8px;
-  font-size: 0.875rem;
   align-self: end;
   margin-top: 4px;
   word-break: keep-all;

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
@@ -43,7 +43,7 @@ export default defineComponent({
 }
 
 .displayName {
-  @include body2-size;
+  @include size-body2;
   font-weight: bold;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
@@ -43,7 +43,7 @@ export default defineComponent({
 }
 
 .displayName {
-  @include font-size-slightly-small;
+  @include body2-size;
   font-weight: bold;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
@@ -43,7 +43,7 @@ export default defineComponent({
 }
 
 .displayName {
+  @include font-size-slightly-small;
   font-weight: bold;
-  font-size: 0.875rem;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 }
 
 .count {
-  @include body2-size;
+  @include size-body2;
   font-weight: bold;
   margin: {
     left: 6px;

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 }
 
 .count {
-  @include font-size-small;
+  @include body2-size;
   font-weight: bold;
   margin: {
     left: 6px;

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 }
 
 .count {
-  font-size: 0.8rem;
+  @include font-size-small;
   font-weight: bold;
   margin: {
     left: 6px;

--- a/src/components/Main/Modal/NotificationModal/NotificationStateSelectorItem.vue
+++ b/src/components/Main/Modal/NotificationModal/NotificationStateSelectorItem.vue
@@ -78,7 +78,7 @@ export default defineComponent({
   }
 }
 .icon {
-  font-size: 1rem;
+  @include font-size-regular;
   grid-area: icon;
 }
 .title {
@@ -90,7 +90,7 @@ export default defineComponent({
 }
 .description {
   @include color-ui-primary;
-  font-size: 0.75rem;
+  @include font-size-extra-small;
   grid-area: description;
 }
 </style>

--- a/src/components/Main/Modal/NotificationModal/NotificationStateSelectorItem.vue
+++ b/src/components/Main/Modal/NotificationModal/NotificationStateSelectorItem.vue
@@ -78,7 +78,7 @@ export default defineComponent({
   }
 }
 .icon {
-  @include body1-size;
+  @include size-body1;
   grid-area: icon;
 }
 .title {
@@ -90,7 +90,7 @@ export default defineComponent({
 }
 .description {
   @include color-ui-primary;
-  @include caption-size;
+  @include size-caption;
   grid-area: description;
 }
 </style>

--- a/src/components/Main/Modal/NotificationModal/NotificationStateSelectorItem.vue
+++ b/src/components/Main/Modal/NotificationModal/NotificationStateSelectorItem.vue
@@ -78,7 +78,7 @@ export default defineComponent({
   }
 }
 .icon {
-  @include font-size-regular;
+  @include body1-size;
   grid-area: icon;
 }
 .title {
@@ -90,7 +90,7 @@ export default defineComponent({
 }
 .description {
   @include color-ui-primary;
-  @include font-size-extra-small;
+  @include caption-size;
   grid-area: description;
 }
 </style>

--- a/src/components/Main/Modal/SettingModal/MobileTabSelector.vue
+++ b/src/components/Main/Modal/SettingModal/MobileTabSelector.vue
@@ -70,9 +70,9 @@ export default defineComponent({
   align-items: center;
 }
 .title {
+  @include font-size-extra-large;
   padding-left: 40px;
   flex: 1 0;
-  font-size: 1.25rem;
 }
 
 .safariWarning {

--- a/src/components/Main/Modal/SettingModal/MobileTabSelector.vue
+++ b/src/components/Main/Modal/SettingModal/MobileTabSelector.vue
@@ -70,7 +70,7 @@ export default defineComponent({
   align-items: center;
 }
 .title {
-  @include font-size-extra-large;
+  @include h2-size;
   padding-left: 40px;
   flex: 1 0;
 }

--- a/src/components/Main/Modal/SettingModal/MobileTabSelector.vue
+++ b/src/components/Main/Modal/SettingModal/MobileTabSelector.vue
@@ -70,7 +70,7 @@ export default defineComponent({
   align-items: center;
 }
 .title {
-  @include h2-size;
+  @include size-h2;
   padding-left: 40px;
   flex: 1 0;
 }

--- a/src/components/Main/Modal/SettingModal/TabContentTitle.vue
+++ b/src/components/Main/Modal/SettingModal/TabContentTitle.vue
@@ -30,10 +30,10 @@ export default defineComponent({
 <style lang="scss" module>
 .container {
   @include color-ui-primary;
-  font-size: 1.5rem;
+  @include h1-size;
   font-weight: bold;
   &[data-is-mobile] {
-    font-size: 1.25rem;
+    @include h2-size;
   }
 }
 </style>

--- a/src/components/Main/Modal/SettingModal/TabContentTitle.vue
+++ b/src/components/Main/Modal/SettingModal/TabContentTitle.vue
@@ -30,10 +30,10 @@ export default defineComponent({
 <style lang="scss" module>
 .container {
   @include color-ui-primary;
-  @include h1-size;
+  @include size-h1;
   font-weight: bold;
   &[data-is-mobile] {
-    @include h2-size;
+    @include size-h2;
   }
 }
 </style>

--- a/src/components/Main/Modal/UserModal/Feature/MobileFeature.vue
+++ b/src/components/Main/Modal/UserModal/Feature/MobileFeature.vue
@@ -65,13 +65,13 @@ export default defineComponent({
   }
 }
 .displayName {
-  font-size: 1.125rem;
+  @include font-size-large;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 .name {
-  font-size: 0.875rem;
+  @include font-size-slightly-small;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/components/Main/Modal/UserModal/Feature/MobileFeature.vue
+++ b/src/components/Main/Modal/UserModal/Feature/MobileFeature.vue
@@ -65,13 +65,13 @@ export default defineComponent({
   }
 }
 .displayName {
-  @include font-size-large;
+  @include h3-size;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 .name {
-  @include font-size-slightly-small;
+  @include body2-size;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/components/Main/Modal/UserModal/Feature/MobileFeature.vue
+++ b/src/components/Main/Modal/UserModal/Feature/MobileFeature.vue
@@ -65,13 +65,13 @@ export default defineComponent({
   }
 }
 .displayName {
-  @include h3-size;
+  @include size-h3;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 .name {
-  @include body2-size;
+  @include size-body2;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/components/Main/Modal/UserModal/ProfileTab/ProfileHeader.vue
+++ b/src/components/Main/Modal/UserModal/ProfileTab/ProfileHeader.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 <style lang="scss" module>
 .header {
   @include color-ui-secondary;
-  font-size: 14px;
+  @include font-size-slightly-small;
   margin-top: 16px;
   margin-bottom: 8px;
 }

--- a/src/components/Main/Modal/UserModal/ProfileTab/ProfileHeader.vue
+++ b/src/components/Main/Modal/UserModal/ProfileTab/ProfileHeader.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 <style lang="scss" module>
 .header {
   @include color-ui-secondary;
-  @include font-size-slightly-small;
+  @include body2-size;
   margin-top: 16px;
   margin-bottom: 8px;
 }

--- a/src/components/Main/Modal/UserModal/ProfileTab/ProfileHeader.vue
+++ b/src/components/Main/Modal/UserModal/ProfileTab/ProfileHeader.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 <style lang="scss" module>
 .header {
   @include color-ui-secondary;
-  @include body2-size;
+  @include size-body2;
   margin-top: 16px;
   margin-bottom: 8px;
 }

--- a/src/components/Main/Navigation/AppListItem.vue
+++ b/src/components/Main/Navigation/AppListItem.vue
@@ -64,7 +64,7 @@ export default defineComponent({
   margin: 4px;
 }
 .label {
-  @include font-size-regular;
+  @include body1-size;
   text-align: center;
 }
 </style>

--- a/src/components/Main/Navigation/AppListItem.vue
+++ b/src/components/Main/Navigation/AppListItem.vue
@@ -64,7 +64,7 @@ export default defineComponent({
   margin: 4px;
 }
 .label {
-  @include body1-size;
+  @include size-body1;
   text-align: center;
 }
 </style>

--- a/src/components/Main/Navigation/AppListItem.vue
+++ b/src/components/Main/Navigation/AppListItem.vue
@@ -64,7 +64,7 @@ export default defineComponent({
   margin: 4px;
 }
 .label {
+  @include font-size-regular;
   text-align: center;
-  font-size: 1rem;
 }
 </style>

--- a/src/components/Main/Navigation/ChannelList/ChannelElement.vue
+++ b/src/components/Main/Navigation/ChannelList/ChannelElement.vue
@@ -241,13 +241,13 @@ $topicLeftPadding: 40px;
   cursor: pointer;
 }
 .channelName {
+  @include font-size-regular;
   display: flex;
   align-items: center;
   width: 100%;
   min-width: 0;
   height: 100%;
   padding: 0 8px;
-  font-size: 1rem;
   cursor: pointer;
 }
 .channelNameInner {
@@ -275,12 +275,11 @@ $topicLeftPadding: 40px;
   pointer-events: none;
 }
 .topic {
+  @include font-size-slightly-small;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
-
-  font-size: 0.875rem;
 
   padding: {
     left: $topicLeftPadding;

--- a/src/components/Main/Navigation/ChannelList/ChannelElement.vue
+++ b/src/components/Main/Navigation/ChannelList/ChannelElement.vue
@@ -241,7 +241,7 @@ $topicLeftPadding: 40px;
   cursor: pointer;
 }
 .channelName {
-  @include body1-size;
+  @include size-body1;
   display: flex;
   align-items: center;
   width: 100%;
@@ -275,7 +275,7 @@ $topicLeftPadding: 40px;
   pointer-events: none;
 }
 .topic {
-  @include body2-size;
+  @include size-body2;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;

--- a/src/components/Main/Navigation/ChannelList/ChannelElement.vue
+++ b/src/components/Main/Navigation/ChannelList/ChannelElement.vue
@@ -241,7 +241,7 @@ $topicLeftPadding: 40px;
   cursor: pointer;
 }
 .channelName {
-  @include font-size-regular;
+  @include body1-size;
   display: flex;
   align-items: center;
   width: 100%;
@@ -275,7 +275,7 @@ $topicLeftPadding: 40px;
   pointer-events: none;
 }
 .topic {
-  @include font-size-slightly-small;
+  @include body2-size;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallControlPanel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallControlPanel.vue
@@ -120,7 +120,7 @@ export default defineComponent({
   user-select: none;
 }
 .channelName {
-  @include font-size-extra-small;
+  @include caption-size;
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallControlPanel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallControlPanel.vue
@@ -120,7 +120,7 @@ export default defineComponent({
   user-select: none;
 }
 .channelName {
-  @include caption-size;
+  @include size-caption;
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallControlPanel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallControlPanel.vue
@@ -120,7 +120,7 @@ export default defineComponent({
   user-select: none;
 }
 .channelName {
-  font-size: 0.75rem;
+  @include font-size-extra-small;
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
@@ -122,7 +122,7 @@ export default defineComponent({
   }
 }
 .userName {
-  @include body2-size;
+  @include size-body2;
   display: flex;
   align-items: center;
 }

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
@@ -122,7 +122,7 @@ export default defineComponent({
   }
 }
 .userName {
-  font-size: 0.875rem;
+  @include font-size-slightly-small;
   display: flex;
   align-items: center;
 }

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
@@ -122,7 +122,7 @@ export default defineComponent({
   }
 }
 .userName {
-  @include font-size-slightly-small;
+  @include body2-size;
   display: flex;
   align-items: center;
 }

--- a/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
+++ b/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-regular;
+  @include body1-size;
   display: flex;
   padding: 2px;
   cursor: pointer;

--- a/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
+++ b/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
@@ -53,10 +53,10 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
+  @include font-size-regular;
   display: flex;
   padding: 2px;
   cursor: pointer;
-  font-size: 1rem;
 }
 .icon {
   flex-shrink: 0;

--- a/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
+++ b/src/components/Main/Navigation/NavigationContent/ClipFoldersElement.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include body1-size;
+  @include size-body1;
   display: flex;
   padding: 2px;
   cursor: pointer;

--- a/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
@@ -42,13 +42,13 @@ export default defineComponent({
   min-width: 0;
 }
 .displayName {
-  @include body1-size;
+  @include size-body1;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 }
 .name {
-  @include body2-size;
+  @include size-body2;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
@@ -42,13 +42,13 @@ export default defineComponent({
   min-width: 0;
 }
 .displayName {
-  @include font-size-regular;
+  @include body1-size;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 }
 .name {
-  @include font-size-slightly-small;
+  @include body2-size;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersElementUserName.vue
@@ -42,13 +42,13 @@ export default defineComponent({
   min-width: 0;
 }
 .displayName {
-  font-size: 1rem;
+  @include font-size-regular;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 }
 .name {
-  font-size: 0.875rem;
+  @include font-size-slightly-small;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/Main/Navigation/NavigationContent/UsersSeparator.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersSeparator.vue
@@ -42,7 +42,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-slightly-small;
+  @include body2-size;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/Main/Navigation/NavigationContent/UsersSeparator.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersSeparator.vue
@@ -42,9 +42,9 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
+  @include font-size-slightly-small;
   display: flex;
   align-items: center;
-  font-size: 0.875rem;
   justify-content: space-between;
   font-weight: bold;
 }

--- a/src/components/Main/Navigation/NavigationContent/UsersSeparator.vue
+++ b/src/components/Main/Navigation/NavigationContent/UsersSeparator.vue
@@ -42,7 +42,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include body2-size;
+  @include size-body2;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/Main/Navigation/NavigationContentContainer.vue
+++ b/src/components/Main/Navigation/NavigationContentContainer.vue
@@ -43,7 +43,7 @@ export default defineComponent({
   justify-content: space-between;
 }
 .subtitle {
-  @include font-size-slightly-small;
+  @include body2-size;
   margin-bottom: 8px;
   font-weight: bold;
 }

--- a/src/components/Main/Navigation/NavigationContentContainer.vue
+++ b/src/components/Main/Navigation/NavigationContentContainer.vue
@@ -43,7 +43,7 @@ export default defineComponent({
   justify-content: space-between;
 }
 .subtitle {
-  @include body2-size;
+  @include size-body2;
   margin-bottom: 8px;
   font-weight: bold;
 }

--- a/src/components/Main/Navigation/NavigationContentContainer.vue
+++ b/src/components/Main/Navigation/NavigationContentContainer.vue
@@ -43,7 +43,7 @@ export default defineComponent({
   justify-content: space-between;
 }
 .subtitle {
-  font-size: 0.875rem;
+  @include font-size-slightly-small;
   margin-bottom: 8px;
   font-weight: bold;
 }

--- a/src/components/Main/Navigation/NavigationContentTitle.vue
+++ b/src/components/Main/Navigation/NavigationContentTitle.vue
@@ -35,7 +35,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  font-size: 1.25rem;
+  @include font-size-extra-large;
   font-weight: bold;
 }
 </style>

--- a/src/components/Main/Navigation/NavigationContentTitle.vue
+++ b/src/components/Main/Navigation/NavigationContentTitle.vue
@@ -35,7 +35,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include h2-size;
+  @include size-h2;
   font-weight: bold;
 }
 </style>

--- a/src/components/Main/Navigation/NavigationContentTitle.vue
+++ b/src/components/Main/Navigation/NavigationContentTitle.vue
@@ -35,7 +35,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-extra-large;
+  @include h2-size;
   font-weight: bold;
 }
 </style>

--- a/src/components/UI/CloseButton.vue
+++ b/src/components/UI/CloseButton.vue
@@ -59,7 +59,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include body2-size;
+  @include size-body2;
   text-align: center;
   font-weight: bold;
   opacity: 0.5;

--- a/src/components/UI/CloseButton.vue
+++ b/src/components/UI/CloseButton.vue
@@ -59,7 +59,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-small;
+  @include body2-size;
   text-align: center;
   font-weight: bold;
   opacity: 0.5;

--- a/src/components/UI/CloseButton.vue
+++ b/src/components/UI/CloseButton.vue
@@ -59,9 +59,9 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
+  @include font-size-small;
   text-align: center;
   font-weight: bold;
-  font-size: 0.8rem;
   opacity: 0.5;
   &:hover,
   &:not([data-react-hover]) {

--- a/src/components/UI/FilterInput.vue
+++ b/src/components/UI/FilterInput.vue
@@ -84,8 +84,8 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
+  @include font-size-regular;
   height: 30px;
-  font-size: 1rem;
   display: flex;
   align-items: center;
   border-radius: 4px;

--- a/src/components/UI/FilterInput.vue
+++ b/src/components/UI/FilterInput.vue
@@ -84,7 +84,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include body1-size;
+  @include size-body1;
   height: 30px;
   display: flex;
   align-items: center;

--- a/src/components/UI/FilterInput.vue
+++ b/src/components/UI/FilterInput.vue
@@ -84,7 +84,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-regular;
+  @include body1-size;
   height: 30px;
   display: flex;
   align-items: center;

--- a/src/components/UI/FormInput.vue
+++ b/src/components/UI/FormInput.vue
@@ -82,8 +82,8 @@ export default defineComponent({
 
 <style lang="scss" module>
 .inputContainer {
+  @include font-size-regular;
   height: 30px;
-  font-size: 1rem;
   display: flex;
   align-items: center;
   border-radius: 4px;

--- a/src/components/UI/FormInput.vue
+++ b/src/components/UI/FormInput.vue
@@ -82,7 +82,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .inputContainer {
-  @include font-size-regular;
+  @include body1-size;
   height: 30px;
   display: flex;
   align-items: center;

--- a/src/components/UI/FormInput.vue
+++ b/src/components/UI/FormInput.vue
@@ -82,7 +82,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .inputContainer {
-  @include body1-size;
+  @include size-body1;
   height: 30px;
   display: flex;
   align-items: center;

--- a/src/components/UI/FormSelector.vue
+++ b/src/components/UI/FormSelector.vue
@@ -64,7 +64,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .inputContainer {
-  @include font-size-regular;
+  @include body1-size;
   height: 30px;
   display: flex;
   align-items: center;

--- a/src/components/UI/FormSelector.vue
+++ b/src/components/UI/FormSelector.vue
@@ -64,8 +64,8 @@ export default defineComponent({
 
 <style lang="scss" module>
 .inputContainer {
+  @include font-size-regular;
   height: 30px;
-  font-size: 1rem;
   display: flex;
   align-items: center;
   border-radius: 4px;

--- a/src/components/UI/FormSelector.vue
+++ b/src/components/UI/FormSelector.vue
@@ -64,7 +64,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .inputContainer {
-  @include body1-size;
+  @include size-body1;
   height: 30px;
   display: flex;
   align-items: center;

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -16,7 +16,6 @@
     :width="size"
     :height="size"
     view-box="0 0 24 24"
-    class="icon"
     v-bind="context.attrs"
     v-on="context.listeners"
     role="img"

--- a/src/components/UI/MessagePanel/ChannelName.vue
+++ b/src/components/UI/MessagePanel/ChannelName.vue
@@ -37,9 +37,9 @@ export default defineComponent({
 
 <style lang="scss" module>
 .path {
-  @include font-size-slightly-small;
+  @include body2-size;
   &[data-is-title] {
-    @include font-size-regular;
+    @include body1-size;
     font-weight: bold;
   }
   &::before {

--- a/src/components/UI/MessagePanel/ChannelName.vue
+++ b/src/components/UI/MessagePanel/ChannelName.vue
@@ -37,9 +37,9 @@ export default defineComponent({
 
 <style lang="scss" module>
 .path {
-  @include body2-size;
+  @include size-body2;
   &[data-is-title] {
-    @include body1-size;
+    @include size-body1;
     font-weight: bold;
   }
   &::before {

--- a/src/components/UI/MessagePanel/ChannelName.vue
+++ b/src/components/UI/MessagePanel/ChannelName.vue
@@ -37,9 +37,9 @@ export default defineComponent({
 
 <style lang="scss" module>
 .path {
-  font-size: 0.875rem;
+  @include font-size-slightly-small;
   &[data-is-title] {
-    font-size: 1rem;
+    @include font-size-regular;
     font-weight: bold;
   }
   &::before {

--- a/src/components/UI/MessagePanel/RenderContent.vue
+++ b/src/components/UI/MessagePanel/RenderContent.vue
@@ -63,7 +63,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include body1-size;
+  @include size-body1;
   word-break: break-all;
   width: 100%;
 }

--- a/src/components/UI/MessagePanel/RenderContent.vue
+++ b/src/components/UI/MessagePanel/RenderContent.vue
@@ -63,7 +63,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  font-size: 1rem;
+  @include font-size-regular;
   word-break: break-all;
   width: 100%;
 }

--- a/src/components/UI/MessagePanel/RenderContent.vue
+++ b/src/components/UI/MessagePanel/RenderContent.vue
@@ -63,7 +63,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-regular;
+  @include body1-size;
   word-break: break-all;
   width: 100%;
 }

--- a/src/components/UI/MessagePanel/UserName.vue
+++ b/src/components/UI/MessagePanel/UserName.vue
@@ -58,11 +58,11 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
+  @include font-size-slightly-small;
   display: flex;
   align-items: center;
-  font-size: 0.875rem;
   &[data-is-title] {
-    font-size: 1rem;
+    @include font-size-regular;
     font-weight: bold;
   }
 }

--- a/src/components/UI/MessagePanel/UserName.vue
+++ b/src/components/UI/MessagePanel/UserName.vue
@@ -58,11 +58,11 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include body2-size;
+  @include size-body2;
   display: flex;
   align-items: center;
   &[data-is-title] {
-    @include body1-size;
+    @include size-body1;
     font-weight: bold;
   }
 }

--- a/src/components/UI/MessagePanel/UserName.vue
+++ b/src/components/UI/MessagePanel/UserName.vue
@@ -58,11 +58,11 @@ export default defineComponent({
 
 <style lang="scss" module>
 .container {
-  @include font-size-slightly-small;
+  @include body2-size;
   display: flex;
   align-items: center;
   &[data-is-title] {
-    @include font-size-regular;
+    @include body1-size;
     font-weight: bold;
   }
 }

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -1,994 +1,193 @@
-.markdown-body .octicon {
-  display: inline-block;
-  fill: currentColor;
-  vertical-align: text-bottom;
-}
-
-.markdown-body .anchor {
-  float: left;
-  line-height: 1;
-  margin-left: -20px;
-  padding-right: 4px;
-}
-
-.markdown-body .anchor:focus {
-  outline: none;
-}
-
-.markdown-body h1 .octicon-link,
-.markdown-body h2 .octicon-link,
-.markdown-body h3 .octicon-link,
-.markdown-body h4 .octicon-link,
-.markdown-body h5 .octicon-link,
-.markdown-body h6 .octicon-link {
-  color: #1b1f23;
-  vertical-align: middle;
-  visibility: hidden;
-}
-
-.markdown-body h1:hover .anchor,
-.markdown-body h2:hover .anchor,
-.markdown-body h3:hover .anchor,
-.markdown-body h4:hover .anchor,
-.markdown-body h5:hover .anchor,
-.markdown-body h6:hover .anchor {
-  text-decoration: none;
-}
-
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
-  visibility: visible;
-}
-
-.markdown-body h1:hover .anchor .octicon-link:before,
-.markdown-body h2:hover .anchor .octicon-link:before,
-.markdown-body h3:hover .anchor .octicon-link:before,
-.markdown-body h4:hover .anchor .octicon-link:before,
-.markdown-body h5:hover .anchor .octicon-link:before,
-.markdown-body h6:hover .anchor .octicon-link:before {
-  width: 16px;
-  height: 16px;
-  content: ' ';
-  display: inline-block;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'%3E%3C/path%3E%3C/svg%3E");
-}
 .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
-  // color: #24292e;
-  // font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-  //   sans-serif, Apple Color Emoji, Segoe UI Emoji;
-  // font-size: 16px;
   line-height: 1.2;
   word-wrap: break-word;
-}
 
-.markdown-body details {
-  display: block;
-}
-
-.markdown-body summary {
-  display: list-item;
-}
-
-.markdown-body a {
-  background-color: initial;
-}
-
-.markdown-body a:active,
-.markdown-body a:hover {
-  outline-width: 0;
-}
-
-.markdown-body strong {
-  font-weight: inherit;
-  font-weight: bolder;
-}
-
-.markdown-body h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-
-.markdown-body img {
-  border-style: none;
-}
-
-.markdown-body code,
-.markdown-body kbd,
-.markdown-body pre {
-  font-family: monospace, monospace;
-  font-size: 1em;
-}
-
-.markdown-body hr {
-  box-sizing: initial;
-  height: 0;
-  overflow: visible;
-}
-
-.markdown-body input {
-  font: inherit;
-  margin: 0;
-}
-
-.markdown-body input {
-  overflow: visible;
-}
-
-.markdown-body [type='checkbox'] {
-  box-sizing: border-box;
-  padding: 0;
-}
-
-.markdown-body * {
-  box-sizing: border-box;
-}
-
-.markdown-body input {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-}
-
-.markdown-body a {
-  color: #0366d6;
-  text-decoration: none;
-}
-
-.markdown-body a:hover {
-  text-decoration: underline;
-}
-
-.markdown-body strong {
-  font-weight: 600;
-}
-
-.markdown-body hr {
-  height: 0;
-  margin: 15px 0;
-  overflow: hidden;
-  background: transparent;
-  border: 0;
-  border-bottom: 1px solid #dfe2e5;
-}
-
-.markdown-body hr:after,
-.markdown-body hr:before {
-  display: table;
-  content: '';
-}
-
-.markdown-body hr:after {
-  clear: both;
-}
-
-.markdown-body table {
-  border-spacing: 0;
-  border-collapse: collapse;
-}
-
-.markdown-body td,
-.markdown-body th {
-  padding: 0;
-}
-
-.markdown-body details summary {
-  cursor: pointer;
-}
-
-.markdown-body kbd {
-  display: inline-block;
-  padding: 3px 5px;
-  font: 11px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-  line-height: 10px;
-  color: #444d56;
-  vertical-align: middle;
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
-  border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #d1d5da;
-}
-
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.markdown-body h1 {
-  font-size: 32px;
-}
-
-.markdown-body h1,
-.markdown-body h2 {
-  font-weight: 600;
-}
-
-.markdown-body h2 {
-  font-size: 24px;
-}
-
-.markdown-body h3 {
-  font-size: 20px;
-}
-
-.markdown-body h3,
-.markdown-body h4 {
-  font-weight: 600;
-}
-
-.markdown-body h4 {
-  font-size: 16px;
-}
-
-.markdown-body h5 {
-  font-size: 14px;
-}
-
-.markdown-body h5,
-.markdown-body h6 {
-  font-weight: 600;
-}
-
-.markdown-body h6 {
-  font-size: 12px;
-}
-
-.markdown-body p {
-  margin-top: 0;
-  margin-bottom: 10px;
-}
-
-.markdown-body blockquote {
-  margin: 0;
-}
-
-.markdown-body ol,
-.markdown-body ul {
-  padding-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.markdown-body ol ol,
-.markdown-body ul ol {
-  list-style-type: lower-roman;
-}
-
-.markdown-body ol ol ol,
-.markdown-body ol ul ol,
-.markdown-body ul ol ol,
-.markdown-body ul ul ol {
-  list-style-type: lower-alpha;
-}
-
-.markdown-body dd {
-  margin-left: 0;
-}
-
-.markdown-body code,
-.markdown-body pre {
-  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-  font-size: 12px;
-}
-
-.markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.markdown-body input::-webkit-inner-spin-button,
-.markdown-body input::-webkit-outer-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.markdown-body :checked + .radio-label {
-  position: relative;
-  z-index: 1;
-  border-color: #0366d6;
-}
-
-.markdown-body .border {
-  border: 1px solid #e1e4e8 !important;
-}
-
-.markdown-body .border-0 {
-  border: 0 !important;
-}
-
-.markdown-body .border-bottom {
-  border-bottom: 1px solid #e1e4e8 !important;
-}
-
-.markdown-body .rounded-1 {
-  border-radius: 3px !important;
-}
-
-.markdown-body .bg-white {
-  background-color: #fff !important;
-}
-
-.markdown-body .bg-gray-light {
-  background-color: #fafbfc !important;
-}
-
-.markdown-body .text-gray-light {
-  color: #6a737d !important;
-}
-
-.markdown-body .mb-0 {
-  margin-bottom: 0 !important;
-}
-
-.markdown-body .my-2 {
-  margin-top: 8px !important;
-  margin-bottom: 8px !important;
-}
-
-.markdown-body .pl-0 {
-  padding-left: 0 !important;
-}
-
-.markdown-body .py-0 {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
-
-.markdown-body .pl-1 {
-  padding-left: 4px !important;
-}
-
-.markdown-body .pl-2 {
-  padding-left: 8px !important;
-}
-
-.markdown-body .py-2 {
-  padding-top: 8px !important;
-  padding-bottom: 8px !important;
-}
-
-.markdown-body .pl-3,
-.markdown-body .px-3 {
-  padding-left: 16px !important;
-}
-
-.markdown-body .px-3 {
-  padding-right: 16px !important;
-}
-
-.markdown-body .pl-4 {
-  padding-left: 24px !important;
-}
-
-.markdown-body .pl-5 {
-  padding-left: 32px !important;
-}
-
-.markdown-body .pl-6 {
-  padding-left: 40px !important;
-}
-
-.markdown-body .f6 {
-  font-size: 12px !important;
-}
-
-.markdown-body .lh-condensed {
-  line-height: 1.25 !important;
-}
-
-.markdown-body .text-bold {
-  font-weight: 600 !important;
-}
-
-.markdown-body .pl-c {
-  color: #6a737d;
-}
-
-.markdown-body .pl-c1,
-.markdown-body .pl-s .pl-v {
-  color: #005cc5;
-}
-
-.markdown-body .pl-e,
-.markdown-body .pl-en {
-  color: #6f42c1;
-}
-
-.markdown-body .pl-s .pl-s1,
-.markdown-body .pl-smi {
-  color: #24292e;
-}
-
-.markdown-body .pl-ent {
-  color: #22863a;
-}
-
-.markdown-body .pl-k {
-  color: #d73a49;
-}
-
-.markdown-body .pl-pds,
-.markdown-body .pl-s,
-.markdown-body .pl-s .pl-pse .pl-s1,
-.markdown-body .pl-sr,
-.markdown-body .pl-sr .pl-cce,
-.markdown-body .pl-sr .pl-sra,
-.markdown-body .pl-sr .pl-sre {
-  color: #032f62;
-}
-
-.markdown-body .pl-smw,
-.markdown-body .pl-v {
-  color: #e36209;
-}
-
-.markdown-body .pl-bu {
-  color: #b31d28;
-}
-
-.markdown-body .pl-ii {
-  color: #fafbfc;
-  background-color: #b31d28;
-}
-
-.markdown-body .pl-c2 {
-  color: #fafbfc;
-  background-color: #d73a49;
-}
-
-.markdown-body .pl-c2:before {
-  content: '^M';
-}
-
-.markdown-body .pl-sr .pl-cce {
-  font-weight: 700;
-  color: #22863a;
-}
-
-.markdown-body .pl-ml {
-  color: #735c0f;
-}
-
-.markdown-body .pl-mh,
-.markdown-body .pl-mh .pl-en,
-.markdown-body .pl-ms {
-  font-weight: 700;
-  color: #005cc5;
-}
-
-.markdown-body .pl-mi {
-  font-style: italic;
-  color: #24292e;
-}
-
-.markdown-body .pl-mb {
-  font-weight: 700;
-  color: #24292e;
-}
-
-.markdown-body .pl-md {
-  color: #b31d28;
-  background-color: #ffeef0;
-}
-
-.markdown-body .pl-mi1 {
-  color: #22863a;
-  background-color: #f0fff4;
-}
-
-.markdown-body .pl-mc {
-  color: #e36209;
-  background-color: #ffebda;
-}
-
-.markdown-body .pl-mi2 {
-  color: #f6f8fa;
-  background-color: #005cc5;
-}
-
-.markdown-body .pl-mdr {
-  font-weight: 700;
-  color: #6f42c1;
-}
-
-.markdown-body .pl-ba {
-  color: #586069;
-}
-
-.markdown-body .pl-sg {
-  color: #959da5;
-}
-
-.markdown-body .pl-corl {
-  text-decoration: underline;
-  color: #032f62;
-}
-
-.markdown-body .mb-0 {
-  margin-bottom: 0 !important;
-}
-
-.markdown-body .my-2 {
-  margin-bottom: 8px !important;
-}
-
-.markdown-body .my-2 {
-  margin-top: 8px !important;
-}
-
-.markdown-body .pl-0 {
-  padding-left: 0 !important;
-}
-
-.markdown-body .py-0 {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
-
-.markdown-body .pl-1 {
-  padding-left: 4px !important;
-}
-
-.markdown-body .pl-2 {
-  padding-left: 8px !important;
-}
-
-.markdown-body .py-2 {
-  padding-top: 8px !important;
-  padding-bottom: 8px !important;
-}
-
-.markdown-body .pl-3 {
-  padding-left: 16px !important;
-}
-
-.markdown-body .pl-4 {
-  padding-left: 24px !important;
-}
-
-.markdown-body .pl-5 {
-  padding-left: 32px !important;
-}
-
-.markdown-body .pl-6 {
-  padding-left: 40px !important;
-}
-
-.markdown-body .pl-7 {
-  padding-left: 48px !important;
-}
-
-.markdown-body .pl-8 {
-  padding-left: 64px !important;
-}
-
-.markdown-body .pl-9 {
-  padding-left: 80px !important;
-}
-
-.markdown-body .pl-10 {
-  padding-left: 96px !important;
-}
-
-.markdown-body .pl-11 {
-  padding-left: 112px !important;
-}
-
-.markdown-body .pl-12 {
-  padding-left: 128px !important;
-}
-
-.markdown-body hr {
-  border-bottom-color: #eee;
-}
-
-.markdown-body kbd {
-  display: inline-block;
-  padding: 3px 5px;
-  font: 11px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-  line-height: 10px;
-  color: #444d56;
-  vertical-align: middle;
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
-  border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #d1d5da;
-}
-
-.markdown-body:after,
-.markdown-body:before {
-  display: table;
-  content: '';
-}
-
-.markdown-body:after {
-  clear: both;
-}
-
-.markdown-body > :first-child {
-  margin-top: 0 !important;
-}
-
-.markdown-body > :last-child {
-  margin-bottom: 0 !important;
-}
-
-.markdown-body a:not([href]) {
-  color: inherit;
-  text-decoration: none;
-}
-
-.markdown-body blockquote,
-.markdown-body details,
-.markdown-body dl,
-.markdown-body ol,
-.markdown-body p,
-.markdown-body pre,
-.markdown-body table,
-.markdown-body ul {
-  margin-top: 0;
-  margin-bottom: 16px;
-}
-
-.markdown-body hr {
-  height: 0.25em;
-  padding: 0;
-  margin: 24px 0;
-  background-color: #e1e4e8;
-  border: 0;
-}
-
-.markdown-body blockquote {
-  padding: 0 1em;
-  color: #6a737d;
-  border-left: 0.25em solid #dfe2e5;
-}
-
-.markdown-body blockquote > :first-child {
-  margin-top: 0;
-}
-
-.markdown-body blockquote > :last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
-  margin-top: 24px;
-  margin-bottom: 16px;
-  font-weight: 600;
-  line-height: 1.25;
-}
-
-.markdown-body h1 {
-  font-size: 2em;
-}
-
-.markdown-body h1,
-.markdown-body h2 {
-  padding-bottom: 0.3em;
-  // border-bottom: 1px solid #eaecef;
-}
-
-.markdown-body h2 {
-  font-size: 1.5em;
-}
-
-.markdown-body h3 {
-  font-size: 1.25em;
-}
-
-.markdown-body h4 {
-  font-size: 1em;
-}
-
-.markdown-body h5 {
-  font-size: 0.875em;
-}
-
-.markdown-body h6 {
-  font-size: 0.85em;
-  color: #6a737d;
-}
-
-.markdown-body ol,
-.markdown-body ul {
-  padding-left: 2em;
-}
-
-.markdown-body ol ol,
-.markdown-body ol ul,
-.markdown-body ul ol,
-.markdown-body ul ul {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.markdown-body li {
-  word-wrap: break-all;
-  list-style: disc;
-}
-
-.markdown-body li > p {
-  margin-top: 16px;
-}
-
-.markdown-body li + li {
-  margin-top: 0.25em;
-}
-
-.markdown-body dl {
-  padding: 0;
-}
-
-.markdown-body dl dt {
-  padding: 0;
-  margin-top: 16px;
-  font-size: 1em;
-  font-style: italic;
-  font-weight: 600;
-}
-
-.markdown-body dl dd {
-  padding: 0 16px;
-  margin-bottom: 16px;
-}
-
-.markdown-body table {
-  display: block;
-  width: 100%;
-  overflow: auto;
-}
-
-.markdown-body table th {
-  font-weight: 600;
-}
-
-.markdown-body table td,
-.markdown-body table th {
-  padding: 6px 13px;
-  border: 1px solid;
-}
-
-.markdown-body table tr {
-  background-color: #fff;
-  border-top: 1px solid;
-}
-
-.markdown-body img {
-  max-width: 100%;
-  box-sizing: initial;
-  background-color: #fff;
-}
-
-.markdown-body img[align='right'] {
-  padding-left: 20px;
-}
-
-.markdown-body img[align='left'] {
-  padding-right: 20px;
-}
-
-.markdown-body code {
-  padding: 0.2em 0.4em;
-  margin: 0;
-  font-size: 85%;
-  background-color: rgba(27, 31, 35, 0.05);
-  border-radius: 3px;
-}
-
-.markdown-body pre {
-  word-wrap: normal;
-}
-
-.markdown-body pre > code {
-  padding: 0;
-  margin: 0;
-  font-size: 100%;
-  word-break: normal;
-  white-space: pre;
-  background: transparent;
-  border: 0;
-}
-
-.markdown-body .highlight {
-  margin-bottom: 16px;
-}
-
-.markdown-body .highlight pre {
-  margin-bottom: 0;
-  word-break: normal;
-}
-
-.markdown-body .highlight pre,
-.markdown-body pre {
-  position: relative;
-  padding: 16px;
-  overflow: auto;
-  font-size: 85%;
-  line-height: 1.45;
-  border-radius: 3px;
-}
-
-.markdown-body pre cite {
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 0 4px;
-  border-bottom-left-radius: 4px;
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
-.markdown-body pre code {
-  display: inline;
-  max-width: auto;
-  padding: 0;
-  margin: 0;
-  overflow: visible;
-  line-height: inherit;
-  word-wrap: normal;
-  background-color: initial;
-  border: 0;
-}
-
-.markdown-body .commit-tease-sha {
-  display: inline-block;
-  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-  font-size: 90%;
-  color: #444d56;
-}
-
-.markdown-body .full-commit .btn-outline:not(:disabled):hover {
-  color: #005cc5;
-  border-color: #005cc5;
-}
-
-.markdown-body .blob-wrapper {
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-
-.markdown-body .blob-wrapper-embedded {
-  max-height: 240px;
-  overflow-y: auto;
-}
-
-.markdown-body .blob-num {
-  width: 1%;
-  min-width: 50px;
-  padding-right: 10px;
-  padding-left: 10px;
-  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-  font-size: 12px;
-  line-height: 20px;
-  color: rgba(27, 31, 35, 0.3);
-  text-align: right;
-  white-space: nowrap;
-  vertical-align: top;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.markdown-body .blob-num:hover {
-  color: rgba(27, 31, 35, 0.6);
-}
-
-.markdown-body .blob-num:before {
-  content: attr(data-line-number);
-}
-
-.markdown-body .blob-code {
-  position: relative;
-  padding-right: 10px;
-  padding-left: 10px;
-  line-height: 20px;
-  vertical-align: top;
-}
-
-.markdown-body .blob-code-inner {
-  overflow: visible;
-  font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
-  font-size: 12px;
-  color: #24292e;
-  word-wrap: normal;
-  white-space: pre;
-}
-
-.markdown-body .pl-token.active,
-.markdown-body .pl-token:hover {
-  cursor: pointer;
-  background: #ffea7f;
-}
-
-.markdown-body .tab-size[data-tab-size='1'] {
-  -moz-tab-size: 1;
-  tab-size: 1;
-}
-
-.markdown-body .tab-size[data-tab-size='2'] {
-  -moz-tab-size: 2;
-  tab-size: 2;
-}
-
-.markdown-body .tab-size[data-tab-size='3'] {
-  -moz-tab-size: 3;
-  tab-size: 3;
-}
-
-.markdown-body .tab-size[data-tab-size='4'] {
-  -moz-tab-size: 4;
-  tab-size: 4;
-}
-
-.markdown-body .tab-size[data-tab-size='5'] {
-  -moz-tab-size: 5;
-  tab-size: 5;
-}
-
-.markdown-body .tab-size[data-tab-size='6'] {
-  -moz-tab-size: 6;
-  tab-size: 6;
-}
-
-.markdown-body .tab-size[data-tab-size='7'] {
-  -moz-tab-size: 7;
-  tab-size: 7;
-}
-
-.markdown-body .tab-size[data-tab-size='8'] {
-  -moz-tab-size: 8;
-  tab-size: 8;
-}
-
-.markdown-body .tab-size[data-tab-size='9'] {
-  -moz-tab-size: 9;
-  tab-size: 9;
-}
-
-.markdown-body .tab-size[data-tab-size='10'] {
-  -moz-tab-size: 10;
-  tab-size: 10;
-}
-
-.markdown-body .tab-size[data-tab-size='11'] {
-  -moz-tab-size: 11;
-  tab-size: 11;
-}
-
-.markdown-body .tab-size[data-tab-size='12'] {
-  -moz-tab-size: 12;
-  tab-size: 12;
-}
-
-.markdown-body .task-list-item {
-  list-style-type: none;
-}
-
-.markdown-body .task-list-item + .task-list-item {
-  margin-top: 3px;
-}
-
-.markdown-body .task-list-item input {
-  margin: 0 0.2em 0.25em -1.6em;
-  vertical-align: middle;
+  > :first-child {
+    margin-top: 0 !important;
+  }
+  > :last-child {
+    margin-bottom: 0 !important;
+  }
+
+  a {
+    color: #0366d6;
+    background-color: initial;
+    text-decoration: none;
+    &:active,
+    &:hover {
+      text-decoration: underline;
+      outline-width: 0;
+    }
+    &:not([href]) {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+
+  strong {
+    font-weight: bold;
+  }
+
+  hr {
+    height: 0.25em;
+    padding: 0;
+    margin: 24px 0;
+    border: 0;
+    background-color: #e1e4e8;
+    overflow: hidden;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    margin-top: 24px;
+    margin-bottom: 16px;
+    font-weight: bold;
+    line-height: 1.25;
+  }
+  h1, h2 {
+    padding-bottom: 0.3em;
+  }
+  h1 {
+    font-size: 2em;
+  }
+  h2 {
+    font-size: 1.5em;
+  }
+  h3 {
+    font-size: 1.25em;
+  }
+  h4 {
+    font-size: 1em;
+  }
+  h5 {
+    font-size: 0.875em;
+    transform: rotate(0.03deg);
+  }
+  h6 {
+    font-size: 0.85em;
+    transform: rotate(0.03deg);
+    color: #6a737d;
+  }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 16px;
+  }
+
+  blockquote {
+    margin-top: 0;
+    margin-bottom: 16px;
+    padding: 0 16px;
+    color: #6a737d;
+    border-left: 0.25em solid #dfe2e5;
+    > :first-child {
+      margin-top: 0;
+    }
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  ol {
+    list-style: decimal;
+  }
+  ul {
+    list-style: disc;
+  }
+  ol, ul {
+    padding-left: 2em;
+    margin-top: 0;
+    margin-bottom: 16px;
+    word-break: break-all;
+    ol {
+      list-style-type: lower-roman;
+    }
+    ol, ul {
+      margin-top: 0;
+      margin-bottom: 0;
+      ol {
+        list-style-type: lower-alpha;
+      }
+    }
+  }
+  li {
+    > p {
+      margin-top: 16px;
+    }
+    + li {
+      margin-top: 4px;
+    }
+  }
+
+  code, pre {
+    font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+    font-size: 0.85em;
+    border-radius: 4px;
+  }
+  code {
+    display: inline-block;
+    padding: 2px 6px;
+    margin: 2px 0;
+  }
+  pre {
+    position: relative;
+    padding: 16px;
+    margin-top: 0;
+    margin-bottom: 16px;
+    overflow: auto;
+    overflow-wrap: normal;
+    line-height: 1.45;
+    cite {
+      position: absolute;
+      top: 0;
+      right: 0;
+      padding: 0 4px;
+      border-bottom-left-radius: 4px;
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+    code {
+      display: inline;
+      padding: 0;
+      margin: 0;
+      border: 0;
+      font-size: 1em;
+      overflow: visible;
+      word-break: normal;
+      overflow-wrap: normal;
+      white-space: pre;
+      line-height: inherit;
+    }
+  }
+
+  table {
+    display: block;
+    width: 100%;
+    margin-top: 0;
+    margin-bottom: 16px;
+    overflow: auto;
+    border-spacing: 0;
+    border-collapse: collapse;
+  }
+  td,
+  th {
+    padding: 4px 12px;
+    border: 1px solid;
+  }
+  th {
+    font-weight: bold;
+  }
+  tr {
+    background-color: #fff;
+    border-top: 1px solid;
+  }
+
+  img {
+    max-width: 100%;
+    border-style: none;
+    box-sizing: initial;
+    background-color: #fff;
+  }
 }
 
 html:not([data-is-dark-theme]) {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -2,23 +2,23 @@
 
 // rotateはWindowsでフォントにジャギーが目立つののを対処
 // https://github.com/traPtitech/traQ_S-UI/issues/311
-@mixin h1-size {
+@mixin size-h1 {
     font-size: 1.5rem;
 }
-@mixin h2-size {
+@mixin size-h2 {
     font-size: 1.25rem;
 }
-@mixin h3-size {
+@mixin size-h3 {
     font-size: 1.125rem;
 }
-@mixin body1-size {
+@mixin size-body1 {
     font-size: 1rem;
 }
-@mixin body2-size {
+@mixin size-body2 {
     font-size: 0.875rem;
     transform: rotate(0.03deg);
 }
-@mixin caption-size {
+@mixin size-caption {
     font-size: 0.75rem;
     transform: rotate(0.03deg);
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,5 +1,32 @@
 @import './variables';
 
+// rotateはWindowsでフォントにジャギーが目立つののを対処
+// https://github.com/traPtitech/traQ_S-UI/issues/311
+@mixin font-size-tremendous-large {
+    font-size: 1.5rem;
+}
+@mixin font-size-extra-large {
+    font-size: 1.25rem;
+}
+@mixin font-size-large {
+    font-size: 1.125rem;
+}
+@mixin font-size-regular {
+    font-size: 1rem;
+}
+@mixin font-size-slightly-small {
+    font-size: 0.875rem;
+    transform: rotate(0.03deg);
+}
+@mixin font-size-small {
+    font-size: 0.8rem;
+    transform: rotate(0.03deg);
+}
+@mixin font-size-extra-small {
+    font-size: 0.75rem;
+    transform: rotate(0.03deg);
+}
+
 @mixin background-accent-primary {
     background: $theme-accent-primary;
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -2,27 +2,23 @@
 
 // rotateはWindowsでフォントにジャギーが目立つののを対処
 // https://github.com/traPtitech/traQ_S-UI/issues/311
-@mixin font-size-tremendous-large {
+@mixin h1-size {
     font-size: 1.5rem;
 }
-@mixin font-size-extra-large {
+@mixin h2-size {
     font-size: 1.25rem;
 }
-@mixin font-size-large {
+@mixin h3-size {
     font-size: 1.125rem;
 }
-@mixin font-size-regular {
+@mixin body1-size {
     font-size: 1rem;
 }
-@mixin font-size-slightly-small {
+@mixin body2-size {
     font-size: 0.875rem;
     transform: rotate(0.03deg);
 }
-@mixin font-size-small {
-    font-size: 0.8rem;
-    transform: rotate(0.03deg);
-}
-@mixin font-size-extra-small {
+@mixin caption-size {
     font-size: 0.75rem;
     transform: rotate(0.03deg);
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -7,6 +7,13 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=M+PLUS+1p:wght@400;700&display=swap');
 
+html {
+  // Windows(Chrome)でフォントにジャギーが目立つののを対処
+  // Firefoxでは16.4px以上にしないと解消できなかったので対処しない
+  // https://github.com/traPtitech/traQ_S-UI/issues/311
+  font-size: 16.01px;
+}
+
 body {
   font-family: 'Inter', 'M PLUS 1p', 'Avenir', 'Helvetica Neue', 'Helvetica',
     'Arial', 'Hiragino Sans', 'ヒラギノ角ゴシック', YuGothic, 'Yu Gothic',


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/80908111-1e1bd380-8d58-11ea-82d3-3edc5dbd97c8.png)

 - after
![image](https://user-images.githubusercontent.com/49056869/80908118-2ffd7680-8d58-11ea-9212-ecc929aa7b4e.png)

兄弟チャンネルをもっと表示するの箇所のデザインを変更しています(`font-size`がここだけ中途半端だったので)

Chromeでは動きますが、Firefoxではジャギーがあるままです
(もしかしたらレンダラによって違う可能性もあります => iGPUのノートも改善されたから問題なさそう)

たぶんcss変数への書き換えとconflictします

よろしくお願いします

close #311 
