### PR TITLE
ツールチップ周り

### DIFF
--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -5,7 +5,7 @@
     :data-include-me="state.includeMe"
     @click="onClick"
   >
-    <stamp :stamp-id="stampId" :size="20" />
+    <stamp :stamp-id="stampId" :size="20" without-title />
     <spin-number :value="state.count" :class="$style.count" />
   </div>
 </template>

--- a/src/components/Main/Navigation/ChannelList/ChannelElement.vue
+++ b/src/components/Main/Navigation/ChannelList/ChannelElement.vue
@@ -15,7 +15,7 @@
         :has-notification-on-child="notificationState.hasNotificationOnChild"
       />
       <div :class="$style.channelName" @click="onChannelNameClick">
-        <span :class="$style.channelNameString">
+        <span :class="$style.channelNameString" :title="pathTooltip">
           {{ pathToShow }}
         </span>
         <icon
@@ -63,6 +63,13 @@ import Icon from '@/components/UI/Icon.vue'
 const useAncestorPath = (skippedAncestorNames?: string[]) => {
   return {
     path: computed(() => skippedAncestorNames?.join('/')?.concat('/') ?? '')
+  }
+}
+
+const useFullPath = (props: TypedProps) => {
+  const { channelIdToPathString } = useChannelPath()
+  return {
+    path: computed(() => channelIdToPathString(props.channel.id))
   }
 }
 
@@ -191,6 +198,11 @@ export default defineComponent({
         : useAncestorPath(typedProps.channel.skippedAncestorNames).path.value +
           typedProps.channel.name
     )
+    const pathTooltip = computed(() =>
+      typedProps.showShortenedPath
+        ? `#${useFullPath(typedProps).path.value}`
+        : undefined
+    )
     const { onChannelHashClick, onChannelNameClick } = useChannelClick(
       context,
       typedProps.channel.id,
@@ -203,6 +215,7 @@ export default defineComponent({
     return {
       state,
       pathToShow,
+      pathTooltip,
       notificationState,
       topic,
       isQalling,

--- a/src/components/UI/Stamp.vue
+++ b/src/components/UI/Stamp.vue
@@ -6,7 +6,7 @@
     :style="styles.container"
     :src="imageUrl"
     :alt="name"
-    :title="name"
+    :title="!withoutTitle ? name : undefined"
     draggable="false"
   />
   <div v-else :class="$style.container" :style="styles.container" />
@@ -42,6 +42,10 @@ export default defineComponent({
     size: {
       type: Number,
       default: 24
+    },
+    withoutTitle: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props) {


### PR DESCRIPTION
- メッセージに押されてるスタンプのツールチップでスタンプ名のみが表示されてた => スタンプホバーでスタンプ名が表示されるのでそれに上書きされてた
- チャンネルリストで省略されたパスの場合ツールチップでフルパスを表示するように

よろしくお願いします
