### PR TITLE
サムネイル画像が生成されなかった画像ファイルで元画像をサムネイルとして扱わないように修正

### DIFF
--- a/src/components/Main/MainView/MessageElement/use/fileMetaList.ts
+++ b/src/components/Main/MainView/MessageElement/use/fileMetaList.ts
@@ -12,13 +12,13 @@ const useFileMetaList = (props: { fileIds: string[] }) => {
   )
   const state = reactive({
     images: computed(() =>
-      fileMetaData.value.filter(meta => isImage(meta.mime))
+      fileMetaData.value.filter(meta => !isNonPreviewable(meta) && isImage(meta.mime))
     ),
     videos: computed(() =>
       fileMetaData.value.filter(meta => isVideo(meta.mime))
     ),
     files: computed(() =>
-      fileMetaData.value.filter(meta => isNonPreviewable(meta.mime))
+      fileMetaData.value.filter(meta => isNonPreviewable(meta))
     )
   })
   return { fileMetaDataState: state }

--- a/src/lib/util/file.ts
+++ b/src/lib/util/file.ts
@@ -1,3 +1,5 @@
+import { FileInfo } from '@traptitech/traq'
+
 export type AttachmentType = 'image' | 'audio' | 'video' | 'file'
 
 export const mimeToFileType = (mime: string): AttachmentType => {
@@ -16,8 +18,11 @@ export const mimeToFileType = (mime: string): AttachmentType => {
 export const isImage = (mime: string) => mimeToFileType(mime) === 'image'
 export const isVideo = (mime: string) => mimeToFileType(mime) === 'video'
 export const isAudio = (mime: string) => mimeToFileType(mime) === 'audio'
-export const isNonPreviewable = (mime: string) => {
-  const type = mimeToFileType(mime)
+export const isNonPreviewable = (meta: FileInfo) => {
+  if (meta.thumbnail === null && meta.mime !== 'image/svg+xml') {
+    return true
+  }
+  const type = mimeToFileType(meta.mime)
   return type === 'file' || type === 'audio'
 }
 


### PR DESCRIPTION
サムネイル画像が作成されなかったsvg以外の`image/*`ファイルのサムネイル画像を元画像にしないように修正