### PR TITLE
メッセージに添付された動画の説明のぼかしがホバーしてないときも表示されてた

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
@@ -58,13 +58,14 @@ export default defineComponent({
   position: absolute;
   width: 100%;
   background: $common-background-overlay;
-  backdrop-filter: blur(4px);
   cursor: pointer;
   z-index: 1;
+  backdrop-filter: blur(0px);
   opacity: 0;
   transition: all 0.2s ease;
 
   .container:hover & {
+    backdrop-filter: blur(4px);
     opacity: 1;
   }
 }


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/81492047-b1f91c80-92cf-11ea-9c17-be5c40315429.png)

 - after
![image](https://user-images.githubusercontent.com/49056869/81492052-ba515780-92cf-11ea-8745-e6cf4ba2872c.png)
