### PR TITLE
画像の回転

### DIFF
--- a/src/lib/resize/blob.ts
+++ b/src/lib/resize/blob.ts
@@ -1,0 +1,17 @@
+export const blobAsArrayBuffer = (blob: Blob): Promise<ArrayBuffer> => {
+  if (blob.arrayBuffer) {
+    return blob.arrayBuffer()
+  }
+
+  const reader = new FileReader()
+  return new Promise((resolve, reject) => {
+    reader.addEventListener('load', () => {
+      resolve(reader.result as ArrayBuffer)
+    })
+    reader.addEventListener('error', () => {
+      reject()
+    })
+
+    reader.readAsArrayBuffer(blob)
+  })
+}

--- a/src/lib/resize/index.ts
+++ b/src/lib/resize/index.ts
@@ -6,12 +6,13 @@ import {
   needDimentionSwap,
   getOrientation
 } from './orientation'
-import { isIOS } from '../util/browser'
+import { isIOS, isFirefox } from '../util/browser'
 
 export const canResize = (mime: string) =>
   ['image/png', 'image/jpeg'].includes(mime)
 const isJpeg = (mime: string) => mime === 'image/jpeg'
-const iOSFlag = isIOS()
+
+const needRotation = isIOS() || isFirefox()
 
 export const resize = async (inputFile: File): Promise<File | null> => {
   start()
@@ -30,7 +31,7 @@ export const resize = async (inputFile: File): Promise<File | null> => {
     }
 
     // iOSでは画像の回転を手動適用
-    if (iOSFlag && isJpeg(inputFile.type)) {
+    if (needRotation && isJpeg(inputFile.type)) {
       const orientation = await getOrientation(inputFile)
       resetAndSetRotatedImgToCanvas($input, inputSize, $img, orientation)
       // resetAndSetRotatedImgToCanvas内では入れ替え前の値がほしいため、そのあとで行う

--- a/src/lib/resize/index.ts
+++ b/src/lib/resize/index.ts
@@ -1,9 +1,17 @@
 import { start, finish, initVars } from './vars'
 import { loadImage, resetCanvas } from './canvas'
 import { needResize, getThumbnailDimensions } from './size'
+import {
+  resetAndSetRotatedImgToCanvas,
+  needDimentionSwap,
+  getOrientation
+} from './orientation'
+import { isIOS } from '../util/browser'
 
 export const canResize = (mime: string) =>
   ['image/png', 'image/jpeg'].includes(mime)
+const isJpeg = (mime: string) => mime === 'image/jpeg'
+const iOSFlag = isIOS()
 
 export const resize = async (inputFile: File): Promise<File | null> => {
   start()
@@ -21,14 +29,27 @@ export const resize = async (inputFile: File): Promise<File | null> => {
       return finish(null, inputUrl)
     }
 
+    // iOSでは画像の回転を手動適用
+    if (iOSFlag && isJpeg(inputFile.type)) {
+      const orientation = await getOrientation(inputFile)
+      resetAndSetRotatedImgToCanvas($input, inputSize, $img, orientation)
+      // resetAndSetRotatedImgToCanvas内では入れ替え前の値がほしいため、そのあとで行う
+      if (needDimentionSwap(orientation)) {
+        ;[inputSize.width, inputSize.height] = [
+          inputSize.height,
+          inputSize.width
+        ]
+      }
+    } else {
+      resetCanvas($input, inputSize, $img)
+    }
+
     const outputSize = getThumbnailDimensions(inputSize)
-
-    resetCanvas($input, inputSize, $img)
     resetCanvas($output, outputSize)
-
     await pica.resize($input, $output, {
       quality: 2
     })
+
     const output = await pica.toBlob($output, 'image/png')
     const outputFile = new File([output], inputFile.name, {
       type: inputFile.type,

--- a/src/lib/resize/index.ts
+++ b/src/lib/resize/index.ts
@@ -50,7 +50,7 @@ export const resize = async (inputFile: File): Promise<File | null> => {
       quality: 2
     })
 
-    const output = await pica.toBlob($output, 'image/png')
+    const output = await pica.toBlob($output, inputFile.type)
     const outputFile = new File([output], inputFile.name, {
       type: inputFile.type,
       lastModified: inputFile.lastModified

--- a/src/lib/resize/orientation.ts
+++ b/src/lib/resize/orientation.ts
@@ -1,0 +1,76 @@
+import { resetCanvas } from './canvas'
+import { Dimensions } from './size'
+import { blobAsArrayBuffer } from './blob'
+
+type Orientaion = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
+
+export const getOrientation = async (file: File): Promise<Orientaion> => {
+  const buffer = await blobAsArrayBuffer(file)
+  const dv = new DataView(buffer)
+  let app1MarkerStart = 2
+  // JFIF with APP0 Marker
+  if (dv.getUint16(app1MarkerStart) !== 0xffe1) {
+    app1MarkerStart += dv.getUint16(4) + 2
+  }
+  // without exif
+  if (dv.getUint16(app1MarkerStart) !== 0xffe1) {
+    return 0
+  }
+
+  const isLittleEndian = dv.getUint16(app1MarkerStart + 10) === 0x49
+  const fieldCount = dv.getUint16(app1MarkerStart + 18, isLittleEndian)
+  for (let i = 0; i < fieldCount; i++) {
+    const start = app1MarkerStart + 20 + 12 * i
+    const tag = dv.getUint16(start, isLittleEndian)
+    // orientaion
+    if (tag === 0x0112) {
+      return dv.getUint16(start + 8, isLittleEndian) as Orientaion
+    }
+  }
+  return 0
+}
+
+export const needDimentionSwap = (orientation: Orientaion) =>
+  [5, 6, 7, 8].includes(orientation)
+
+export const resetAndSetRotatedImgToCanvas = (
+  $canvas: HTMLCanvasElement,
+  { width, height }: Dimensions,
+  $img: HTMLImageElement,
+  orientation: Orientaion
+) => {
+  if (needDimentionSwap(orientation)) {
+    // 縦横入れ替え
+    resetCanvas($canvas, { width: height, height: width })
+  } else {
+    resetCanvas($canvas, { width, height })
+  }
+
+  const ctx = $canvas.getContext('2d')
+  if (!ctx) return
+
+  switch (orientation) {
+    case 2:
+      ctx.transform(-1, 0, 0, 1, width, 0)
+      break
+    case 3:
+      ctx.transform(-1, 0, 0, -1, width, height)
+      break
+    case 4:
+      ctx.transform(1, 0, 0, -1, 0, height)
+      break
+    case 5:
+      ctx.transform(0, 1, 1, 0, 0, 0)
+      break
+    case 6:
+      ctx.transform(0, 1, -1, 0, height, 0)
+      break
+    case 7:
+      ctx.transform(0, -1, -1, 0, height, width)
+      break
+    case 8:
+      ctx.transform(0, -1, 1, 0, 0, width)
+      break
+  }
+  ctx.drawImage($img, 0, 0)
+}

--- a/src/lib/util/browser.ts
+++ b/src/lib/util/browser.ts
@@ -5,6 +5,16 @@ export const isSafari = () => {
   return ua.includes('safari') && !ua.includes('chrome') && !ua.includes('edge')
 }
 
+export const isIOS = () => {
+  const ua = navigator.userAgent
+  return (
+    isIOSApp() ||
+    ua.includes('iPhone') ||
+    ua.includes('iPod') ||
+    ua.includes('iPad')
+  )
+}
+
 export const isIOSApp = () => {
   return navigator.userAgent.includes('traQ-iOS')
 }
@@ -14,14 +24,7 @@ export const isPWA = () => {
 }
 
 export const isTouchDevice = () => {
-  const ua = navigator.userAgent
-  return (
-    ua.includes('traQ-iOS') ||
-    ua.includes('iPhone') ||
-    ua.includes('iPod') ||
-    ua.includes('iPad') ||
-    ua.includes('Android')
-  )
+  return isIOS() || navigator.userAgent.includes('Android')
 }
 
 // https://github.com/ianstormtaylor/slate/blob/7377266b43451c4be44a1442aa1076ef3d13227e/packages/slate-dev-environment/src/index.js#L74-L79

--- a/src/lib/util/browser.ts
+++ b/src/lib/util/browser.ts
@@ -1,22 +1,26 @@
 export const isMac = () => navigator.platform.includes('Mac')
 
+const ua = navigator.userAgent.toLowerCase()
+
 export const isSafari = () => {
-  const ua = navigator.userAgent.toLowerCase()
   return ua.includes('safari') && !ua.includes('chrome') && !ua.includes('edge')
 }
 
+export const isFirefox = () => {
+  return ua.includes('firefox')
+}
+
 export const isIOS = () => {
-  const ua = navigator.userAgent
   return (
     isIOSApp() ||
-    ua.includes('iPhone') ||
-    ua.includes('iPod') ||
-    ua.includes('iPad')
+    ua.includes('iphone') ||
+    ua.includes('ipod') ||
+    ua.includes('ipad')
   )
 }
 
 export const isIOSApp = () => {
-  return navigator.userAgent.includes('traQ-iOS')
+  return ua.includes('traq-ios')
 }
 
 export const isPWA = () => {
@@ -24,7 +28,7 @@ export const isPWA = () => {
 }
 
 export const isTouchDevice = () => {
-  return isIOS() || navigator.userAgent.includes('Android')
+  return isIOS() || ua.includes('android')
 }
 
 // https://github.com/ianstormtaylor/slate/blob/7377266b43451c4be44a1442aa1076ef3d13227e/packages/slate-dev-environment/src/index.js#L74-L79

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -17,3 +17,7 @@ body {
   touch-action: manipulation;
   overscroll-behavior-y: contain;
 }
+
+img {
+  image-orientation: from-image;
+}


### PR DESCRIPTION
chrome/safari(PC)では`<canvas>`に`<img>`を元に書き込むときEXIFの回転がちゃんと適用されていたのに対してiOSでは適用されていなかったため、画像が回転してしまっていた

iOSではEXIF読み取って画像を回転させた上でリサイズかけるようにしました(回転を手動で指定して動くことは確認しましたが、実機での確認はできてません)
検知方法がなさそうだったのでiOSならっていう分岐になってます
(Firefoxでも必要だったのでするようにしました)

ついでに下の二つもやってます
- リサイズ後のファイルの実体と拡張子がかみ合ってなかった
- imgタグでEXIFの回転を有効化 close #660

よろしくお願いします
