### PR TITLE
マスターボリュームの挙動がおかしかった close #1356

### DIFF
--- a/src/components/Main/Modal/SettingModal/QallTab/QallTab.vue
+++ b/src/components/Main/Modal/SettingModal/QallTab/QallTab.vue
@@ -26,7 +26,7 @@
           max="1"
         />
         <div :class="$style.masterVolumeValue">
-          {{ Math.round(state.masterVolume * 100) }}%
+          {{ Math.round(state.masterVolume * 200) }}%
         </div>
       </div>
     </div>

--- a/src/store/app/rtcSettings/state.ts
+++ b/src/store/app/rtcSettings/state.ts
@@ -12,7 +12,7 @@ export interface S {
 
 export const state: S = {
   isEnabled: true,
-  masterVolume: 1,
+  masterVolume: 0.5,
   audioInputDeviceId: '',
   audioOutputDeviceId: '',
   isTtsEnabled: false,


### PR DESCRIPTION
マスターボリューム設定後に新しくQallに入ってくるユーザーの音にマスターボリュームが適用されなかったり、ユーザーの音量を変化させたときにマスターボリュームが適用されてなかったりしてたのを修正しました
あと、マスタボリュームを0～100%表示から0～200%表示にしました

デフォルト100%にしてますが、最初200%になってるかもしれないのと、音量が変わっているのでリリース時にアナウンスする必要があります

よろしくお願いします
