### PR TITLE
初回ロード時にスクロール位置がずれることがあった

### DIFF
--- a/src/components/Main/MainView/MessageElement/use/elementRenderObserver.ts
+++ b/src/components/Main/MainView/MessageElement/use/elementRenderObserver.ts
@@ -51,8 +51,7 @@ const useElementRenderObserver = (
   })
   const stop = watchEffect(async () => {
     if (
-      (props.isEntryMessage ||
-        (state.content.length > 0 && embeddingsState.fileIds.length > 0)) &&
+      (props.isEntryMessage || embeddingsState.fileIds.length > 0) &&
       bodyRef.value
     ) {
       // 添付ファイルがある場合か、エントリーメッセージは高さ監視をする


### PR DESCRIPTION
元々添付ファイルだけの場合でも改行が含まれていたけど、今は文字列が空である場合もありうるため

refs #700 