### PR TITLE
キャッシュとか読み込みファイル分割とか

### DIFF
--- a/src/components/Main/Modal/FileModal/FileModal.vue
+++ b/src/components/Main/Modal/FileModal/FileModal.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent, computed, reactive } from '@vue/composition-api'
 import useFileMeta from '@/use/fileMeta'
 import store from '@/store'
 import FileModalImage from '@/components/Main/Modal/FileModal/FileModalImage.vue'
@@ -25,13 +25,16 @@ export default defineComponent({
     FileModalAudio
   },
   props: {
-    fileId: {
+    id: {
       type: String,
       required: true
     }
   },
   setup(props, context) {
-    const { fileMeta, fileType } = useFileMeta(props, context)
+    const fileIdState = reactive({
+      fileId: computed(() => props.id)
+    })
+    const { fileMeta, fileType } = useFileMeta(fileIdState, context)
     const onClickOutSide = () => store.dispatch.ui.modal.clearModal()
     return { fileMeta, fileType, onClickOutSide }
   }

--- a/src/components/Main/Modal/GroupModal/GroupModal.vue
+++ b/src/components/Main/Modal/GroupModal/GroupModal.vue
@@ -28,13 +28,13 @@ export default defineComponent({
     UserListItem
   },
   props: {
-    groupId: {
+    id: {
       type: String,
       required: true
     }
   },
   setup(props) {
-    const group = computed(() => store.state.entities.userGroups[props.groupId])
+    const group = computed(() => store.state.entities.userGroups[props.id])
     const groupName = computed(() => group.value?.name)
     const groupMember = computed(
       () =>

--- a/src/components/Main/Modal/ModalContainer.vue
+++ b/src/components/Main/Modal/ModalContainer.vue
@@ -5,25 +5,17 @@
         :is="component"
         :id="
           modalState.current.type === 'user' ||
+          modalState.current.type === 'tag' ||
+          modalState.current.type === 'group' ||
+          modalState.current.type === 'file' ||
           modalState.current.type === 'channel-manage'
             ? modalState.current.id
             : undefined
-        "
-        :group-id="
-          modalState.current.type === 'group'
-            ? modalState.current.id
-            : undefined
-        "
-        :tag-id="
-          modalState.current.type === 'tag' ? modalState.current.id : undefined
         "
         :parent-channel-id="
           modalState.current.type === 'channel-create'
             ? modalState.current.parentChannelId
             : undefined
-        "
-        :file-id="
-          modalState.current.type === 'file' ? modalState.current.id : undefined
         "
         :message-id="
           modalState.current.type === 'clip-create'

--- a/src/components/Main/Modal/ModalContainer.vue
+++ b/src/components/Main/Modal/ModalContainer.vue
@@ -1,41 +1,35 @@
 <template>
   <transition name="background-shadow">
     <div v-if="modalState.shouldShowModal" :class="$style.container">
-      <setting-modal v-if="modalState.current.type === 'setting'" />
-      <user-modal
-        v-else-if="modalState.current.type === 'user'"
-        :id="modalState.current.id"
-      />
-      <notification-modal
-        v-else-if="modalState.current.type === 'notification'"
-      />
-      <group-modal
-        v-else-if="modalState.current.type === 'group'"
-        :group-id="modalState.current.id"
-      />
-      <tag-modal
-        v-else-if="modalState.current.type === 'tag'"
-        :tag-id="modalState.current.id"
-      />
-      <channel-create-modal
-        v-else-if="modalState.current.type === 'channel-create'"
-        :parent-channel-id="modalState.current.parentChannelId"
-      />
-      <file-modal
-        v-else-if="modalState.current.type === 'file'"
-        :file-id="modalState.current.id"
-      />
-      <qr-code-modal v-else-if="modalState.current.type === 'qrcode'" />
-      <clip-create-modal
-        v-else-if="modalState.current.type === 'clip-create'"
-        :message-id="modalState.current.messageId"
-      />
-      <clip-folder-create-modal
-        v-else-if="modalState.current.type === 'clip-folder-create'"
-      />
-      <channel-manage-modal
-        v-else-if="modalState.current.type === 'channel-manage'"
-        :id="modalState.current.id"
+      <component
+        :is="component"
+        :id="
+          modalState.current.type === 'user' ||
+          modalState.current.type === 'channel-manage'
+            ? modalState.current.id
+            : undefined
+        "
+        :group-id="
+          modalState.current.type === 'group'
+            ? modalState.current.id
+            : undefined
+        "
+        :tag-id="
+          modalState.current.type === 'tag' ? modalState.current.id : undefined
+        "
+        :parent-channel-id="
+          modalState.current.type === 'channel-create'
+            ? modalState.current.parentChannelId
+            : undefined
+        "
+        :file-id="
+          modalState.current.type === 'file' ? modalState.current.id : undefined
+        "
+        :message-id="
+          modalState.current.type === 'clip-create'
+            ? modalState.current.messageId
+            : undefined
+        "
       />
     </div>
   </transition>
@@ -44,17 +38,21 @@
 <script lang="ts">
 import { defineComponent, computed, reactive } from '@vue/composition-api'
 import store from '@/store'
-import SettingModal from '@/components/Main/Modal/SettingModal/SettingModal.vue'
-import UserModal from '@/components/Main/Modal/UserModal/UserModal.vue'
-import NotificationModal from '@/components/Main/Modal/NotificationModal/NotificationModal.vue'
-import TagModal from '@/components/Main/Modal/TagModal/TagModal.vue'
-import GroupModal from '@/components/Main/Modal/GroupModal/GroupModal.vue'
-import ChannelCreateModal from '@/components/Main/Modal/ChannelCreateModal/ChannelCreateModal.vue'
-import FileModal from '@/components/Main/Modal/FileModal/FileModal.vue'
-import QrCodeModal from '@/components/Main/Modal/QRCodeModal/QRCodeModal.vue'
-import ClipCreateModal from '@/components/Main/Modal/ClipCreateModal/ClipCreateModal.vue'
-import ClipFolderCreateModal from '@/components/Main/Modal/ClipFolderCreateModal/ClipFolderCreateModal.vue'
-import ChannelManageModal from '@/components/Main/Modal/ChannelManageModal/ChannelManageModal.vue'
+import { ModalState } from '@/store/ui/modal/state'
+
+const modalComponentMap: Record<ModalState['type'], string> = {
+  setting: 'SettingModal/SettingModal',
+  user: 'UserModal/UserModal',
+  notification: 'Notification/NotificationModal',
+  tag: 'TagModal/TagModal',
+  group: 'GroupModal/GroupModal',
+  'channel-create': 'ChannelCreateModal/ChannelCreateModal',
+  file: 'FileModal/FileModal',
+  qrcode: 'QRCodeModal/QRCodeModal',
+  'clip-create': 'ClipCreateModal/ClipCreateModal',
+  'clip-folder-create': 'ClipFolderCreateModal/ClipFolderCreateModal',
+  'channel-manage': 'ChannelManageModal/ChannelManageModal'
+}
 
 const useModal = () => {
   const state = reactive({
@@ -82,22 +80,19 @@ export default defineComponent({
   name: 'ModalContainer',
   setup() {
     const { modalState } = useModal()
+
+    // ここでpathを束縛することでcomputed内で戻り値の関数がpathに依存していることが伝わる？
+    const getComponent = (path: string) => () =>
+      import(`@/components/Main/Modal/${path}.vue`)
+
+    const component = computed(() =>
+      getComponent(modalComponentMap[modalState.current.type])
+    )
+
     return {
-      modalState
+      modalState,
+      component
     }
-  },
-  components: {
-    SettingModal,
-    UserModal,
-    NotificationModal,
-    GroupModal,
-    TagModal,
-    ChannelCreateModal,
-    FileModal,
-    QrCodeModal,
-    ClipCreateModal,
-    ClipFolderCreateModal,
-    ChannelManageModal
   }
 })
 </script>

--- a/src/components/Main/Modal/TagModal/TagModal.vue
+++ b/src/components/Main/Modal/TagModal/TagModal.vue
@@ -29,14 +29,14 @@ export default defineComponent({
     UserListItem
   },
   props: {
-    tagId: {
+    id: {
       type: String,
       required: true
     }
   },
   setup(props) {
-    store.dispatch.entities.fetchTag(props.tagId)
-    const tag = computed(() => store.state.entities.tags[props.tagId])
+    store.dispatch.entities.fetchTag(props.id)
+    const tag = computed(() => store.state.entities.tags[props.id])
     const tagName = computed(() => tag.value?.tag)
     const taggedUsers = computed(
       () =>

--- a/src/store/entities/getters.ts
+++ b/src/store/entities/getters.ts
@@ -41,8 +41,14 @@ export const getters = defineGetters<S>()({
   userNameByDMChannelId(state): (id: DMChannelId) => string | undefined {
     return id => state.users[state.dmChannels[id].userId]?.name
   },
-  DMChannelIdByUserId(state): (id: UserId) => DMChannelId | undefined {
-    return id => Object.values(state.dmChannels).find(c => c.userId === id)?.id
+  DMChannelUserIdTable(state) {
+    return Object.fromEntries(
+      Object.values(state.dmChannels).map(c => [c.userId, c.id])
+    )
+  },
+  DMChannelIdByUserId(...args): (id: UserId) => DMChannelId | undefined {
+    const { getters } = entitiesGetterContext(args)
+    return id => getters.DMChannelUserIdTable[id]
   },
   userGroupByName(state): (name: string) => UserGroup | undefined {
     return name => {

--- a/src/store/entities/getters.ts
+++ b/src/store/entities/getters.ts
@@ -21,9 +21,14 @@ export const getters = defineGetters<S>()({
         userGroup.members?.some(member => member.id === userId)
       )?.name
   },
-  stampByName(state): (name: string) => Stamp | undefined {
-    return name =>
-      Object.values(state.stamps as StampMap).find(stamp => stamp.name === name)
+  stampNameTable(state) {
+    return Object.fromEntries(
+      Object.values(state.stamps as StampMap).map(stamp => [stamp.name, stamp])
+    )
+  },
+  stampByName(...args): (name: string) => Stamp | undefined {
+    const { getters } = entitiesGetterContext(args)
+    return name => getters.stampNameTable[name]
   },
   userByName(state): (name: string) => User | undefined {
     return name => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,7 +10,13 @@ module.exports = {
       scss: {
         prependData: '@import "src/styles/common.scss";'
       }
-    }
+    },
+    extract:
+      process.env.NODE_ENV === 'production'
+        ? {
+            ignoreOrder: true
+          }
+        : false
   },
 
   configureWebpack,


### PR DESCRIPTION
- モーダル周りの遅延ロード
  - 最初からロードする必要ないので
  - CSSの順序warningの無効化 => css modulesなのでしても問題ないはず
- スタンプ別名テーブルの別ファイル化
  - そんなに変わらないのでキャッシュを利くようにしたい
- スタンプのnameによるテーブルをキャッシュするように
  - よく呼び出されるので
- ユーザーIDによるDMチャンネルIDのテーブル
  - 割と呼び出されるので
- モーダルのpropsをリファクタ
