### PR TITLE
Chrome88以降で画像のサムネイルが0x0pxになってた

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -1,5 +1,9 @@
 <template>
   <router-link :to="fileLink" v-if="isLarge" :class="$style.largeContainer">
+    <!--
+      height, widthはlayout shift対策
+      https://www.mizdra.net/entry/2020/05/31/192613
+    -->
     <img
       draggable="false"
       :alt="fileMeta.name"
@@ -9,6 +13,9 @@
     />
   </router-link>
   <router-link v-else :to="fileLink" :class="$style.container">
+    <!--
+      CSSで固定値指定なのでheight, widthはつけない
+    -->
     <img draggable="false" :alt="fileMeta.name" :src="fileThumbnailPath" />
   </router-link>
 </template>

--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -70,7 +70,7 @@ export default defineComponent({
   }
   max-width: min(600px, 100%);
   img {
-    height: 100%;
+    height: auto;
     width: 100%;
     max-width: 100%;
     max-height: 450px;


### PR DESCRIPTION
largeContainer、つまりメッセージに一つしか画像がない場合のとき