### PR TITLE
OGPのフルスクリーン許可とreferrer無効化

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageOgpEmbed.vue
+++ b/src/components/Main/MainView/MessageElement/MessageOgpEmbed.vue
@@ -4,6 +4,8 @@
       v-if="!previewUrl || isContentShown"
       :src="embeddedUrl"
       :class="$style.content"
+      allowfullscreen
+      allow="fullscreen; autoplay; encrypted-media; picture-in-picture"
     />
     <template v-else>
       <img :src="previewUrl" :class="$style.image" />

--- a/src/components/Main/MainView/MessageElement/MessageOgpEmbed.vue
+++ b/src/components/Main/MainView/MessageElement/MessageOgpEmbed.vue
@@ -6,6 +6,7 @@
       :class="$style.content"
       allowfullscreen
       allow="fullscreen; autoplay; encrypted-media; picture-in-picture"
+      referrerpolicy="no-referrer"
     />
     <template v-else>
       <img :src="previewUrl" :class="$style.image" />


### PR DESCRIPTION
- OGPのiframe
  - fullscreenの許可
  - picture-in-pictureの許可(youtubeもニコ動もボタンないけど…)
  - 自動再生の許可
  - Encrypted Media Extensionsの許可
  - referrerの無効化 (`<img>`が無効化されてたので)

よろしくお願いします
