### PR TITLE
ユーザーモーダルのタグ/グループタブとタグ/グループモーダルのホバー表示

### DIFF
--- a/src/components/Main/Modal/Common/ModalHeader.vue
+++ b/src/components/Main/Modal/Common/ModalHeader.vue
@@ -45,6 +45,7 @@ export default defineComponent({
   @include color-ui-primary;
   padding-right: 4px;
   margin-left: -8px;
+  flex-shrink: 0;
 }
 .title {
   @include color-ui-primary;

--- a/src/components/Main/Modal/Common/UserListItem.vue
+++ b/src/components/Main/Modal/Common/UserListItem.vue
@@ -39,10 +39,24 @@ export default defineComponent({
 <style lang="scss" module>
 .container {
   @include color-ui-primary;
+  position: relative;
   display: flex;
   align-items: center;
+  padding: 4px;
   &[role='button'] {
     cursor: pointer;
+  }
+
+  &:hover::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: $theme-ui-primary;
+    opacity: 0.1;
   }
 }
 .icon {

--- a/src/components/Main/Modal/GroupModal/GroupModal.vue
+++ b/src/components/Main/Modal/GroupModal/GroupModal.vue
@@ -51,7 +51,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .item {
-  margin: 16px 0;
+  margin: 8px 0;
   &:first-child {
     margin-top: 0;
   }

--- a/src/components/Main/Modal/TagModal/TagModal.vue
+++ b/src/components/Main/Modal/TagModal/TagModal.vue
@@ -50,7 +50,7 @@ export default defineComponent({
 
 <style lang="scss" module>
 .item {
-  margin: 16px 0;
+  margin: 8px 0;
   &:first-child {
     margin-top: 0;
   }

--- a/src/components/Main/Modal/UserModal/GroupsTab.vue
+++ b/src/components/Main/Modal/UserModal/GroupsTab.vue
@@ -65,11 +65,25 @@ export default defineComponent({
 }
 
 .group {
-  margin: 16px 8px;
+  position: relative;
+  margin: 8px 4px;
+  padding: 4px;
   cursor: pointer;
   &:first-child {
     // ナビゲーションと頭を揃える
-    margin-top: 8px;
+    margin-top: 0;
+  }
+
+  &:hover::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: $theme-ui-primary;
+    opacity: 0.1;
   }
 }
 

--- a/src/components/Main/Modal/UserModal/TagsTab.vue
+++ b/src/components/Main/Modal/UserModal/TagsTab.vue
@@ -63,10 +63,10 @@ export default defineComponent({
 }
 
 .tag {
-  margin: 16px 8px;
+  margin: 8px 4px;
   &:first-child {
     // ナビゲーションと頭を揃える
-    margin-top: 8px;
+    margin-top: 0;
   }
 }
 </style>

--- a/src/components/Main/Modal/UserModal/TagsTabEdit.vue
+++ b/src/components/Main/Modal/UserModal/TagsTabEdit.vue
@@ -1,14 +1,20 @@
 <template>
   <div :class="$style.container">
-    <icon v-if="isLocked" name="lock" mdi :size="20" @click="toggleTagState" />
+    <icon
+      v-if="isLocked"
+      name="lock"
+      mdi
+      :size="20"
+      @click.stop="toggleTagState"
+    />
     <div v-else :class="$style.element">
-      <icon name="close" mdi :size="20" @click="removeTag" />
+      <icon name="close" mdi :size="20" @click.stop="removeTag" />
       <icon
         v-if="isMine"
         name="lock-open"
         mdi
         :size="20"
-        @click="toggleTagState"
+        @click.stop="toggleTagState"
         :class="$style.open"
       />
     </div>

--- a/src/components/Main/Modal/UserModal/TagsTabTag.vue
+++ b/src/components/Main/Modal/UserModal/TagsTabTag.vue
@@ -50,10 +50,24 @@ export default defineComponent({
 
 <style lang="scss" module>
 .tag {
+  position: relative;
   cursor: pointer;
   display: flex;
+  padding: 4px;
   justify-content: space-between;
   align-items: center;
+
+  &:hover::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: $theme-ui-primary;
+    opacity: 0.1;
+  }
 }
 
 .content {

--- a/src/components/Main/Modal/UserModal/TagsTabTag.vue
+++ b/src/components/Main/Modal/UserModal/TagsTabTag.vue
@@ -1,6 +1,6 @@
 <template>
-  <li :class="$style.tag">
-    <div @click="onTagClick" :class="$style.content">
+  <li :class="$style.tag" @click="onTagClick">
+    <div :class="$style.content">
       <icon name="tag" mdi :class="$style.icon" :size="20" />
       <div :class="$style.text">
         {{ tag.tag }}


### PR DESCRIPTION
 - ユーザーモーダルのタグタブの当たり判定の修正
![image](https://user-images.githubusercontent.com/49056869/86345805-fb923200-bc96-11ea-9b79-ad35449a0ca6.png)
このあたりに当たり判定を追加

- ユーザーモーダルのタグ/グループタブのホバー表示
![image](https://user-images.githubusercontent.com/49056869/86345863-11075c00-bc97-11ea-8674-3bfafd736019.png)

- タグ/グループモーダルの戻るボタンが小さく表示されていた
![image](https://user-images.githubusercontent.com/49056869/86346004-4318be00-bc97-11ea-8ecc-2f74dc21274c.png)
![image](https://user-images.githubusercontent.com/49056869/86345959-33997500-bc97-11ea-9b6f-be0361b6c16d.png)

- タグ/グループモーダルのホバー表示
![image](https://user-images.githubusercontent.com/49056869/86346040-5166da00-bc97-11ea-90c3-cafc25bcaa07.png)

refs #277 
close #1111 
