### PR TITLE
音声ファイルの表示の改善

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileList.vue
@@ -14,6 +14,11 @@
       :key="meta.id"
       :file-id="meta.id"
     />
+    <message-file-list-audio
+      v-for="meta in fileMetaDataState.audios"
+      :key="meta.id"
+      :file-id="meta.id"
+    />
     <message-file-list-file
       v-for="meta in fileMetaDataState.files"
       :key="meta.id"
@@ -28,16 +33,18 @@ import { defineComponent, PropType, computed } from '@vue/composition-api'
 import { FileId } from '@/types/entity-ids'
 import { mimeToFileType } from '@/lib/util/file'
 import useFileMetaList from './use/fileMetaList'
-import MessageFileListFile from './MessageFileListFile.vue'
 import MessageFileListImage from './MessageFileListImage.vue'
 import MessageFileListVideo from './MessageFileListVideo.vue'
+import MessageFileListAudio from './MessageFileListAudio.vue'
+import MessageFileListFile from './MessageFileListFile.vue'
 
 export default defineComponent({
   name: 'MessageFileList',
   components: {
-    MessageFileListFile,
     MessageFileListImage,
-    MessageFileListVideo
+    MessageFileListVideo,
+    MessageFileListAudio,
+    MessageFileListFile
   },
   props: {
     fileIds: {

--- a/src/components/Main/MainView/MessageElement/MessageFileListAudio.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListAudio.vue
@@ -1,9 +1,9 @@
 <template>
   <div :class="$style.container">
-    <div :class="$style.overlay">
-      <message-file-list-item-content :file-id="fileId" is-white />
+    <div :class="$style.description">
+      <message-file-list-item-content :file-id="fileId" />
     </div>
-    <video
+    <audio
       controls
       preload="none"
       draggable="false"
@@ -47,24 +47,18 @@ export default defineComponent({
     radius: 6px;
     color: $theme-ui-secondary;
   }
-  video {
+  audio {
     display: block;
     max-width: 100%;
     max-height: 450px;
+    &::-webkit-media-controls-enclosure {
+      border-radius: 0;
+    }
   }
 }
-.overlay {
-  position: absolute;
+.description {
   width: 100%;
-  background: $common-background-overlay;
-  backdrop-filter: blur(4px);
+  margin: 6px 0;
   cursor: pointer;
-  z-index: 1;
-  opacity: 0;
-  transition: all 0.2s ease;
-
-  .container:hover & {
-    opacity: 1;
-  }
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
@@ -47,7 +47,6 @@ export default defineComponent({
   &[data-is-white] {
     color: $common-text-white-primary;
   }
-  border-color: $theme-ui-secondary;
   width: 100%;
 }
 .description {

--- a/src/components/Main/MainView/MessageElement/use/fileMetaList.ts
+++ b/src/components/Main/MainView/MessageElement/use/fileMetaList.ts
@@ -1,6 +1,6 @@
 import { computed, reactive } from '@vue/composition-api'
 import store from '@/store'
-import { isImage, isNonPreviewable, isVideo } from '@/lib/util/file'
+import { isImage, isNonPreviewable, isVideo, isAudio } from '@/lib/util/file'
 import { FileInfo } from '@traptitech/traq'
 
 const useFileMetaList = (props: { fileIds: string[] }) => {
@@ -18,6 +18,9 @@ const useFileMetaList = (props: { fileIds: string[] }) => {
     ),
     videos: computed(() =>
       fileMetaData.value.filter(meta => isVideo(meta.mime))
+    ),
+    audios: computed(() =>
+      fileMetaData.value.filter(meta => isAudio(meta.mime))
     ),
     files: computed(() =>
       fileMetaData.value.filter(meta => isNonPreviewable(meta))

--- a/src/lib/util/file.ts
+++ b/src/lib/util/file.ts
@@ -19,11 +19,14 @@ export const isImage = (mime: string) => mimeToFileType(mime) === 'image'
 export const isVideo = (mime: string) => mimeToFileType(mime) === 'video'
 export const isAudio = (mime: string) => mimeToFileType(mime) === 'audio'
 export const isNonPreviewable = (meta: FileInfo) => {
-  if (meta.thumbnail === null && meta.mime !== 'image/svg+xml') {
+  const type = mimeToFileType(meta.mime)
+  if (type === 'file') {
     return true
   }
-  const type = mimeToFileType(meta.mime)
-  return type === 'file' || type === 'audio'
+  if (type === 'image' && !meta.thumbnail && meta.mime !== 'image/svg+xml') {
+    return true
+  }
+  return false
 }
 
 const sizePrefix = ['', 'K', 'M', 'G']


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/81361759-2ee29580-911a-11ea-9c65-cc6ba5c622ec.png)

 - after
![image](https://user-images.githubusercontent.com/49056869/81361769-373ad080-911a-11ea-97d3-1dac3b82a728.png)

close #803 

> - 押すとモーダルが出ることがわかるようにしたい
> - メッセージに添付されてるのを直接再生したい

下はやったんですが、上はいい感じなのが思いつかなかったのでやってないです

それと、動画ファイルの動画表示とファイル表示が両方表示されてたのは意図されてなさそうだったので修正しました

よろしくお願いします
