### PR TITLE
z-indexの修正

### DIFF
--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -179,6 +179,7 @@ $radius: 4px;
 
   border-radius: $radius;
   transform: translateY(-$radius);
+  z-index: $z-index-message-input;
 }
 .stampPickerLocator {
   width: 100%;

--- a/src/styles/_z-index.scss
+++ b/src/styles/_z-index.scss
@@ -12,11 +12,12 @@ $z-index-message-input: 10;
 $z-index-stamp-picker: 100;
 $z-index-header-tools: 100;
 
-$z-index-toast-container: 500;
-$z-index-file-upload-overlay: 510;
+$z-index-file-upload-overlay: 500;
 $z-index-services: 600;
 
 $z-index-modal-container: 1000;
 $z-index-file-modal-header: 1001;
 $z-index-file-modal-footer: 1001;
 $z-index-user-modal-header: 1001;
+
+$z-index-toast-container: 10000;

--- a/src/styles/_z-index.scss
+++ b/src/styles/_z-index.scss
@@ -7,6 +7,8 @@ $z-index-message-input-file-close-button: 1;
 $z-index-message-element-tools: 3;
 $z-index-message-element-tools-menu: 5;
 
+$z-index-message-input: 10;
+
 $z-index-stamp-picker: 100;
 $z-index-header-tools: 100;
 


### PR DESCRIPTION
- チャンネル閲覧者よりも入力欄が前にくるように
![image](https://user-images.githubusercontent.com/49056869/83222687-e0259a00-a1b3-11ea-834c-28e2869fe4c6.png)
スマホでIME？入力欄？が出ることで縦幅小さくなった時に送信ボタンに被っていちいち閉じないといけなかったみたいなので

- 設定モーダルでのトーストが見えなかった
![image](https://user-images.githubusercontent.com/49056869/83222666-d1d77e00-a1b3-11ea-84d0-5f243a2c93ab.png)

よろしくお願いします
