### PR TITLE
モバイル時にはクイックリアクションを折りたたむ

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageTools.vue
+++ b/src/components/Main/MainView/MessageElement/MessageTools.vue
@@ -52,7 +52,7 @@ import Stamp from '@/components/UI/Stamp.vue'
 import { StampId, MessageId } from '@/types/entity-ids'
 import useStampPickerInvoker from '@/use/stampPickerInvoker'
 import { targetPortalName } from '@/views/Main.vue'
-import useIsMobile from '../../../../use/isMobile'
+import useIsMobile from '@/use/isMobile'
 
 export default defineComponent({
   name: 'MessageTools',

--- a/src/components/Main/MainView/MessageElement/MessageTools.vue
+++ b/src/components/Main/MainView/MessageElement/MessageTools.vue
@@ -9,6 +9,7 @@
         :size="28"
         :class="$style.stampListItem"
       />
+      <span :class="$style.line"></span>
       <icon
         v-if="isMobile"
         mdi
@@ -17,7 +18,6 @@
         :class="$style.icon"
         @click="toggleQuickReaction"
       />
-      <span :class="$style.line"></span>
     </template>
     <icon
       v-else

--- a/src/components/Main/MainView/MessageElement/MessageTools.vue
+++ b/src/components/Main/MainView/MessageElement/MessageTools.vue
@@ -1,23 +1,41 @@
 <template>
   <div :class="$style.container">
-    <stamp
-      v-for="stamp in recentStamps"
-      :key="stamp"
-      :stamp-id="stamp"
-      @click.native="addStamp(stamp)"
+    <template v-if="showQuickReaction || !isMobile">
+      <stamp
+        v-for="stamp in recentStamps"
+        :key="stamp"
+        :stamp-id="stamp"
+        @click.native="addStamp(stamp)"
+        :size="28"
+        :class="$style.stampListItem"
+      />
+      <icon
+        v-if="isMobile"
+        mdi
+        name="chevron-right"
+        :size="28"
+        :class="$style.icon"
+        @click="toggleQuickReaction"
+      />
+      <span :class="$style.line"></span>
+    </template>
+    <icon
+      v-else
+      mdi
+      name="chevron-left"
       :size="28"
-      :class="$style.stampListItem"
+      :class="$style.icon"
+      @click="toggleQuickReaction"
     />
-    <span :class="$style.line"></span>
     <icon
       mdi
       name="emoticon-outline"
       :size="28"
-      :class="$style.emojiIcon"
+      :class="$style.icon"
       @click="onStampIconClick"
     />
     <icon
-      :class="$style.dotIcon"
+      :class="$style.icon"
       :size="28"
       mdi
       name="dots-horizontal"
@@ -27,13 +45,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, PropType } from '@vue/composition-api'
+import { defineComponent, computed, PropType, ref } from '@vue/composition-api'
 import store from '@/store'
 import Icon from '@/components/UI/Icon.vue'
 import Stamp from '@/components/UI/Stamp.vue'
 import { StampId, MessageId } from '@/types/entity-ids'
 import useStampPickerInvoker from '@/use/stampPickerInvoker'
 import { targetPortalName } from '@/views/Main.vue'
+import useIsMobile from '../../../../use/isMobile'
 
 export default defineComponent({
   name: 'MessageTools',
@@ -75,11 +94,19 @@ export default defineComponent({
       })
     }
 
+    const { isMobile } = useIsMobile()
+    const showQuickReaction = ref(!isMobile.value)
+    const toggleQuickReaction = () =>
+      (showQuickReaction.value = !showQuickReaction.value)
+
     return {
       recentStamps,
       addStamp,
       onDotsClick,
-      onStampIconClick
+      onStampIconClick,
+      isMobile,
+      showQuickReaction,
+      toggleQuickReaction
     }
   }
 })
@@ -104,8 +131,7 @@ export default defineComponent({
   margin: 0 4px;
 }
 
-.emojiIcon,
-.dotIcon {
+.icon {
   display: block;
   padding: 4px;
   cursor: pointer;


### PR DESCRIPTION
誤爆が多そうだったのでモバイル時には展開させる様にしました
before（とafterのデスクトップ）
<img width="187" alt="スクリーンショット 2020-05-09 0 26 10" src="https://user-images.githubusercontent.com/5803399/81420959-b1576d80-918b-11ea-94e8-03271dc10e6e.png">

after
<img width="218" alt="スクリーンショット 2020-05-09 0 27 02" src="https://user-images.githubusercontent.com/5803399/81421055-d1872c80-918b-11ea-9c8c-a192ffe5764d.png">
<img width="115" alt="スクリーンショット 2020-05-09 0 26 59" src="https://user-images.githubusercontent.com/5803399/81421071-d8ae3a80-918b-11ea-9421-9585fb422e45.png">
