### PR TITLE
Safariではみ出す箇所を修正

### DIFF
--- a/src/components/Authenticate/ConsentForm/ClientDescription.vue
+++ b/src/components/Authenticate/ConsentForm/ClientDescription.vue
@@ -87,6 +87,8 @@ export default defineComponent({
 }
 .descContent {
   word-break: keep-all;
+  min-width: 0;
+  overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   margin: auto 0;
 }

--- a/src/components/Main/MainView/MessageElement/ClipElement.vue
+++ b/src/components/Main/MainView/MessageElement/ClipElement.vue
@@ -141,6 +141,7 @@ $messagePaddingMobile: 16px;
   margin-top: 4px;
   margin-left: 42px;
   word-break: keep-all;
+  overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
 }
 

--- a/src/components/Main/MainView/MessageElement/MessageContents.vue
+++ b/src/components/Main/MainView/MessageElement/MessageContents.vue
@@ -137,6 +137,7 @@ export default defineComponent({
 .content {
   grid-area: message-contents;
   word-break: keep-all;
+  overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   line-break: loose;
 }

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -129,7 +129,9 @@ export default defineComponent({
   align-self: end;
   margin-top: 4px;
   word-break: keep-all;
+  overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
+  min-width: 0;
 }
 .description {
   font-weight: normal;

--- a/src/components/UI/MessagePanel/UserName.vue
+++ b/src/components/UI/MessagePanel/UserName.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="$style.container" :data-is-title="isTitle">
     <user-icon :class="$style.icon" :user-id="id" :size="isTitle ? 24 : 20" />
-    <span>
+    <span :class="$style.displayName">
       {{ displayName }}
     </span>
   </div>
@@ -42,6 +42,7 @@ export default defineComponent({
   display: flex;
   align-items: center;
   word-break: keep-all;
+  overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   &[data-is-title] {
     @include color-ui-primary;
@@ -51,5 +52,8 @@ export default defineComponent({
 }
 .icon {
   margin-right: 8px;
+}
+.displayName {
+  min-width: 0;
 }
 </style>


### PR DESCRIPTION
`overflow-wrap: anywhere` がSafariで未対応なので直前に `overflow-wrap: break-word` を挿入しました
必要そうなところは `min-width: 0` もつけています
よろしくお願いします

- [x] ClientDescription
- [x] ClipElement
- [x] MessageContents
- [x] MessageQuoteListItem
- [x] UserName