### PR TITLE
emitsの付与

### DIFF
--- a/src/components/Authenticate/AuthenticateButton.vue
+++ b/src/components/Authenticate/AuthenticateButton.vue
@@ -2,7 +2,6 @@
   <button
     :class="$style.container"
     :disabled="$boolAttr(disabled)"
-    @click="$emit('click')"
     :data-type="type"
   >
     <icon
@@ -26,6 +25,9 @@ export default defineComponent({
   components: {
     Icon
   },
+  emits: {
+    click: () => true
+  },
   props: {
     type: {
       type: String as PropType<Type>,
@@ -41,9 +43,6 @@ export default defineComponent({
       type: Boolean,
       default: false
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Authenticate/AuthenticateHeader.vue
+++ b/src/components/Authenticate/AuthenticateHeader.vue
@@ -15,9 +15,6 @@ export default defineComponent({
   name: 'AuthenticateHeader',
   props: {
     title: String
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Authenticate/AuthenticateInput.vue
+++ b/src/components/Authenticate/AuthenticateInput.vue
@@ -14,12 +14,15 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, SetupContext, PropType } from 'vue'
+import { defineComponent, PropType } from 'vue'
 import useInput from '@/use/input'
 import { randomString } from '@/lib/util/randomString'
 
 export default defineComponent({
   name: 'AuthenticateInput',
+  emits: {
+    inputValue: (value: string) => true
+  },
   props: {
     text: { type: String, default: '' },
     label: { type: String, default: '' },
@@ -33,7 +36,7 @@ export default defineComponent({
     },
     enterkeyhint: String
   },
-  setup(props, context: SetupContext) {
+  setup(props, context) {
     const { onInput } = useInput(context)
     const id = randomString()
     return { onInput, id }

--- a/src/components/Authenticate/AuthenticateMainView.vue
+++ b/src/components/Authenticate/AuthenticateMainView.vue
@@ -29,9 +29,6 @@ export default defineComponent({
       type: String as PropType<PageType>,
       default: 'login' as const
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Authenticate/AuthenticateModal.vue
+++ b/src/components/Authenticate/AuthenticateModal.vue
@@ -1,15 +1,12 @@
 <template>
-  <div :class="$style.container"><slot></slot></div>
+  <div :class="$style.container"><slot /></div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 
 export default defineComponent({
-  name: 'AuthenticateModal',
-  setup() {
-    return {}
-  }
+  name: 'AuthenticateModal'
 })
 </script>
 

--- a/src/components/Authenticate/AuthenticateSeparator.vue
+++ b/src/components/Authenticate/AuthenticateSeparator.vue
@@ -1,10 +1,10 @@
 <template>
   <div :class="$style.container">
-    <span :class="$style.hr"></span>
+    <span :class="$style.hr" />
     <span :class="$style.label">
       {{ label }}
     </span>
-    <span :class="$style.hr"></span>
+    <span :class="$style.hr" />
   </div>
 </template>
 
@@ -19,9 +19,6 @@ export default defineComponent({
       type: String,
       default: ''
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Authenticate/ConsentForm/ClientDescription.vue
+++ b/src/components/Authenticate/ConsentForm/ClientDescription.vue
@@ -39,9 +39,6 @@ export default defineComponent({
     },
     developer: Object as PropType<User>
   },
-  setup() {
-    return {}
-  },
   components: {
     UserIcon
   }

--- a/src/components/Authenticate/ConsentForm/ClientScopes.vue
+++ b/src/components/Authenticate/ConsentForm/ClientScopes.vue
@@ -27,9 +27,6 @@ export default defineComponent({
       type: Array as PropType<OAuth2Scope[]>,
       default: []
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Authenticate/ConsentForm/ConsentForm.vue
+++ b/src/components/Authenticate/ConsentForm/ConsentForm.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     ClientScopes,
     AuthenticateButton
   },
-  setup(_, context) {
+  setup() {
     const route = useRoute()
     const { scopes: rawScopes, client_id: rawClientId } = route.query
 

--- a/src/components/Authenticate/RegistrationForm.vue
+++ b/src/components/Authenticate/RegistrationForm.vue
@@ -48,7 +48,7 @@ export default defineComponent({
     AuthenticateHeader,
     AuthenticateButton
   },
-  setup(_, context) {
+  setup() {
     const { loginState, login, loginExternal, setName, setPass } = useLogin()
     return { loginState, setName, setPass, login, loginExternal }
   }

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarContent.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarContent.vue
@@ -15,7 +15,7 @@
     />
     <channel-sidebar-pinned
       :pinned-message-length="pinnedMessagesCount"
-      @open="emit('pinned-mode-toggle')"
+      @open="$emit('pinned-mode-toggle')"
       :class="$style.sidebarItem"
     />
     <channel-sidebar-relation
@@ -48,6 +48,9 @@ import { UserId, ChannelId } from '@/types/entity-ids'
 
 export default defineComponent({
   name: 'ChannelSidebarContent',
+  emits: {
+    pinnedModeToggle: () => true
+  },
   props: {
     channelId: { type: String as PropType<ChannelId>, requried: true },
     viewerIds: {
@@ -72,9 +75,6 @@ export default defineComponent({
     ChannelSidebarRelation,
     ChannelSidebarQall,
     ChannelSidebarBots
-  },
-  setup(_, { emit }) {
-    return { emit }
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeader.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeader.vue
@@ -25,6 +25,9 @@ import ChannelSidebarHeaderName from './ChannelSidebarHeaderName.vue'
 
 export default defineComponent({
   name: 'ChannelSidebarHeader',
+  emits: {
+    back: () => true
+  },
   props: {
     channelId: { type: String as PropType<ChannelId>, required: false },
     title: { type: String, default: 'チャンネル' },

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHeaderName.vue
@@ -13,9 +13,6 @@ export default defineComponent({
   props: {
     channelName: { type: String, required: true },
     showHash: { type: Boolean, default: false }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHidden.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarHidden.vue
@@ -26,6 +26,9 @@ import { UserId } from '@/types/entity-ids'
 
 export default defineComponent({
   name: 'ChannelSidebarHidden',
+  emits: {
+    open: () => true
+  },
   props: {
     viewerIds: { type: Array as PropType<UserId[]>, default: [] }
   },

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarMemberIcons.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarMemberIcons.vue
@@ -26,9 +26,6 @@ export default defineComponent({
   components: { UserIcon },
   props: {
     viewerStates: { type: Array as PropType<ViewState[]>, default: [] }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinned.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinned.vue
@@ -12,6 +12,7 @@ import SidebarContentContainerLink from '@/components/Main/MainView/MainViewSide
 
 export default defineComponent({
   name: 'ChannelSidebarPinned',
+  emits: { open: () => true },
   props: { pinnedMessageLength: { type: Number, default: 0 } },
   components: { SidebarContentContainerLink },
   setup(_, context) {

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedList.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarPinnedList.vue
@@ -26,7 +26,7 @@ export default defineComponent({
   props: {
     pinnedMessages: { type: Array as PropType<Pin[]>, default: [] }
   },
-  setup(props, context) {
+  setup(props) {
     const sortedMessages = computed(() =>
       [...props.pinnedMessages]
         .sort((a, b) => Date.parse(b.pinnedAt) - Date.parse(a.pinnedAt))

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelation.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelation.vue
@@ -11,7 +11,6 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
-
 import { ChannelId } from '@/types/entity-ids'
 import SidebarContentContainerFoldable from '@/components/Main/MainView/MainViewSidebar/SidebarContentContainerFoldable.vue'
 import ChannelSidebarRelationContent from './ChannelSidebarRelationContent.vue'

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarRelationElement.vue
@@ -24,9 +24,6 @@ export default defineComponent({
     topic: { type: String, default: '' },
     isCurrent: { type: Boolean, default: false },
     link: { type: String }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelSidebar/ChannelSidebarViewersDetail.vue
+++ b/src/components/Main/MainView/ChannelSidebar/ChannelSidebarViewersDetail.vue
@@ -18,6 +18,7 @@ import { isDefined } from '@/lib/util/array'
 export default defineComponent({
   name: 'ChannelSidebarViewerDetail',
   components: { UserIcon, SidebarContentContainer },
+  emits: { close: () => true },
   props: { viewerIds: { type: Array as PropType<UserId[]>, default: [] } },
   setup(props, context) {
     const closeDetail = () => {

--- a/src/components/Main/MainView/ChannelView/ChannelViewFileUploadOverlay.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelViewFileUploadOverlay.vue
@@ -13,10 +13,7 @@ import Icon from '@/components/UI/Icon.vue'
 
 export default defineComponent({
   name: 'ChannelViewFileUploadOverlay',
-  components: { Icon },
-  setup() {
-    return {}
-  }
+  components: { Icon }
 })
 </script>
 

--- a/src/components/Main/MainView/ChannelView/Header.vue
+++ b/src/components/Main/MainView/ChannelView/Header.vue
@@ -33,9 +33,6 @@ export default defineComponent({
       type: String as PropType<ChannelId>,
       required: true
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderChannelName.vue
@@ -31,16 +31,12 @@ import useChannelPath from '@/use/channelPath'
 import { constructChannelPath } from '@/router'
 import useIsMobile from '@/use/isMobile'
 
-type Props = {
-  channelId: ChannelId
-}
-
 type ChannelPathInfo = {
   name: string
   path: string[]
 }
 
-const usePathInfo = (props: Props) => {
+const usePathInfo = (props: { channelId: ChannelId }) => {
   const { channelIdToPath } = useChannelPath()
 
   /** 現在のチャンネルに至るまでのフルパスたち */

--- a/src/components/Main/MainView/ChannelView/HeaderToolsList.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderToolsList.vue
@@ -3,7 +3,7 @@
     <template v-if="!isMobile">
       <header-tools-item
         v-if="isQallEnabled"
-        @toggle="emit('click-qall')"
+        @toggle="$emit('click-qall')"
         icon-mdi
         :icon-name="qallIconName"
         :class="$style.qallIcon"
@@ -50,7 +50,7 @@
     </template>
     <header-tools-item
       v-if="isStared"
-      @toggle="emit('unstar-channel')"
+      @toggle="$emit('unstar-channel')"
       :class="$style.starIcon"
       data-is-stared
       icon-name="star"
@@ -58,7 +58,7 @@
     />
     <header-tools-item
       v-else
-      @toggle="emit('star-channel')"
+      @toggle="$emit('star-channel')"
       :class="$style.starIcon"
       icon-name="star-outline"
       tooltip="お気に入りに追加する"
@@ -74,7 +74,7 @@
     <div :class="$style.moreButton">
       <div :class="$style.popupLocator" :id="teleportTargetName" />
       <header-tools-item
-        @toggle="emit('click-more')"
+        @toggle="$emit('click-more')"
         :class="$style.icon"
         icon-mdi
         icon-name="dots-horizontal"
@@ -98,6 +98,12 @@ export default defineComponent({
   components: {
     HeaderToolsItem
   },
+  emits: {
+    'click-qall': () => true,
+    'unstar-channel': () => true,
+    'star-channel': () => true,
+    'click-more': () => true
+  },
   props: {
     isStared: { type: Boolean, default: false },
     isForcedChannel: { type: Boolean, default: false },
@@ -106,7 +112,7 @@ export default defineComponent({
     isJoinedQallSession: { type: Boolean, default: false },
     isArchived: { type: Boolean, default: false }
   },
-  setup(props, { emit }) {
+  setup(props) {
     const {
       changeToNextSubscriptionLevel,
       currentChannelSubscription
@@ -122,7 +128,6 @@ export default defineComponent({
 
     return {
       qallIconName,
-      emit,
       currentChannelSubscription,
       changeToNextSubscriptionLevel,
       teleportTargetName,

--- a/src/components/Main/MainView/ChannelView/HeaderToolsMenu.vue
+++ b/src/components/Main/MainView/ChannelView/HeaderToolsMenu.vue
@@ -2,7 +2,7 @@
   <main-view-header-popup-frame>
     <header-tools-menu-item
       v-if="isMobile"
-      @click="emit('click-qall')"
+      @click="$emit('click-qall')"
       icon-name="phone"
       icon-mdi
       :class="$style.qallIcon"
@@ -12,25 +12,25 @@
     />
     <header-tools-menu-item
       v-if="canCreateChildChannel"
-      @click="emit('click-create-channel')"
+      @click="$emit('click-create-channel')"
       icon-name="hash"
       label="子チャンネルを作成"
     />
     <header-tools-menu-item
       v-if="showNotificationSettingBtn"
-      @click="emit('click-notification')"
+      @click="$emit('click-notification')"
       icon-name="notified-or-subscribed"
       label="通知設定"
     />
     <header-tools-menu-item
-      @click="emit('click-copy-channel-link')"
+      @click="$emit('click-copy-channel-link')"
       icon-name="link"
       icon-mdi
       label="チャンネルリンクをコピー"
     />
     <header-tools-menu-item
       v-if="hasChannelEditPermission"
-      @click="emit('click-manage-channel')"
+      @click="$emit('click-manage-channel')"
       icon-name="hash"
       :class="$style.manageChannel"
       label="チャンネル管理"
@@ -52,6 +52,13 @@ export default defineComponent({
     MainViewHeaderPopupFrame,
     HeaderToolsMenuItem
   },
+  emits: {
+    'click-qall': () => true,
+    'click-create-channel': () => true,
+    'click-notification': () => true,
+    'click-copy-channel-link': () => true,
+    'click-manage-channel': () => true
+  },
   props: {
     showNotificationSettingBtn: { type: Boolean, default: true },
     hasActiveQallSession: { type: Boolean, default: false },
@@ -60,7 +67,7 @@ export default defineComponent({
     canCreateChildChannel: { type: Boolean, default: false },
     isArchived: { type: Boolean, default: false }
   },
-  setup(props, { emit }) {
+  setup(props) {
     const { isMobile } = useIsMobile()
     const qallLabel = computed(() => {
       if (props.isJoinedQallSession) {
@@ -79,7 +86,7 @@ export default defineComponent({
         UserPermission.EditChannel
       )
     )
-    return { emit, isMobile, qallLabel, hasChannelEditPermission }
+    return { isMobile, qallLabel, hasChannelEditPermission }
   }
 })
 </script>

--- a/src/components/Main/MainView/ClipsSidebar/ClipsSidebar.vue
+++ b/src/components/Main/MainView/ClipsSidebar/ClipsSidebar.vue
@@ -34,9 +34,7 @@ export default defineComponent({
   setup() {
     const { closeSidebar } = useSidebar()
 
-    return {
-      closeSidebar
-    }
+    return { closeSidebar }
   }
 })
 </script>

--- a/src/components/Main/MainView/ClipsView/ClipsView.vue
+++ b/src/components/Main/MainView/ClipsView/ClipsView.vue
@@ -11,12 +11,9 @@ import ClipsViewContent from './ClipsViewContent.vue'
 
 export default defineComponent({
   name: 'ClipsView',
+  components: { ClipsViewContent },
   props: {
     clipFolderId: { type: String as PropType<ClipFolderId>, required: true }
-  },
-  components: { ClipsViewContent },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/DMSidebar/DMSidebarContent.vue
+++ b/src/components/Main/MainView/DMSidebar/DMSidebarContent.vue
@@ -21,6 +21,9 @@ export default defineComponent({
     ChannelSidebarPinned,
     ChannelSidebarViewers
   },
+  emits: {
+    'pinned-mode-toggle': () => true
+  },
   props: {
     viewerIds: {
       type: Array as PropType<UserId[]>,
@@ -30,9 +33,6 @@ export default defineComponent({
       type: Number,
       default: 0
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
+++ b/src/components/Main/MainView/DMSidebar/DMSidebarHeader.vue
@@ -11,9 +11,6 @@ export default defineComponent({
   name: 'DMSidebarHeader',
   props: {
     name: { type: String, required: true }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderPopupFrame.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderPopupFrame.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="$style.container">
-    <slot></slot>
+    <slot />
   </div>
 </template>
 
@@ -8,10 +8,7 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
-  name: 'MainViewHeaderPopupFrame',
-  setup() {
-    return {}
-  }
+  name: 'MainViewHeaderPopupFrame'
 })
 </script>
 

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderPopupMenuItem.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderPopupMenuItem.vue
@@ -25,9 +25,6 @@ export default defineComponent({
     iconMdi: { type: Boolean, default: false },
     label: { type: String, default: '' },
     disabled: { type: Boolean, default: false }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderTitle.vue
@@ -24,9 +24,6 @@ export default defineComponent({
     },
     iconName: String,
     title: { type: String, required: true }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeaderToolsItem.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeaderToolsItem.vue
@@ -20,6 +20,9 @@ export default defineComponent({
   components: {
     Icon
   },
+  emits: {
+    toggle: () => true
+  },
   props: {
     iconName: {
       type: String,

--- a/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
+++ b/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
@@ -39,6 +39,11 @@ export default defineComponent({
   components: {
     Icon
   },
+  emits: {
+    'edit-start': () => true,
+    'edit-done': () => true,
+    'input-value': (value: string) => true
+  },
   props: {
     value: { type: String, required: false },
     isEditing: { type: Boolean, default: false },

--- a/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
+++ b/src/components/Main/MainView/MainViewSidebar/SidebarContentContainer.vue
@@ -18,6 +18,9 @@ import { defineComponent } from 'vue'
 
 export default defineComponent({
   name: 'SidebarContentContainer',
+  emits: {
+    toggle: () => true
+  },
   props: {
     title: String,
     largePadding: {

--- a/src/components/Main/MainView/MainViewSidebar/SidebarContentContainerLink.vue
+++ b/src/components/Main/MainView/MainViewSidebar/SidebarContentContainerLink.vue
@@ -3,7 +3,7 @@
     clickable
     :title="title"
     :large-padding="largePadding"
-    @toggle="onClickLink"
+    @toggle="$emit('click-link')"
   >
     <template #header-control v-if="count !== undefined">
       <span :class="$style.count">{{ count }}</span>
@@ -21,6 +21,9 @@ export default defineComponent({
   components: {
     SidebarContentContainer
   },
+  emits: {
+    'click-link': () => true
+  },
   props: {
     title: String,
     count: Number,
@@ -28,10 +31,6 @@ export default defineComponent({
       type: Boolean,
       default: false
     }
-  },
-  setup(_, context) {
-    const onClickLink = () => context.emit('click-link')
-    return { onClickLink }
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageElement/ClipElement.vue
+++ b/src/components/Main/MainView/MessageElement/ClipElement.vue
@@ -24,7 +24,9 @@ import { defineComponent, computed, reactive, shallowRef, PropType } from 'vue'
 import store from '@/store'
 import { MessageId } from '@/types/entity-ids'
 import useIsMobile from '@/use/isMobile'
-import useElementRenderObserver from './use/elementRenderObserver'
+import useElementRenderObserver, {
+  emitsOption
+} from './use/elementRenderObserver'
 import useEmbeddings from './use/embeddings'
 import MessageContents from './MessageContents.vue'
 import MessageTools from './MessageTools.vue'
@@ -39,6 +41,7 @@ export default defineComponent({
     MessageTools,
     MessageQuoteListItemFooter
   },
+  emits: emitsOption,
   props: {
     messageId: {
       type: String as PropType<MessageId>,

--- a/src/components/Main/MainView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MainView/MessageElement/MessageElement.vue
@@ -40,7 +40,9 @@ import store from '@/store'
 import { MessageId } from '@/types/entity-ids'
 import useIsMobile from '@/use/isMobile'
 import MessageStampList from './MessageStampList.vue'
-import useElementRenderObserver from './use/elementRenderObserver'
+import useElementRenderObserver, {
+  emitsOption
+} from './use/elementRenderObserver'
 import useEmbeddings from './use/embeddings'
 import MessagePinned from './MessagePinned.vue'
 import MessageContents from './MessageContents.vue'
@@ -55,6 +57,7 @@ export default defineComponent({
     MessagePinned,
     MessageTools
   },
+  emits: emitsOption,
   props: {
     messageId: {
       type: String as PropType<MessageId>,

--- a/src/components/Main/MainView/MessageElement/MessageFileListAudio.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListAudio.vue
@@ -25,8 +25,8 @@ export default defineComponent({
       default: ''
     }
   },
-  setup(props, context) {
-    const { fileMeta, fileLink, fileRawPath } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta, fileLink, fileRawPath } = useFileMeta(props)
     return { fileMeta, fileLink, fileRawPath }
   }
 })

--- a/src/components/Main/MainView/MessageElement/MessageFileListFile.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListFile.vue
@@ -17,9 +17,6 @@ export default defineComponent({
       type: String as PropType<FileId>,
       default: ''
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -29,13 +29,13 @@ export default defineComponent({
       default: ''
     }
   },
-  setup(props, context) {
+  setup(props) {
     const {
       fileMeta,
       fileLink,
       fileThumbnailPath,
       fileThumbnailSize
-    } = useFileMeta(props, context)
+    } = useFileMeta(props)
     return { fileThumbnailPath, fileThumbnailSize, fileLink, fileMeta }
   }
 })

--- a/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListItemContent.vue
@@ -31,12 +31,9 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
-    const { fileLink } = useFileMeta(props, context)
-    return {
-      fileLink,
-      props
-    }
+  setup(props) {
+    const { fileLink } = useFileMeta(props)
+    return { fileLink }
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
@@ -28,8 +28,8 @@ export default defineComponent({
       default: ''
     }
   },
-  setup(props, context) {
-    const { fileMeta, fileLink, fileRawPath } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta, fileLink, fileRawPath } = useFileMeta(props)
     return { fileMeta, fileLink, fileRawPath }
   }
 })

--- a/src/components/Main/MainView/MessageElement/MessageOgpContentVideo.vue
+++ b/src/components/Main/MainView/MessageElement/MessageOgpContentVideo.vue
@@ -46,9 +46,6 @@ export default defineComponent({
       type: String,
       default: ''
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteList.vue
@@ -29,9 +29,6 @@ export default defineComponent({
       type: Array as PropType<MessageId[]>,
       default: []
     }
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageElement/MessageToolsMenuContainer.vue
+++ b/src/components/Main/MainView/MessageElement/MessageToolsMenuContainer.vue
@@ -20,7 +20,6 @@ import {
   ref,
   Ref,
   watch,
-  SetupContext,
   nextTick,
   shallowRef
 } from 'vue'
@@ -35,10 +34,7 @@ const useMenu = () => {
   return { state }
 }
 
-const useMenuHeight = (
-  context: SetupContext,
-  state: { isPopupMenuShown: boolean }
-) => {
+const useMenuHeight = (state: { isPopupMenuShown: boolean }) => {
   const height = ref(0)
   const menuContainerRef = shallowRef<HTMLDivElement | null>(null)
   watch(
@@ -72,9 +68,9 @@ export default defineComponent({
   components: {
     MessageToolsMenu
   },
-  setup(_, context) {
+  setup() {
     const { state } = useMenu()
-    const { height, menuContainerRef } = useMenuHeight(context, state)
+    const { height, menuContainerRef } = useMenuHeight(state)
 
     const styles = useStyles(state, height)
     const closePopupMenu = () => {

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -30,10 +30,15 @@ import store from '@/store'
 import SpinNumber from '@/components/UI/SpinNumber.vue'
 import Stamp from '@/components/UI/Stamp.vue'
 import { MessageStampById } from './MessageStampList.vue'
+import { StampId } from '@/types/entity-ids'
 
 export default defineComponent({
   name: 'StampElement',
   components: { Stamp, SpinNumber },
+  emits: {
+    'add-stamp': (id: StampId) => true,
+    'remove-stamp': (id: StampId) => true
+  },
   props: {
     stamp: {
       type: Object as PropType<MessageStampById>,

--- a/src/components/Main/MainView/MessageElement/use/elementRenderObserver.ts
+++ b/src/components/Main/MainView/MessageElement/use/elementRenderObserver.ts
@@ -6,6 +6,18 @@ import { useRoute } from 'vue-router'
 
 declare const window: ResizeObserverWindow
 
+export const emitsOption = {
+  'entry-message-loaded': (height: number) => true,
+  'change-height': (changed: {
+    heightDiff: number
+    top: number
+    bottom: number
+    lastTop: number
+    lastBottom: number
+    date?: string
+  }) => true
+}
+
 const useElementRenderObserver = (
   bodyRef: Ref<HTMLDivElement | null>,
   props: { isEntryMessage: boolean },
@@ -16,7 +28,7 @@ const useElementRenderObserver = (
   embeddingsState: Readonly<{
     fileIds: Readonly<FileId[]>
   }>,
-  context: SetupContext
+  context: SetupContext<typeof emitsOption>
 ) => {
   const route = useRoute()
 

--- a/src/components/Main/MainView/MessageInput/MessageInputControls.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputControls.vue
@@ -22,7 +22,7 @@ import Icon from '@/components/UI/Icon.vue'
 
 const useClickHandlers = (
   props: { canPostMessage: boolean },
-  context: SetupContext
+  context: SetupContext<{ 'click-send': () => true; 'click-stamp': () => true }>
 ) => {
   const onClickSendButton = () => {
     if (props.canPostMessage) {
@@ -40,6 +40,10 @@ export default defineComponent({
   components: {
     MessageInputInsertStampButton,
     Icon
+  },
+  emits: {
+    'click-send': () => true,
+    'click-stamp': () => true
   },
   props: {
     canPostMessage: {

--- a/src/components/Main/MainView/MessageInput/MessageInputFileListItem.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileListItem.vue
@@ -29,6 +29,9 @@ export default defineComponent({
     MessageInputFileListItemCloseButton,
     FileTypeIcon
   },
+  emits: {
+    'item-remove': () => true
+  },
   props: {
     attachment: {
       type: Object as PropType<Attachment>,

--- a/src/components/Main/MainView/MessageInput/MessageInputFileListItemCloseButton.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileListItemCloseButton.vue
@@ -13,6 +13,9 @@ export default defineComponent({
   name: 'MessageInputFileListItem',
   components: {
     Icon
+  },
+  emits: {
+    close: () => true
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageInput/MessageInputInsertStampButton.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputInsertStampButton.vue
@@ -15,9 +15,6 @@ export default defineComponent({
   name: 'MessageInputInsertStampButton',
   components: {
     IconButton
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -12,8 +12,6 @@
     @before-input="onBeforeInput"
     @keydown="onKeyDown"
     @keyup="onKeyUp"
-    @focus="onFocus"
-    @blur="onBlur"
     @paste="onPaste"
   />
 </template>
@@ -30,29 +28,18 @@ import {
 import useSendKeyWatcher from './use/sendKeyWatcher'
 import store from '@/store'
 
-const useFocus = (context: SetupContext) => {
-  const onFocus = () => {
-    context.emit('focus')
-  }
-  const onBlur = () => {
-    context.emit('blur')
-  }
-
-  return { onFocus, onBlur }
-}
-
 const useLineBreak = (
   props: { text: string },
   textareaRef: Ref<HTMLTextAreaElement | undefined>,
-  context: SetupContext
+  context: SetupContext<{ 'input-value': (value: string) => true }>
 ) => {
   const insertLineBreak = async () => {
     if (!textareaRef.value) return
     const pre = props.text.slice(0, textareaRef.value.selectionStart)
     const suf = props.text.slice(textareaRef.value.selectionEnd)
     const selectionIndex = pre.length + 1
-    // inputイベントを発火することでテキストを変更
-    context.emit('input', `${pre}\n${suf}`)
+    // input-valueイベントを発火することでテキストを変更
+    context.emit('input-value', `${pre}\n${suf}`)
 
     await nextTick()
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -79,6 +66,14 @@ const usePaste = () => {
 
 export default defineComponent({
   name: 'MessageInputTextArea',
+  emits: {
+    'input-value': (value: string) => true,
+    'post-message': () => true,
+    'modifier-key-down': () => true,
+    'modifier-key-up': () => true,
+    focus: () => true,
+    blur: () => true
+  },
   props: {
     text: {
       type: String,
@@ -89,7 +84,7 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context: SetupContext) {
+  setup(props, context) {
     const onInput = (value: string) => {
       context.emit('input-value', value)
     }
@@ -111,7 +106,6 @@ export default defineComponent({
       insertLineBreak
     )
 
-    const { onFocus, onBlur } = useFocus(context)
     const { onPaste } = usePaste()
 
     return {
@@ -121,8 +115,6 @@ export default defineComponent({
       onKeyDown,
       onKeyUp,
       textareaAutosizeRef,
-      onFocus,
-      onBlur,
       onPaste
     }
   }

--- a/src/components/Main/MainView/MessageInput/MessageInputUploadButton.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputUploadButton.vue
@@ -15,9 +15,6 @@ export default defineComponent({
   name: 'MessageInputUploadButton',
   components: {
     IconButton
-  },
-  setup() {
-    return {}
   }
 })
 </script>

--- a/src/components/Main/MainView/MessageInput/use/sendKeyWatcher.ts
+++ b/src/components/Main/MainView/MessageInput/use/sendKeyWatcher.ts
@@ -86,14 +86,12 @@ const needBreakLineInsert = (keyEvent: KeyboardEvent) => {
   )
 }
 
-/**
- * contextに対して発火されるイベント
- * - `post-message`: 投稿トリガー時
- * - `modifier-key-down`: 修飾キーが押された
- * - `modifier-key-up`: 修飾キーが離された
- */
 const useSendKeyWatcher = (
-  context: SetupContext,
+  context: SetupContext<{
+    'post-message': () => true // 投稿トリガー時
+    'modifier-key-down': () => true // 修飾キーが押された
+    'modifier-key-up': () => true // 修飾キーが離された
+  }>,
   insertLineBreak: () => void
 ) => {
   const state = reactive({

--- a/src/components/Main/Modal/FileModal/FileModal.vue
+++ b/src/components/Main/Modal/FileModal/FileModal.vue
@@ -30,11 +30,11 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props, context) {
+  setup(props) {
     const fileIdState = reactive({
       fileId: computed(() => props.id)
     })
-    const { fileMeta, fileType } = useFileMeta(fileIdState, context)
+    const { fileMeta, fileType } = useFileMeta(fileIdState)
     const onClickOutSide = () => store.dispatch.ui.modal.clearModal()
     return { fileMeta, fileType, onClickOutSide }
   }

--- a/src/components/Main/Modal/FileModal/FileModalAudio.vue
+++ b/src/components/Main/Modal/FileModal/FileModalAudio.vue
@@ -29,8 +29,8 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props, context) {
-    const { fileMeta, fileRawPath } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta, fileRawPath } = useFileMeta(props)
     return { fileMeta, fileRawPath }
   }
 })

--- a/src/components/Main/Modal/FileModal/FileModalContentFooter.vue
+++ b/src/components/Main/Modal/FileModal/FileModalContentFooter.vue
@@ -33,8 +33,8 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
-    const { fileMeta } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta } = useFileMeta(props)
     const user = computed(
       () => store.state.entities.users[fileMeta.value?.uploaderId ?? '']
     )

--- a/src/components/Main/Modal/FileModal/FileModalImage.vue
+++ b/src/components/Main/Modal/FileModal/FileModalImage.vue
@@ -39,8 +39,8 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props, context) {
-    const { fileMeta, fileRawPath } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta, fileRawPath } = useFileMeta(props)
     return { fileMeta, fileRawPath }
   }
 })

--- a/src/components/Main/Modal/FileModal/FileModalVideo.vue
+++ b/src/components/Main/Modal/FileModal/FileModalVideo.vue
@@ -35,8 +35,8 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props, context) {
-    const { fileMeta, fileRawPath } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta, fileRawPath } = useFileMeta(props)
     return { fileMeta, fileRawPath }
   }
 })

--- a/src/components/UI/ChromeAudio.vue
+++ b/src/components/UI/ChromeAudio.vue
@@ -53,8 +53,8 @@ export default defineComponent({
       default: ''
     }
   },
-  setup(props, context) {
-    const { fileMeta, fileRawPath } = useFileMeta(props, context)
+  setup(props) {
+    const { fileMeta, fileRawPath } = useFileMeta(props)
     const {
       isPlaying,
       currentTime,

--- a/src/components/UI/FileDescription.vue
+++ b/src/components/UI/FileDescription.vue
@@ -43,13 +43,13 @@ export default defineComponent({
       default: false
     }
   },
-  setup(props, context) {
+  setup(props) {
     const {
       fileMeta,
       fileType,
       fileSize,
       onFileDownloadLinkClick
-    } = useFileMeta(props, context)
+    } = useFileMeta(props)
     return {
       fileMeta,
       fileType,

--- a/src/components/UI/FormInput.vue
+++ b/src/components/UI/FormInput.vue
@@ -39,13 +39,16 @@ import useInput from '@/use/input'
 
 export default defineComponent({
   name: 'FormInput',
+  emits: {
+    'update:modelValue': (value: string) => true
+  },
   props: {
     type: {
       type: String,
       default: 'text'
     },
     modelValue: {
-      type: [String, Number],
+      type: String,
       default: ''
     },
     onSecondary: {

--- a/src/components/UI/FormRadio.vue
+++ b/src/components/UI/FormRadio.vue
@@ -21,6 +21,9 @@ import useInput from '@/use/input'
 
 export default defineComponent({
   name: 'FormRadio',
+  emits: {
+    'update:modelValue': (value: string) => true
+  },
   props: {
     /**
      * v-model用なので基本的には直接触らない

--- a/src/components/UI/FormSelector.vue
+++ b/src/components/UI/FormSelector.vue
@@ -32,6 +32,9 @@ import { randomString } from '@/lib/util/randomString'
 
 export default defineComponent({
   name: 'FormSelector',
+  emits: {
+    'update:modelValue': (value: string) => true
+  },
   props: {
     modelValue: {
       type: String,

--- a/src/use/fileMeta.ts
+++ b/src/use/fileMeta.ts
@@ -1,10 +1,10 @@
-import { computed, SetupContext } from 'vue'
+import { computed } from 'vue'
 import store from '@/store'
 import { buildFilePath, buildFileThumbnailPath } from '@/lib/apis'
 import { mimeToFileType, prettifyFileSize } from '@/lib/util/file'
 import useFileLink from '@/use/fileLink'
 
-const useFileMeta = (props: { fileId: string }, context: SetupContext) => {
+const useFileMeta = (props: { fileId: string }) => {
   const fileMeta = computed(
     () => store.state.entities.fileMetaData[props.fileId]
   )

--- a/src/use/input.ts
+++ b/src/use/input.ts
@@ -2,9 +2,13 @@ import { SetupContext } from 'vue'
 
 type InputElement = HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement
 
-const useInput = (context: SetupContext, eventName = 'input-value') => {
+const useInput = <EventName extends string>(
+  context: SetupContext<{ [K in EventName]: (value: string) => true }>,
+  eventName: EventName = 'input-value' as EventName
+) => {
   const onInput = (event: InputEvent) =>
-    context.emit(eventName, (event.target as InputElement).value)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (context.emit as any)(eventName, (event.target as InputElement).value)
   return {
     onInput
   }


### PR DESCRIPTION
現地点での問題点

```ts
const useAEmitter = (context: SetupContext<{ a: () => true }>) => {
  context.emit('a')
}
```
```ts
export default defineComponents({
  emits: {
    a: () => true,
    b: () => true
  },
  setup(props, context) {
    useAEmitter(context)
    // Argument of type 'SetupContext<{ 'a': () => true; 'b': () => true }>' is not assignable to parameter of type 'SetupContext<{ 'a': () => true; }>'.
  }
})
```
本来はこれが通ってもよいのに、これが通らない
内部でUnionToIntersection使われてたからそれ関連な気がするけどちゃんと見ないといけない
