### PR TITLE
[画面共有] 画面共有の送受信

### DIFF
--- a/src/components/Main/MainView/ChannelView/use/screenShare.ts
+++ b/src/components/Main/MainView/ChannelView/use/screenShare.ts
@@ -1,0 +1,51 @@
+import { ChannelId } from '@/types/entity-ids'
+import { computed } from '@vue/composition-api'
+import store from '@/store'
+
+const useScreenShare = (props: { channelId: ChannelId }) => {
+  const isScreenShareSessionOpened = computed(() =>
+    Object.values(store.state.app.rtc.sessionInfoMap).some(
+      s => s?.channelId === props.channelId && s?.type === 'video'
+    )
+  )
+  const hasActiveScreenShareSession = computed(() => {
+    return !!store.getters.app.rtc.videoSession
+  })
+  const isJoinedScreenShareSession = computed(
+    () =>
+      hasActiveScreenShareSession.value &&
+      store.state.app.rtc.currentRTCState?.channelId === props.channelId
+  )
+  const startScreenCasting = async () => {
+    try {
+      await store.dispatch.app.rtc.startVideoCasting(props.channelId)
+    } catch {
+      window.alert('画面共有の開始に失敗しました')
+    }
+  }
+  const startScreenStreaming = async () => {
+    await store.dispatch.app.rtc.startVideoStreaming(props.channelId)
+  }
+  const endScreenShareSession = async () => {
+    await store.dispatch.app.rtc.endVideoSession()
+  }
+  const toggleScreenSharing = async () => {
+    if (isJoinedScreenShareSession.value) {
+      endScreenShareSession()
+    } else if (isScreenShareSessionOpened.value) {
+      startScreenStreaming()
+    } else if (hasActiveScreenShareSession.value) {
+      return
+    } else {
+      startScreenCasting()
+    }
+  }
+  return {
+    toggleScreenSharing,
+    hasActiveScreenShareSession,
+    isJoinedScreenShareSession,
+    isScreenShareSessionOpened
+  }
+}
+
+export default useScreenShare

--- a/src/store/app/rtc/getters.ts
+++ b/src/store/app/rtc/getters.ts
@@ -8,6 +8,11 @@ export const getters = defineGetters<S>()({
       s => state.sessionInfoMap[s.sessionId]?.type === 'qall'
     )
   },
+  videoSession(state) {
+    return state.currentRTCState?.sessionStates.find(
+      s => state.sessionInfoMap[s.sessionId]?.type === 'video'
+    )
+  },
   channelRTCSessionId: state => (
     sessionType: SessionType,
     channelId: ChannelId

--- a/src/store/app/rtc/mutations.ts
+++ b/src/store/app/rtc/mutations.ts
@@ -187,6 +187,12 @@ export const mutations = defineMutations<S>()({
     })
     state.isMicMuted = false
   },
+  setLocalVideoStream(state, videoStream: ExtendedMediaStream) {
+    state.localVideoStream = videoStream
+  },
+  unsetLocalVideoStream(state) {
+    state.localVideoStream = undefined
+  },
   addRemoteStream(
     state,
     payload: { userId: UserId; mediaStream: MediaStream }

--- a/src/store/app/rtc/mutations.ts
+++ b/src/store/app/rtc/mutations.ts
@@ -209,6 +209,22 @@ export const mutations = defineMutations<S>()({
     )
     state.remoteAudioStreamMap = {}
   },
+  addVideoRemoteStream(
+    state,
+    payload: { userId: UserId; mediaStream: MediaStream }
+  ) {
+    Vue.set(state.remoteVideoStreamMap, payload.userId, payload.mediaStream)
+  },
+  removeRemoteVideoStream(state, userId: UserId) {
+    state.remoteVideoStreamMap[userId]?.getTracks().forEach(t => t.stop())
+    Vue.delete(state.remoteVideoStreamMap, userId)
+  },
+  clearRemoteVideoStream(state) {
+    Object.values(state.remoteVideoStreamMap).forEach(stream =>
+      stream?.getTracks().forEach(t => t.stop())
+    )
+    state.remoteVideoStreamMap = {}
+  },
   /**
    * @param volume 0-1で指定するボリューム (0がミュート、1がAudioStreamMixer.maxGainに相当するゲイン)
    */

--- a/src/store/app/rtc/mutations.ts
+++ b/src/store/app/rtc/mutations.ts
@@ -18,7 +18,9 @@ const toSessionInfo = (
   const [sessionType, id] = sessionId.split('-')
   if (
     id &&
-    (sessionType === ('qall' as const) || sessionType === ('draw' as const))
+    (sessionType === ('qall' as const) ||
+      sessionType === ('draw' as const) ||
+      sessionType === ('video' as const))
   ) {
     return {
       sessionId,
@@ -209,7 +211,7 @@ export const mutations = defineMutations<S>()({
     )
     state.remoteAudioStreamMap = {}
   },
-  addVideoRemoteStream(
+  addRemoteVideoStream(
     state,
     payload: { userId: UserId; mediaStream: MediaStream }
   ) {

--- a/src/store/app/rtc/state.ts
+++ b/src/store/app/rtc/state.ts
@@ -2,15 +2,17 @@ import { UserId, ChannelId } from '@/types/entity-ids'
 import AudioStreamMixer from '@/lib/audioStreamMixer'
 
 export type SessionId = string
-export type SessionType = 'qall' | 'draw'
+export type SessionType = 'qall' | 'video' | 'draw'
 export type SessionInfoBase = {
   sessionId: SessionId
   type: SessionType
   channelId: ChannelId
 }
 export type QallSessionInfo = SessionInfoBase & { type: 'qall' }
+export type VideoSessionInfo = SessionInfoBase & { type: 'video' }
 export type DrawSessionInfo = SessionInfoBase & { type: 'draw' }
-export type SessionInfo = QallSessionInfo | DrawSessionInfo
+export type SessionInfo = QallSessionInfo | VideoSessionInfo | DrawSessionInfo
+
 export type UserSessionState = {
   sessionId: SessionId
   states: string[]
@@ -30,6 +32,9 @@ export interface S {
 
   /** 送信するMediaStream */
   localStream?: ExtendedMediaStream
+
+  /** 送信するMediaStream (ビデオ接続用) */
+  localVideoStream?: ExtendedMediaStream
 
   /** マイクミュート */
   isMicMuted: boolean
@@ -62,6 +67,7 @@ export interface S {
 export const state: S = {
   mixer: undefined,
   localStream: undefined,
+  localVideoStream: undefined,
   isMicMuted: false,
   currentRTCState: undefined,
   userStateMap: {},

--- a/src/store/app/rtc/state.ts
+++ b/src/store/app/rtc/state.ts
@@ -60,6 +60,9 @@ export interface S {
   /** 他ユーザーのオーディオ */
   remoteAudioStreamMap: Record<UserId, MediaStream | undefined>
 
+  /** 他ユーザーのビデオ */
+  remoteVideoStreamMap: Record<UserId, MediaStream | undefined>
+
   /** 現在発話しているユーザーを判定するsetIntervalのID */
   talkingStateUpdateIntervalId: number
 }
@@ -76,5 +79,6 @@ export const state: S = {
   sessionUsersMap: {},
   userVolumeMap: {},
   remoteAudioStreamMap: {},
+  remoteVideoStreamMap: {},
   talkingStateUpdateIntervalId: 0
 }


### PR DESCRIPTION
- セッション種別として`video'を追加
- 音声ストリームとは別にビデオのストリームについても音声と同様にローカルのストリームやリモートのストリームを持つ
- Qallの終了時、即座に通話を終了せずにまず部屋からの離脱を行う