### PR TITLE
スタンプピッカーを編集で使える&カーソル位置でのスタンプの挿入

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageEditor.vue
+++ b/src/components/Main/MainView/MessageElement/MessageEditor.vue
@@ -3,6 +3,7 @@
     <message-input-key-guide :show="textState.isModifierKeyPressed" />
     <div :class="$style.inputContainer">
       <message-input-text-area
+        ref="textareaRef"
         :class="$style.inputTextArea"
         :text="textState.text"
         @input="onInputText"
@@ -25,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent, ref } from '@vue/composition-api'
 import apis from '@/lib/apis'
 import store from '@/store'
 import MessageInputKeyGuide from '@/components/Main/MainView/MessageInput/MessageInputKeyGuide.vue'
@@ -69,7 +70,7 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props) {
+  setup(props, context) {
     const {
       textState,
       onInputText,
@@ -78,9 +79,12 @@ export default defineComponent({
     } = useTextInput(props.rawContent)
     const { editMessage, cancel } = useEditMessage(props, textState)
 
+    const textareaRef = ref<{ $el: HTMLTextAreaElement }>()
     const { invokeStampPicker } = useTextStampPickerInvoker(
       targetPortalName,
-      textState
+      textState,
+      textareaRef,
+      context
     )
 
     const onStampClick = (e: MouseEvent) => {
@@ -92,6 +96,7 @@ export default defineComponent({
     }
 
     return {
+      textareaRef,
       editMessage,
       cancel,
       textState,

--- a/src/components/Main/MainView/MessageElement/MessageEditor.vue
+++ b/src/components/Main/MainView/MessageElement/MessageEditor.vue
@@ -1,5 +1,6 @@
 <template>
-  <div>
+  <div :class="$style.container">
+    <message-input-key-guide :show="textState.isModifierKeyPressed" />
     <div :class="$style.inputContainer">
       <message-input-text-area
         :class="$style.inputTextArea"
@@ -27,6 +28,7 @@
 import { defineComponent } from '@vue/composition-api'
 import apis from '@/lib/apis'
 import store from '@/store'
+import MessageInputKeyGuide from '@/components/Main/MainView/MessageInput/MessageInputKeyGuide.vue'
 import MessageInputTextArea from '@/components/Main/MainView/MessageInput/MessageInputTextArea.vue'
 import useTextInput, {
   TextState
@@ -52,6 +54,7 @@ const useEditMessage = (props: { messageId: string }, textState: TextState) => {
 export default defineComponent({
   name: 'MessageEditor',
   components: {
+    MessageInputKeyGuide,
     MessageInputTextArea,
     FormButton,
     Icon
@@ -103,6 +106,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
+.container {
+  position: relative;
+}
 .inputContainer {
   @include background-secondary;
   width: 100%;

--- a/src/components/Main/MainView/MessageElement/MessageEditor.vue
+++ b/src/components/Main/MainView/MessageElement/MessageEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="$style.container">
-    <message-input-key-guide :show="textState.isModifierKeyPressed" />
+    <message-input-key-guide :show="textState.isModifierKeyPressed" is-edit />
     <div :class="$style.inputContainer">
       <message-input-text-area
         ref="textareaRef"
@@ -134,6 +134,7 @@ export default defineComponent({
 }
 .stampButton {
   @include color-ui-secondary;
+  margin: 0 4px;
   cursor: pointer;
 }
 .controls {

--- a/src/components/Main/MainView/MessageElement/MessageEditor.vue
+++ b/src/components/Main/MainView/MessageElement/MessageEditor.vue
@@ -1,13 +1,21 @@
 <template>
   <div>
-    <message-input-text-area
-      :class="$style.inputTextArea"
-      :text="textState.text"
-      @input="onInputText"
-      @modifier-key-down="onModifierKeyDown"
-      @modifier-key-up="onModifierKeyUp"
-      @post-message="editMessage"
-    />
+    <div :class="$style.inputContainer">
+      <message-input-text-area
+        :class="$style.inputTextArea"
+        :text="textState.text"
+        @input="onInputText"
+        @modifier-key-down="onModifierKeyDown"
+        @modifier-key-up="onModifierKeyUp"
+        @post-message="editMessage"
+      />
+      <icon
+        :class="$style.stampButton"
+        name="emoticon-outline"
+        mdi
+        @click="onStampClick"
+      />
+    </div>
     <div :class="$style.controls">
       <form-button @click="cancel" label="キャンセル" />
       <form-button @click="editMessage" label="OK" />
@@ -23,7 +31,10 @@ import MessageInputTextArea from '@/components/Main/MainView/MessageInput/Messag
 import useTextInput, {
   TextState
 } from '@/components/Main/MainView/MessageInput/use/textInput'
+import useTextStampPickerInvoker from '../use/textStampPickerInvoker'
 import FormButton from '@/components/UI/FormButton.vue'
+import { targetPortalName } from '@/views/Main.vue'
+import Icon from '@/components/UI/Icon.vue'
 
 const useEditMessage = (props: { messageId: string }, textState: TextState) => {
   const editMessage = async () => {
@@ -42,7 +53,8 @@ export default defineComponent({
   name: 'MessageEditor',
   components: {
     MessageInputTextArea,
-    FormButton
+    FormButton,
+    Icon
   },
   props: {
     rawContent: {
@@ -62,24 +74,56 @@ export default defineComponent({
       onModifierKeyUp
     } = useTextInput(props.rawContent)
     const { editMessage, cancel } = useEditMessage(props, textState)
+
+    const { invokeStampPicker } = useTextStampPickerInvoker(
+      targetPortalName,
+      textState
+    )
+
+    const onStampClick = (e: MouseEvent) => {
+      if (store.getters.ui.stampPicker.isStampPickerShown) {
+        store.dispatch.ui.stampPicker.closeStampPicker()
+      } else {
+        invokeStampPicker({ x: e.pageX, y: e.pageY })
+      }
+    }
+
     return {
       editMessage,
       cancel,
       textState,
       onInputText,
       onModifierKeyDown,
-      onModifierKeyUp
+      onModifierKeyUp,
+      targetPortalName,
+      onStampClick
     }
   }
 })
 </script>
 
 <style lang="scss" module>
-.inputTextArea {
+.inputContainer {
   @include background-secondary;
-  padding: 8px 12px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  margin: 8px 0;
+  padding: 8px;
   border-radius: 4px;
+  justify-content: space-between;
+
+  .container[data-is-mobile='true'] & {
+    padding: 4px 0;
+  }
+}
+.inputTextArea {
+  margin: 0 4px;
   overflow: hidden;
+}
+.stampButton {
+  @include color-ui-secondary;
+  cursor: pointer;
 }
 .controls {
   display: grid;

--- a/src/components/Main/MainView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MainView/MessageElement/MessageElement.vue
@@ -16,7 +16,7 @@
       :class="$style.pinned"
     />
     <message-tools
-      v-if="isHovered"
+      v-if="isHovered && !state.isEditing"
       :class="$style.tools"
       :message-id="messageId"
     />

--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -40,8 +40,8 @@ import {
 } from '@vue/composition-api'
 import store from '@/store'
 import { ChannelId, DMChannelId } from '@/types/entity-ids'
-import useStampPickerInvoker from '@/use/stampPickerInvoker'
 import useIsMobile from '@/use/isMobile'
+import useTextStampPickerInvoker from '../use/textStampPickerInvoker'
 import useAttachments from './use/attachments'
 import useTextInput from './use/textInput'
 import usePostMessage from './use/postMessage'
@@ -108,19 +108,9 @@ export default defineComponent({
     )
 
     const targetPortalName = 'message-input-stamp-picker'
-    const { invokeStampPicker } = useStampPickerInvoker(
+    const { invokeStampPicker } = useTextStampPickerInvoker(
       targetPortalName,
-      stampData => {
-        // TODO: 編集でも使うのでロジックを分離
-        const stampName = store.state.entities.stamps[stampData.id]?.name
-        if (!stampName) return
-        const size = stampData.size ? `.${stampData.size}` : ''
-        const effects =
-          stampData.effects && stampData.effects.length > 0
-            ? `.${stampData.effects.join('.')}`
-            : ''
-        textState.text += `:${stampName}${size}${effects}:`
-      }
+      textState
     )
 
     const onStampClick = () => {

--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -13,6 +13,7 @@
         @click="addAttachment"
       />
       <message-input-text-area
+        ref="textareaRef"
         :text="textState.text"
         @focus="onFocus"
         @blur="onBlur"
@@ -36,7 +37,8 @@ import {
   defineComponent,
   PropType,
   computed,
-  onBeforeUnmount
+  onBeforeUnmount,
+  ref
 } from '@vue/composition-api'
 import store from '@/store'
 import { ChannelId, DMChannelId } from '@/types/entity-ids'
@@ -107,10 +109,13 @@ export default defineComponent({
           canPostMessage.value)
     )
 
+    const textareaRef = ref<{ $el: HTMLTextAreaElement }>()
     const targetPortalName = 'message-input-stamp-picker'
     const { invokeStampPicker } = useTextStampPickerInvoker(
       targetPortalName,
-      textState
+      textState,
+      textareaRef,
+      context
     )
 
     const onStampClick = () => {
@@ -122,6 +127,7 @@ export default defineComponent({
     }
 
     return {
+      textareaRef,
       targetPortalName,
       isMobile,
       typingUsers,

--- a/src/components/Main/MainView/MessageInput/MessageInputKeyGuide.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputKeyGuide.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="show" :class="$style.container">
-    + Enterを押して{{ sendWithModifierKey === 'modifier' ? '送信' : '改行' }}
+    + Enterを押して{{ sendWithModifierKey === 'modifier' ? sendText : '改行' }}
   </div>
 </template>
 
@@ -14,14 +14,19 @@ export default defineComponent({
     show: {
       type: Boolean,
       required: true
+    },
+    isEdit: {
+      type: Boolean,
+      default: false
     }
   },
-  setup() {
+  setup(props) {
     const sendWithModifierKey = computed(
       () => store.state.app.browserSettings.sendWithModifierKey
     )
+    const sendText = computed(() => (props.isEdit ? '保存' : '送信'))
 
-    return { sendWithModifierKey }
+    return { sendWithModifierKey, sendText }
   }
 })
 </script>

--- a/src/components/Main/MainView/use/textStampPickerInvoker.ts
+++ b/src/components/Main/MainView/use/textStampPickerInvoker.ts
@@ -1,0 +1,25 @@
+import useStampPickerInvoker from '@/use/stampPickerInvoker'
+import store from '@/store'
+
+const useTextStampPickerInvoker = (
+  targetPortalName: string,
+  textState: { text: string }
+) => {
+  const { invokeStampPicker } = useStampPickerInvoker(
+    targetPortalName,
+    stampData => {
+      const stampName = store.state.entities.stamps[stampData.id]?.name
+      if (!stampName) return
+      const size = stampData.size ? `.${stampData.size}` : ''
+      const effects =
+        stampData.effects && stampData.effects.length > 0
+          ? `.${stampData.effects.join('.')}`
+          : ''
+      textState.text += `:${stampName}${size}${effects}:`
+    }
+  )
+
+  return { invokeStampPicker }
+}
+
+export default useTextStampPickerInvoker


### PR DESCRIPTION
- スタンプピッカーを編集で使えるように close #628
![image](https://user-images.githubusercontent.com/49056869/82922080-1c8aa780-9fb4-11ea-8743-2c6711ebe666.png)
Rの同じボタンが状態によって別の挙動するのはわかりにくいと思ったので、編集中はツールボックス出ないようにして右上にスタンプピッカーボタン入れたんですが、これもこれで微妙みがあってどうしましょうってなってます

- キーガイドを編集でも出すように
![image](https://user-images.githubusercontent.com/49056869/82922367-78edc700-9fb4-11ea-89c7-36ff14ee6b94.png)

- スタンプピッカーでカーソルの位置にスタンプを挿入するように close #630
投稿でも編集でも動作します

よろしくお願いします
