### PR TITLE
設定画面のレイアウト調整

### DIFF
--- a/src/components/Settings/DesktopSetting.vue
+++ b/src/components/Settings/DesktopSetting.vue
@@ -41,6 +41,6 @@ export default defineComponent({
 .close {
   position: absolute;
   top: 30px;
-  right: 120px;
+  right: 60px;
 }
 </style>

--- a/src/components/Settings/DesktopTabFrame.vue
+++ b/src/components/Settings/DesktopTabFrame.vue
@@ -1,7 +1,9 @@
 <template>
   <section :class="$style.container">
-    <tab-content-title :class="$style.title" />
-    <slot />
+    <div :class="$style.content">
+      <tab-content-title :class="$style.title" />
+      <slot />
+    </div>
   </section>
 </template>
 
@@ -26,11 +28,16 @@ export default defineComponent({
   @include background-primary;
   flex: 1 1;
   padding: 40px;
-  padding-right: 240px;
+  padding-right: 160px;
   overflow: {
     x: hidden;
     y: auto;
   }
+}
+
+.content {
+  max-width: 720px;
+  margin: 0 auto;
 }
 
 .title {


### PR DESCRIPTION
設定画面のレイアウト関連です

- 設定画面が幅広い時に読みづらいため720pxに制限して中央に揃えた
- 閉じるボタンに対するpaddingを小さくした