### PR TITLE
再生に対応してない形式の音声ファイルの表示

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListAudio.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListAudio.vue
@@ -3,7 +3,7 @@
     <div :class="$style.description">
       <message-file-list-item-content :file-id="fileId" />
     </div>
-    <chrome-audio :file-id="fileId" :class="$style.audio" />
+    <chrome-audio :file-id="fileId" />
   </div>
 </template>
 
@@ -49,8 +49,5 @@ export default defineComponent({
   width: 100%;
   margin: 6px 0;
   cursor: pointer;
-}
-.audio {
-  width: 100%;
 }
 </style>

--- a/src/components/UI/ChromeAudio.vue
+++ b/src/components/UI/ChromeAudio.vue
@@ -24,7 +24,11 @@
     >
       <icon mdi name="picture-in-picture-bottom-right" :size="20" />
     </div>
+    <div v-if="wasUnsupportedType" :class="$style.unsupportedError">
+      対応していないファイル形式でした
+    </div>
   </div>
+  <div></div>
 </template>
 
 <script lang="ts">
@@ -57,6 +61,7 @@ export default defineComponent({
     const { fileMeta, fileRawPath } = useFileMeta(props, context)
     const {
       cantPlay,
+      wasUnsupportedType,
       isPlaying,
       currentTime,
       displayCurrentTime,
@@ -78,6 +83,7 @@ export default defineComponent({
 
     return {
       cantPlay,
+      wasUnsupportedType,
       isPlaying,
       currentTime,
       displayCurrentTime,
@@ -96,9 +102,12 @@ export default defineComponent({
 </script>
 
 <style lang="scss" module>
+$background-color: rgb(241, 243, 244);
+
 .container {
+  position: relative;
   color: black;
-  background-color: rgb(241, 243, 244);
+  background-color: $background-color;
   align-items: center;
   display: flex;
   flex: 0;
@@ -124,5 +133,16 @@ export default defineComponent({
 .sliderContainer {
   margin: 0 4px;
   flex: 1;
+}
+.unsupportedError {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: $background-color;
 }
 </style>

--- a/src/components/UI/ChromeAudio.vue
+++ b/src/components/UI/ChromeAudio.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.container">
+  <div v-if="!cantPlay" :class="$style.container">
     <div :class="$style.icon" @click="togglePlay">
       <icon mdi :name="isPlaying ? 'pause' : 'play'" :size="20" />
     </div>
@@ -56,6 +56,7 @@ export default defineComponent({
   setup(props, context) {
     const { fileMeta, fileRawPath } = useFileMeta(props, context)
     const {
+      cantPlay,
       isPlaying,
       currentTime,
       displayCurrentTime,
@@ -76,6 +77,7 @@ export default defineComponent({
     }
 
     return {
+      cantPlay,
       isPlaying,
       currentTime,
       displayCurrentTime,

--- a/src/components/UI/use/audio.ts
+++ b/src/components/UI/use/audio.ts
@@ -24,6 +24,7 @@ const useAudio = (
   const cantPlay = computed(
     () => fileMeta.value && audio.canPlayType(fileMeta.value.mime) === ''
   )
+  const wasUnsupportedType = ref(false)
 
   watch(
     () => fileMeta.value?.mime + fileRawPath.value,
@@ -56,7 +57,14 @@ const useAudio = (
     }
   }
   const start = async () => {
-    await audio.play()
+    try {
+      await audio.play()
+    } catch (e: unknown) {
+      const err = e as Error
+      if (err.name === 'NotSupportedError') {
+        wasUnsupportedType.value = true
+      }
+    }
   }
   const pause = () => {
     audio.pause()
@@ -90,6 +98,7 @@ const useAudio = (
   }
   return {
     cantPlay,
+    wasUnsupportedType,
     isPlaying,
     currentTime,
     displayCurrentTime,

--- a/src/components/UI/use/audio.ts
+++ b/src/components/UI/use/audio.ts
@@ -21,6 +21,10 @@ const useAudio = (
 
   const audio = new Audio()
 
+  const cantPlay = computed(
+    () => fileMeta.value && audio.canPlayType(fileMeta.value.mime) === ''
+  )
+
   watch(
     () => fileMeta.value?.mime + fileRawPath.value,
     () => {
@@ -85,6 +89,7 @@ const useAudio = (
     showPictureInPictureWindow(audio, iconId)
   }
   return {
+    cantPlay,
     isPlaying,
     currentTime,
     displayCurrentTime,


### PR DESCRIPTION
- 再生前にmimeで再生できないことがわかってる場合([`HTMLMediaElement.canPlayType`](https://developer.mozilla.org/ja/docs/Web/API/HTMLMediaElement/canPlayType))
![image](https://user-images.githubusercontent.com/49056869/100049091-d37bb900-2e59-11eb-9920-087487f4978e.png)
プレイヤーを最初から非表示

- 再生後に再生できないことが分かった場合(`NotSupportedError`)
![image](https://user-images.githubusercontent.com/49056869/100049169-045bee00-2e5a-11eb-8051-3aed8f09120e.png)
プレイヤーを押した後に非表示にする
