### PR TITLE
fix #832など

### DIFF
--- a/src/components/Authenticate/ConsentForm/ClientDescription.vue
+++ b/src/components/Authenticate/ConsentForm/ClientDescription.vue
@@ -86,8 +86,8 @@ export default defineComponent({
   text-align: center;
 }
 .descContent {
-  word-break: keep-all;
   min-width: 0;
+  word-break: normal;
   overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   margin: auto 0;

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedListItem.vue
@@ -31,30 +31,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss" module>
-.container {
-  display: block;
-  width: 256px;
-  border-radius: 4px;
-  word-break: break-all;
-  padding: 16px;
-}
-
-.itemHeader {
-  display: flex;
-  padding-bottom: 4px;
-  margin-bottom: 4px;
-  border-bottom: solid 2px;
-}
-
-.displayName {
-  @include size-body1;
-  font-weight: bold;
-  margin-left: 8px;
-}
-
-.text {
-  @include size-body1;
-}
-</style>

--- a/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
+++ b/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
@@ -69,7 +69,7 @@ export default defineComponent({
 .content {
   width: 100%;
   white-space: pre-line;
-  word-break: keep-all;
+  word-break: normal;
   overflow-wrap: break-word;
   min-width: 0;
   &[data-is-empty] {

--- a/src/components/Main/MainView/MessageElement/MessageContents.vue
+++ b/src/components/Main/MainView/MessageElement/MessageContents.vue
@@ -136,7 +136,7 @@ export default defineComponent({
 
 .content {
   grid-area: message-contents;
-  word-break: keep-all;
+  word-break: normal;
   overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   line-break: loose;

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -97,5 +97,6 @@ export default defineComponent({
 .editIcon {
   @include color-ui-secondary;
   margin-left: 4px;
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -71,6 +71,8 @@ export default defineComponent({
   font-weight: bold;
   word-break: keep-all;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .badge {
@@ -84,8 +86,6 @@ export default defineComponent({
 
   word-break: keep-all;
   white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
 }
 
 .date {

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItemHeader.vue
@@ -40,10 +40,15 @@ export default defineComponent({
 .header {
   display: inline-flex;
   align-items: center;
+  min-width: 0;
 }
 
 .displayName {
   @include size-body2;
   font-weight: bold;
+  word-break: keep-all;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 </style>

--- a/src/components/UI/MessagePanel/ChannelName.vue
+++ b/src/components/UI/MessagePanel/ChannelName.vue
@@ -29,10 +29,20 @@ export default defineComponent({
 .path {
   @include color-ui-secondary;
   @include size-body2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
   &[data-is-title] {
     @include color-ui-primary;
     @include size-body1;
     font-weight: bold;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    white-space: normal;
+    word-break: break-all;
   }
   &::before {
     content: '# ';

--- a/src/components/UI/MessagePanel/RenderContent.vue
+++ b/src/components/UI/MessagePanel/RenderContent.vue
@@ -80,7 +80,6 @@ export default defineComponent({
 .container {
   @include color-ui-primary;
   @include size-body1;
-  word-break: break-all;
   width: 100%;
 }
 .lineClamp {

--- a/src/components/UI/MessagePanel/UserName.vue
+++ b/src/components/UI/MessagePanel/UserName.vue
@@ -41,7 +41,7 @@ export default defineComponent({
   @include size-body2;
   display: flex;
   align-items: center;
-  word-break: keep-all;
+  word-break: normal;
   overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   &[data-is-title] {

--- a/src/components/UI/MessagePanel/UserName.vue
+++ b/src/components/UI/MessagePanel/UserName.vue
@@ -55,5 +55,16 @@ export default defineComponent({
 }
 .displayName {
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  .container[data-is-title] & {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    white-space: normal;
+    word-break: break-all;
+  }
 }
 </style>


### PR DESCRIPTION
- メッセージヘッダーで編集済みアイコンがつぶれることがあった
![image](https://user-images.githubusercontent.com/49056869/81504831-7dfd1600-9326-11ea-9ea7-e36e42c5d347.png)
![image](https://user-images.githubusercontent.com/49056869/81504839-82c1ca00-9326-11ea-83ee-8e539b3a9faa.png)

- メッセージヘッダーが収まらないときにnameではなくdisplay_nameを省略表示するように
![image](https://user-images.githubusercontent.com/49056869/81504847-8bb29b80-9326-11ea-97b6-1a55f75f2783.png)
![image](https://user-images.githubusercontent.com/49056869/81504854-92d9a980-9326-11ea-8376-a407e28110ef.png)
display_nameのがnameより長くなる可能性があるので

- 引用メッセージのヘッダーが飛び出てた
![image](https://user-images.githubusercontent.com/49056869/81504864-9ff69880-9326-11ea-8182-1e6c04d2d0d9.png)
![image](https://user-images.githubusercontent.com/49056869/81504867-a38a1f80-9326-11ea-8353-943472d21cad.png)

- fix #832
![image](https://user-images.githubusercontent.com/49056869/81504870-aa189700-9326-11ea-8b54-52ed4f9b9627.png)
![image](https://user-images.githubusercontent.com/49056869/81504872-adac1e00-9326-11ea-900e-b0340e7e0dcc.png)

- MessagePanelのタイトルを2行まで、サブタイトルを1行までに制限
  - before
![image](https://user-images.githubusercontent.com/49056869/81504876-b866b300-9326-11ea-8d65-4a1a1eaa793a.png)
![image](https://user-images.githubusercontent.com/49056869/81504889-c4527500-9326-11ea-81c7-3aa56138440b.png)
  - after
![image](https://user-images.githubusercontent.com/49056869/81504892-c9172900-9326-11ea-992c-6a610090faf4.png)
![image](https://user-images.githubusercontent.com/49056869/81504899-d59b8180-9326-11ea-8083-2db3163e5014.png)
![image](https://user-images.githubusercontent.com/49056869/81504908-e9df7e80-9326-11ea-9eca-3f9ce4ead0e4.png)

よろしくお願いします
