### PR TITLE
setupでcontextを返していたため重かった

### DIFF
--- a/src/components/Authenticate/AuthenticateButtonPrimary.vue
+++ b/src/components/Authenticate/AuthenticateButtonPrimary.vue
@@ -1,9 +1,5 @@
 <template>
-  <button
-    :class="$style.container"
-    :disabled="disabled"
-    @click="context.emit('click')"
-  >
+  <button :class="$style.container" :disabled="disabled" @click="emit('click')">
     {{ label }}
   </button>
 </template>
@@ -23,8 +19,8 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
-    return { context }
+  setup(props, { emit }) {
+    return { emit }
   }
 })
 </script>

--- a/src/components/Authenticate/AuthenticateButtonSecondary.vue
+++ b/src/components/Authenticate/AuthenticateButtonSecondary.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :class="$style.container" @click="context.emit('click')">
+  <button :class="$style.container" @click="emit('click')">
     <icon
       v-if="iconName"
       :class="$style.icon"
@@ -24,8 +24,8 @@ export default defineComponent({
     iconName: String,
     iconMdi: { type: Boolean, default: false }
   },
-  setup(props, context) {
-    return { context }
+  setup(props, { emit }) {
+    return { emit }
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarContent.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarContent.vue
@@ -15,7 +15,7 @@
     />
     <channel-sidebar-pinned
       :pinned-message-length="pinnedMessagesCount"
-      @open="context.emit('pinned-mode-toggle')"
+      @open="emit('pinned-mode-toggle')"
       :class="$style.sidebarItem"
     />
     <channel-sidebar-relation
@@ -73,8 +73,8 @@ export default defineComponent({
     ChannelSidebarQall,
     ChannelSidebarBots
   },
-  setup(_, context) {
-    return { context }
+  setup(_, { emit }) {
+    return { emit }
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelView/HeaderToolsList.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderToolsList.vue
@@ -3,7 +3,7 @@
     <template v-if="!isMobile">
       <header-tools-item
         v-if="isQallEnabled"
-        @click="context.emit('click-qall')"
+        @click="emit('click-qall')"
         icon-mdi
         :icon-name="qallIconName"
         :class="$style.qallIcon"
@@ -51,7 +51,7 @@
     </template>
     <header-tools-item
       v-if="isStared"
-      @click="context.emit('unstar-channel')"
+      @click="emit('unstar-channel')"
       :class="$style.starIcon"
       data-is-stared
       icon-name="star"
@@ -59,14 +59,14 @@
     />
     <header-tools-item
       v-else
-      @click="context.emit('star-channel')"
+      @click="emit('star-channel')"
       :class="$style.starIcon"
       icon-name="star-outline"
       tooltip="お気に入りに追加する"
     />
     <!--
     <header-tools-item
-      @click="context.emit('click-pin')"
+      @click="emit('click-pin')"
       :class="$style.icon"
       icon-mdi
       icon-name="pin"
@@ -75,7 +75,7 @@
     <div :class="$style.moreButton">
       <portal-target :class="$style.popupLocator" :name="targetPortalName" />
       <header-tools-item
-        @click="context.emit('click-more')"
+        @click="emit('click-more')"
         :class="$style.icon"
         icon-mdi
         icon-name="dots-horizontal"
@@ -85,7 +85,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, SetupContext, computed } from '@vue/composition-api'
+import { defineComponent, computed } from '@vue/composition-api'
 import useChannelSubscriptionState from '@/use/channelSubscriptionState'
 import HeaderToolsItem from '@/components/Main/MainView/MainViewHeader/MainViewHeaderToolsItem.vue'
 import store from '@/store'
@@ -106,7 +106,7 @@ export default defineComponent({
     isQallSessionOpened: { type: Boolean, default: false },
     isJoinedQallSession: { type: Boolean, default: false }
   },
-  setup(props, context: SetupContext) {
+  setup(props, { emit }) {
     const {
       changeToNextSubscriptionLevel,
       currentChannelSubscription
@@ -122,7 +122,7 @@ export default defineComponent({
 
     return {
       qallIconName,
-      context,
+      emit,
       currentChannelSubscription,
       changeToNextSubscriptionLevel,
       targetPortalName,

--- a/src/components/Main/MainView/ChannelView/HeaderToolsMenu.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderToolsMenu.vue
@@ -2,7 +2,7 @@
   <main-view-header-popup-frame>
     <header-tools-menu-item
       v-if="isMobile"
-      @click.native="context.emit('click-qall')"
+      @click.native="emit('click-qall')"
       icon-name="phone"
       icon-mdi
       :class="$style.qallIcon"
@@ -11,25 +11,25 @@
       :data-is-active="isJoinedQallSession || isQallSessionOpened"
     />
     <header-tools-menu-item
-      @click.native="context.emit('click-create-channel')"
+      @click.native="emit('click-create-channel')"
       icon-name="hash"
       label="子チャンネルを作成"
     />
     <header-tools-menu-item
       v-if="showNotificationSettingBtn"
-      @click.native="context.emit('click-notification')"
+      @click.native="emit('click-notification')"
       icon-name="notified"
       label="通知設定"
     />
     <header-tools-menu-item
-      @click.native="context.emit('click-copy-channel-link')"
+      @click.native="emit('click-copy-channel-link')"
       icon-name="link"
       icon-mdi
       label="チャンネルリンクをコピー"
     />
     <header-tools-menu-item
       v-if="hasChannelEditPermission"
-      @click.native="context.emit('click-manage-channel')"
+      @click.native="emit('click-manage-channel')"
       icon-name="hash"
       :class="$style.manageChannel"
       label="チャンネル管理"
@@ -57,7 +57,7 @@ export default defineComponent({
     isQallSessionOpened: { type: Boolean, default: false },
     isJoinedQallSession: { type: Boolean, default: false }
   },
-  setup(props, context) {
+  setup(props, { emit }) {
     const { isMobile } = useIsMobile()
     const qallLabel = computed(() => {
       if (props.isJoinedQallSession) {
@@ -76,7 +76,7 @@ export default defineComponent({
         UserPermission.EditChannel
       )
     )
-    return { context, isMobile, qallLabel, hasChannelEditPermission }
+    return { emit, isMobile, qallLabel, hasChannelEditPermission }
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageInput/MessageInputFileListItemCloseButton.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileListItemCloseButton.vue
@@ -1,12 +1,12 @@
 <template>
-  <button @click="context.emit('click')" :class="$style.container">
+  <button @click="emit('click')" :class="$style.container">
     <icon mdi name="close" :size="12" :class="$style.icon" />
     <div role="presentation" :class="$style.bg"></div>
   </button>
 </template>
 
 <script lang="ts">
-import { defineComponent, SetupContext } from '@vue/composition-api'
+import { defineComponent } from '@vue/composition-api'
 import Icon from '@/components/UI/Icon.vue'
 
 export default defineComponent({
@@ -14,8 +14,8 @@ export default defineComponent({
   components: {
     Icon
   },
-  setup(_, context: SetupContext) {
-    return { context }
+  setup(_, { emit }) {
+    return { emit }
   }
 })
 </script>

--- a/src/components/Main/Navigation/ChannelList/ChannelFilter.vue
+++ b/src/components/Main/Navigation/ChannelList/ChannelFilter.vue
@@ -6,7 +6,7 @@
     <button
       :class="$style.star"
       :aria-selected="isStared ? 'true' : 'false'"
-      @click="context.emit('toggle-star-filter')"
+      @click="emit('toggle-star-filter')"
     >
       <icon :class="$style.icon" name="star" :width="22" :height="22" mdi />
     </button>
@@ -34,12 +34,12 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
+  setup(props, { emit }) {
     const onInput = (value: string) => {
-      context.emit('input', value)
+      emit('input', value)
     }
     return {
-      context,
+      emit,
       onInput
     }
   }

--- a/src/components/Main/StampPicker/StampPickerEffectToggleButton.vue
+++ b/src/components/Main/StampPicker/StampPickerEffectToggleButton.vue
@@ -2,7 +2,7 @@
   <button
     :class="$style.container"
     :aria-selected="isActive"
-    @click="context.emit('click')"
+    @click="emit('click')"
   >
     <icon name="effect" />
   </button>
@@ -20,8 +20,8 @@ export default defineComponent({
   props: {
     isActive: { type: Boolean, default: false }
   },
-  setup(_, context) {
-    return { context }
+  setup(_, { emit }) {
+    return { emit }
   }
 })
 </script>

--- a/src/components/Main/StampPicker/StampPickerStampSetSelectorItem.vue
+++ b/src/components/Main/StampPicker/StampPickerStampSetSelectorItem.vue
@@ -2,7 +2,7 @@
   <div
     :class="$style.container"
     :aria-selected="isActive"
-    @click="context.emit('click')"
+    @click="emit('click')"
   >
     <div v-if="isActive" :class="$style.indicator"></div>
     <stamp
@@ -62,9 +62,9 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
+  setup(props, { emit }) {
     const { pickThumbnail } = useStampPaletteThumbnail()
-    return { context, pickThumbnail }
+    return { pickThumbnail, emit }
   }
 })
 </script>

--- a/src/components/UI/FormButton.vue
+++ b/src/components/UI/FormButton.vue
@@ -2,7 +2,7 @@
   <button
     :class="$style.container"
     :disabled="disabled"
-    @click="context.emit('click')"
+    @click="emit('click')"
     :data-color="color"
   >
     {{ label }}
@@ -28,8 +28,8 @@ export default defineComponent({
       default: 'primary' as const
     }
   },
-  setup(_, context) {
-    return { context }
+  setup(_, { emit }) {
+    return { emit }
   }
 })
 </script>

--- a/src/components/UI/Icon.vue
+++ b/src/components/UI/Icon.vue
@@ -4,8 +4,8 @@
     :width="size"
     :height="size"
     viewBox="0 0 24 24"
-    v-bind="context.attrs"
-    v-on="context.listeners"
+    v-bind="attrs"
+    v-on="listeners"
     role="img"
     :class="$style.icon"
   >
@@ -17,8 +17,8 @@
     :width="size"
     :height="size"
     view-box="0 0 24 24"
-    v-bind="context.attrs"
-    v-on="context.listeners"
+    v-bind="attrs"
+    v-on="listeners"
     role="img"
     :class="$style.icon"
   />
@@ -46,7 +46,7 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
+  setup(props, { attrs, listeners }) {
     // ここでnameを束縛することでcomputed内で戻り値の関数がprops.nameに依存していることが伝わる？
     const getComponent = (name: string) => () =>
       import(`@/assets/icons/${name}.svg?component`)
@@ -56,11 +56,7 @@ export default defineComponent({
       return mdi[name]
     }
 
-    return {
-      context,
-      svgComponent,
-      getMdiPath
-    }
+    return { svgComponent, getMdiPath, attrs, listeners }
   }
 })
 </script>


### PR DESCRIPTION
`composition-api`は`setup`内で返したオブジェクトをクローンするような挙動をするので(するようになったので)
https://github.com/vuejs/composition-api/blob/4a9cf520b064eeaa75e978cf01c8837b8e5c031c/src/reactivity/unwrap.ts#L5
でかいオブジェクトを渡してそれを何十個もつくると重くなる

contextはでかくてよく使われてたのでとりあえずこれをスリムにした
