### PR TITLE
細かいデザイン修正

### DIFF
--- a/src/components/Authenticate/AuthenticateMainView.vue
+++ b/src/components/Authenticate/AuthenticateMainView.vue
@@ -42,7 +42,7 @@ export default defineComponent({
   width: 100vw;
   height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow: auto;
+  padding: 48px 24px;
 }
 </style>

--- a/src/components/Authenticate/AuthenticateModal.vue
+++ b/src/components/Authenticate/AuthenticateModal.vue
@@ -18,8 +18,8 @@ export default defineComponent({
   @include background-primary;
   border-radius: 4px;
   width: 100%;
-  margin: 16px;
   max-width: 480px;
   padding: 48px;
+  margin: auto;
 }
 </style>

--- a/src/components/Authenticate/ConsentForm/ClientDescription.vue
+++ b/src/components/Authenticate/ConsentForm/ClientDescription.vue
@@ -60,6 +60,7 @@ export default defineComponent({
   flex-direction: column;
   align-items: center;
   width: fit-content;
+  max-width: 100%;
   padding: 12px;
   border-radius: 12px;
 }
@@ -67,6 +68,9 @@ export default defineComponent({
   margin-bottom: 12px;
   font-weight: bold;
   text-align: center;
+  word-break: normal;
+  overflow-wrap: break-word; // for Safari
+  overflow-wrap: anywhere;
 }
 .desc {
   display: grid;

--- a/src/components/Authenticate/ConsentForm/ConsentForm.vue
+++ b/src/components/Authenticate/ConsentForm/ConsentForm.vue
@@ -77,6 +77,7 @@ export default defineComponent({
 
 .buttons {
   display: flex;
+  flex-wrap: wrap-reverse;
   justify-content: space-between;
   align-items: center;
   width: 100%;

--- a/src/components/Main/MainView/ChannelView/ChannelViewContent.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent.vue
@@ -17,8 +17,6 @@
 <script lang="ts">
 import { defineComponent, PropType } from '@vue/composition-api'
 import { ChannelId } from '@/types/entity-ids'
-import { makeStyles } from '@/lib/styles'
-
 import MessagesScroller from '@/components/Main/MainView/MessagesScroller/MessagesScroller.vue'
 import MessageInput from '@/components/Main/MainView/MessageInput/MessageInput.vue'
 import ChannelViewFileUploadOverlay from './ChannelViewFileUploadOverlay.vue'
@@ -36,11 +34,6 @@ export default defineComponent({
     ChannelViewFileUploadOverlay
   },
   setup(props) {
-    const containerStyle = makeStyles(theme => ({
-      background: theme.background.primary,
-      color: theme.ui.primary
-    }))
-
     const {
       messageIds,
       isReachedEnd,
@@ -57,7 +50,6 @@ export default defineComponent({
       messageIds,
       isReachedEnd,
       isReachedLatest,
-      containerStyle,
       isLoading,
       lastLoadingDirection,
       onLoadFormerMessagesRequest,

--- a/src/components/Main/MainView/MainView.vue
+++ b/src/components/Main/MainView/MainView.vue
@@ -106,6 +106,7 @@ export default defineComponent({
   top: 0;
 }
 .primary {
+  min-width: 0;
   width: 100%;
 }
 .primaryContainer {

--- a/src/components/Main/MainView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MainView/MessageElement/MessageElement.vue
@@ -157,7 +157,6 @@ $messagePaddingMobile: 16px;
 
 .pinned {
   grid-area: pinned;
-  height: 28px;
   padding: {
     top: 4px;
     bottom: 8px;

--- a/src/components/Main/MainView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MainView/MessageElement/MessageElement.vue
@@ -156,7 +156,6 @@ $messagePaddingMobile: 16px;
 }
 
 .pinned {
-  grid-area: pinned;
   padding: {
     top: 4px;
     bottom: 8px;
@@ -164,13 +163,11 @@ $messagePaddingMobile: 16px;
 }
 
 .messageContents {
-  grid-area: message-contents;
   min-width: 0;
 }
 
 .stampWrapper {
   position: relative;
-  grid-area: stamp-wrapper;
   margin-top: 8px;
   margin-left: 42px;
 }

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -69,6 +69,9 @@ export default defineComponent({
 
 .displayName {
   font-weight: bold;
+  flex: 2;
+  max-width: min-content;
+
   word-break: keep-all;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -83,9 +86,13 @@ export default defineComponent({
   @include color-ui-secondary;
   @include size-body2;
   margin-left: 4px;
+  flex: 1;
+  max-width: min-content;
 
   word-break: keep-all;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .date {

--- a/src/components/Main/MainView/MessageElement/MessagePinned.vue
+++ b/src/components/Main/MainView/MessageElement/MessagePinned.vue
@@ -41,5 +41,6 @@ export default defineComponent({
 .pin {
   color: $common-ui-pin;
   margin-right: 8px;
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/Main/MainView/MessageElement/MessagePinned.vue
+++ b/src/components/Main/MainView/MessageElement/MessagePinned.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="$style.container">
     <icon name="pin" mdi :size="16" :class="$style.pin" />
-    {{ username }}さんがピン留めしました
+    {{ userDisplayName }}さんがピン留めしました
   </div>
 </template>
 
@@ -20,14 +20,14 @@ export default defineComponent({
     messageId: String as PropType<MessageId>
   },
   setup(props) {
-    const username = computed(() => {
+    const userDisplayName = computed(() => {
       const pin = store.state.domain.messagesView.pinnedMessages.find(
         v => v.message.id === props.messageId
       )
       const user = store.state.entities.users[pin?.userId ?? '']
-      return user?.name
+      return user?.displayName
     })
-    return { username }
+    return { userDisplayName }
   }
 })
 </script>

--- a/src/components/Main/Navigation/DesktopNavigation.vue
+++ b/src/components/Main/Navigation/DesktopNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.container" :style="navigationStyle">
+  <div :class="$style.container">
     <div :class="$style.selector">
       <desktop-navigation-selector
         @navigation-change="onNavigationChange"
@@ -39,7 +39,6 @@ import DesktopNavigationSelector from '@/components/Main/Navigation/DesktopNavig
 import DesktopToolBox, {
   targetPortalName
 } from '@/components/Main/Navigation/DesktopToolBox.vue'
-import { makeStyles } from '@/lib/styles'
 
 export default defineComponent({
   name: 'DesktopNavigation',
@@ -59,11 +58,6 @@ export default defineComponent({
       onEphemeralEntryAdd
     } = useNavigation()
 
-    const navigationStyle = makeStyles(theme => ({
-      background: theme.background.secondary,
-      color: theme.ui.primary
-    }))
-
     return {
       navigationSelectorState,
       ephemeralNavigationSelectorState,
@@ -71,7 +65,6 @@ export default defineComponent({
       onEphemeralNavigationChange,
       onEphemeralEntryRemove,
       onEphemeralEntryAdd,
-      navigationStyle,
       targetPortalName
     }
   }
@@ -85,6 +78,8 @@ $ephemeralNavigationRightMargin: 16px;
 $ephemeralNavigationMinHeight: 64px;
 
 .container {
+  @include color-ui-primary;
+  @include background-secondary;
   display: flex;
   width: 100%;
   height: 100%;

--- a/src/components/Main/Navigation/DesktopNavigation.vue
+++ b/src/components/Main/Navigation/DesktopNavigation.vue
@@ -87,10 +87,13 @@ $ephemeralNavigationMinHeight: 64px;
 .selector {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   width: $selectorWidth;
   height: 100%;
   flex-shrink: 0;
+  overflow: {
+    x: hidden;
+    y: auto;
+  }
 }
 .navigations {
   display: flex;

--- a/src/components/Main/Navigation/DesktopNavigation.vue
+++ b/src/components/Main/Navigation/DesktopNavigation.vue
@@ -72,9 +72,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
-$selectorWidth: 64px;
-$ephemeralNavigationLeftMargin: 8px;
-$ephemeralNavigationRightMargin: 16px;
+$ephemeralNavigationSideMargin: 8px;
 $ephemeralNavigationMinHeight: 64px;
 
 .container {
@@ -87,7 +85,6 @@ $ephemeralNavigationMinHeight: 64px;
 .selector {
   display: flex;
   flex-direction: column;
-  width: $selectorWidth;
   height: 100%;
   flex-shrink: 0;
   overflow: {
@@ -105,10 +102,8 @@ $ephemeralNavigationMinHeight: 64px;
   width: 100%;
 }
 .ephemeralNavigation {
-  width: #{calc(
-      100% - #{$ephemeralNavigationLeftMargin + $ephemeralNavigationRightMargin}
-    )};
-  margin-left: $ephemeralNavigationLeftMargin;
+  width: #{calc(100% - #{$ephemeralNavigationSideMargin * 2})};
+  margin: 0 $ephemeralNavigationSideMargin;
   flex: 0 1 $ephemeralNavigationMinHeight;
 }
 </style>

--- a/src/components/Main/Navigation/DesktopNavigationSelector.vue
+++ b/src/components/Main/Navigation/DesktopNavigationSelector.vue
@@ -1,5 +1,6 @@
 <template>
   <div :class="$style.container">
+    <icon :class="$style.logo" name="traQ" :size="44" />
     <navigation-selector-item
       v-for="item in entries"
       :key="item.type"
@@ -90,6 +91,11 @@ export default defineComponent({
   flex: 1 0;
   align-items: center;
   padding: 8px 0;
+}
+.logo {
+  @include color-accent-primary;
+  padding: 8px;
+  margin: 8px 0;
 }
 .item {
   margin: 8px 0;

--- a/src/components/Main/Navigation/DesktopNavigationSelector.vue
+++ b/src/components/Main/Navigation/DesktopNavigationSelector.vue
@@ -95,10 +95,10 @@ export default defineComponent({
 .logo {
   @include color-accent-primary;
   padding: 8px;
-  margin: 8px 0;
+  margin: 8px;
 }
 .item {
-  margin: 8px 0;
+  margin: 8px;
 }
 .separator {
   @include background-tertiary;

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanelUser.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="$style.container">
     <user-icon :user-id="userId" :size="24" />
-    <div>
+    <div :class="$style.userDesc">
       <slider
         v-if="showVolumeControl"
         :value="volume"
@@ -103,10 +103,17 @@ export default defineComponent({
 .tuneDone {
   @include color-accent-primary;
 }
+.userDesc {
+  min-width: 0;
+}
 .userName {
   @include color-ui-secondary;
   @include size-body2;
-  display: flex;
-  align-items: center;
+  display: inline-block;
+  width: 100%;
+  vertical-align: middle;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 </style>

--- a/src/components/Main/Navigation/NavigationContent.vue
+++ b/src/components/Main/Navigation/NavigationContent.vue
@@ -70,7 +70,7 @@ export default defineComponent({
   overflow-y: scroll;
   padding: {
     top: 24px;
-    left: 24px;
+    left: 16px;
   }
   backface-visibility: hidden;
 }

--- a/src/components/UI/EmptyState.vue
+++ b/src/components/UI/EmptyState.vue
@@ -1,27 +1,23 @@
 <template>
-  <div :class="$style.container" :style="containerStyle">
+  <div :class="$style.container">
     <slot></slot>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api'
-import { makeStyles } from '@/lib/styles'
 
 export default defineComponent({
   name: 'EmptyState',
   setup() {
-    return {
-      containerStyle: makeStyles(theme => ({
-        color: theme.ui.tertiary
-      }))
-    }
+    return {}
   }
 })
 </script>
 
 <style lang="scss" module>
 .container {
+  @include color-ui-tertiary;
   display: flex;
   justify-content: center;
   width: 100%;

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -157,6 +157,9 @@
     padding: 2px 6px;
     margin: 2px 0;
   }
+  s > code {
+    text-decoration: line-through;
+  }
   pre {
     position: relative;
     margin-top: 0;

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.container" :style="style.container">
+  <div :class="$style.container">
     <h1>
       Not Found
     </h1>
@@ -12,16 +12,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from '@vue/composition-api'
-import { makeStyles } from '@/lib/styles'
-
-const useStyle = () =>
-  reactive({
-    container: makeStyles(theme => ({
-      color: theme.ui.primary,
-      background: theme.background.primary
-    }))
-  })
+import { defineComponent } from '@vue/composition-api'
 
 export default defineComponent({
   name: 'NotFound',
@@ -30,15 +21,15 @@ export default defineComponent({
     routeParam: String
   },
   setup() {
-    return {
-      style: useStyle()
-    }
+    return {}
   }
 })
 </script>
 
 <style lang="scss" module>
 .container {
+  @include color-ui-primary;
+  @include background-primary;
   height: 100%;
   padding: 1rem;
 }


### PR DESCRIPTION
- インラインコードの打ち消し
![image](https://user-images.githubusercontent.com/49056869/81777371-a2760f80-952b-11ea-9f26-1ce763dd5c88.png)![image](https://user-images.githubusercontent.com/49056869/81777385-a9048700-952b-11ea-9322-4d3d45143091.png)

- Qallパネルでユーザー名を改行しないように
![image](https://user-images.githubusercontent.com/49056869/81777539-08629700-952c-11ea-92ab-75ae337a6e06.png)![image](https://user-images.githubusercontent.com/49056869/81777570-144e5900-952c-11ea-809d-438fd9d0f98c.png)

- DesktopNavigationにtraQロゴを表示
![image](https://user-images.githubusercontent.com/49056869/81777583-1e705780-952c-11ea-91ef-917ec921c86d.png)

- 画面縦幅が狭いときDesktopNavigationSelectorの一部が隠れる fix #650
![image](https://user-images.githubusercontent.com/49056869/81777648-45c72480-952c-11ea-926b-a09045700d8a.png)![image](https://user-images.githubusercontent.com/49056869/81777665-4bbd0580-952c-11ea-8a13-a55d0d9b9b0e.png)

- 横幅がぎりぎりDesktopのときに表示が崩れてた
![image](https://user-images.githubusercontent.com/49056869/81777813-99d20900-952c-11ea-91c2-425d0d78f456.png)
![image](https://user-images.githubusercontent.com/49056869/81777804-9474be80-952c-11ea-98db-fba350b0b1cc.png)

![image](https://user-images.githubusercontent.com/49056869/81777991-f2a1a180-952c-11ea-9137-a0afb4002ab1.png)
![image](https://user-images.githubusercontent.com/49056869/81778014-f9301900-952c-11ea-8451-8023879d61e2.png)

これでも崩れてるんですがまだピン留めが閉じられるので…(下はピン留めアイコンがつぶれてた+文字が縦に飛び出ることがあったのを修正してます)

- ピン止めの表示をnameからdisplay_nameに
![image](https://user-images.githubusercontent.com/49056869/81777955-e0bffe80-952c-11ea-8231-37cf7da942fb.png)
![image](https://user-images.githubusercontent.com/49056869/81777963-e4538580-952c-11ea-8481-49f4bd5f7461.png)

- 画面縦幅が狭いときスクロールできなくてOAuthの認可ボタンが押せない refs #650
![image](https://user-images.githubusercontent.com/49056869/81778182-4b713a00-952d-11ea-9af1-f259832f9e2f.png)
![image](https://user-images.githubusercontent.com/49056869/81778193-4f9d5780-952d-11ea-8912-a5c4c3267716.png)

- OAuth認可のクライアント名が飛び出てた
![image](https://user-images.githubusercontent.com/49056869/81778252-6d6abc80-952d-11ea-8d12-c92521665116.png)
![image](https://user-images.githubusercontent.com/49056869/81778267-7491ca80-952d-11ea-9cfb-41a4a40992ac.png)

- OAuth認可のボタンがつぶれることがあった refs #384
![image](https://user-images.githubusercontent.com/49056869/81778344-a30fa580-952d-11ea-80ba-1d43bd21eaff.png)
![image](https://user-images.githubusercontent.com/49056869/81778355-a99e1d00-952d-11ea-8f09-b8dca24572bc.png)

- Navigationの余白の調整
![image](https://user-images.githubusercontent.com/49056869/81781015-714d0d80-9532-11ea-99cb-7d973746690a.png)
![image](https://user-images.githubusercontent.com/49056869/81780976-5ed2d400-9532-11ea-9ae7-8d4fd6d06406.png)

- メッセージヘッダーの省略をいい感じに
![image](https://user-images.githubusercontent.com/49056869/81892789-f42fa000-95e6-11ea-9cda-c00d5e9dd1d8.png)![image](https://user-images.githubusercontent.com/49056869/81892859-1a554000-95e7-11ea-9b77-49239a3d9b52.png)![image](https://user-images.githubusercontent.com/49056869/81892894-348f1e00-95e7-11ea-8f7a-169c2a4e64c7.png)

![image](https://user-images.githubusercontent.com/49056869/81892824-07427000-95e7-11ea-913e-f316914aebd3.png)![image](https://user-images.githubusercontent.com/49056869/81892884-2b05b600-95e7-11ea-9421-c6e739323921.png)![image](https://user-images.githubusercontent.com/49056869/81892908-3ce75900-95e7-11ea-8c8d-f59bcc1e17b4.png)

- 残ってたCSS変数化

よろしくお願いします
