### PR TITLE
Store architecture refactor (8.5: misc)

### DIFF
--- a/src/components/Main/MainView/ChannelView/use/channelMessageFetcher.ts
+++ b/src/components/Main/MainView/ChannelView/use/channelMessageFetcher.ts
@@ -111,11 +111,41 @@ const useChannelMessageFetcher = (
     ]
   }
 
+  const fetchNewMessages = async (isReachedLatest: Ref<boolean>) => {
+    const {
+      messages,
+      hasMore
+    } = await store.dispatch.domain.messagesView.fetchMessagesByChannelId({
+      channelId: props.channelId,
+      limit: fetchLimit,
+      order: 'desc',
+      since: state.loadedMessageLatestDate
+    })
+
+    if (!hasMore) {
+      isReachedLatest.value = true
+    }
+
+    const oldestMessage = messages[messages.length - 1] as Message | undefined
+    if (oldestMessage) {
+      const oldestMessageDate = new Date(oldestMessage.createdAt)
+      if (
+        !state.loadedMessageOldestDate ||
+        oldestMessageDate < state.loadedMessageOldestDate
+      ) {
+        state.loadedMessageOldestDate = oldestMessageDate
+      }
+    }
+
+    return messages.map(message => message.id)
+  }
+
   const messagesFetcher = useMessageFetcher(
     props,
     fetchFormerMessages,
     fetchLatterMessages,
-    fetchAroundMessages
+    fetchAroundMessages,
+    fetchNewMessages
   )
 
   onMounted(() => {

--- a/src/components/Main/MainView/ClipsView/use/clipsFetcher.ts
+++ b/src/components/Main/MainView/ClipsView/use/clipsFetcher.ts
@@ -36,9 +36,13 @@ const useClipsFetcher = (props: {
     return clips.map(clip => clip.message.id)
   }
 
+  // クリップフォルダは、wsの再接続時にうまく取得ができないので、
+  // 自動で再取得するのはあきらめる
+
   const messagesFetcher = useMessageFetcher(
     {},
     fetchFormerMessages,
+    undefined,
     undefined,
     undefined
   )

--- a/src/components/Main/MainView/MessagesScroller/use/messagesFetcher.ts
+++ b/src/components/Main/MainView/MessagesScroller/use/messagesFetcher.ts
@@ -1,7 +1,8 @@
-import { computed, ref, Ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, Ref } from 'vue'
 import store from '@/store'
 import { MessageId } from '@/types/entity-ids'
 import { Message } from '@traptitech/traq'
+import { wsListener } from '@/lib/websocket'
 
 export type LoadingDirection = 'former' | 'latter' | 'around' | 'latest'
 
@@ -17,6 +18,9 @@ const useMessageFetcher = (
         isReachedLatest: Ref<boolean>,
         isReachedEnd: Ref<boolean>
       ) => Promise<MessageId[]>)
+    | undefined,
+  fetchNewMessages:
+    | ((isReachedLatest: Ref<boolean>) => Promise<MessageId[]>)
     | undefined
 ) => {
   // メッセージIDはwsイベントで処理されるため、storeに置く
@@ -165,6 +169,29 @@ const useMessageFetcher = (
     )
   }
 
+  const loadNewMessages = async () => {
+    if (!fetchNewMessages || !isReachedLatest.value) {
+      return
+    }
+    isLoading.value = true
+
+    await runWithIdentifierCheck(
+      async () => {
+        const newMessageIds = await fetchNewMessages(isReachedLatest)
+        await renderMessageFromIds(newMessageIds)
+        return newMessageIds
+      },
+      newMessageIds => {
+        isLoading.value = false
+        lastLoadingDirection.value = 'latter'
+
+        store.commit.domain.messagesView.setMessageIds([
+          ...new Set([...messageIds.value, ...newMessageIds])
+        ])
+      }
+    )
+  }
+
   const init = () => {
     reset()
     if (props.entryMessageId) {
@@ -175,6 +202,16 @@ const useMessageFetcher = (
       onLoadFormerMessagesRequest()
     }
   }
+
+  const onReconnect = () => {
+    loadNewMessages()
+  }
+  onMounted(() => {
+    wsListener.on('reconnect', onReconnect)
+  })
+  onBeforeUnmount(() => {
+    wsListener.off('reconnect', onReconnect)
+  })
 
   return {
     messageIds,

--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -32,6 +32,8 @@ export default class AutoReconnectWebSocket {
   isInitialized = false
   reconnecting = false
 
+  mockFail = false
+
   constructor(
     url: string,
     protocols: string | string[] | undefined,
@@ -142,7 +144,9 @@ export default class AutoReconnectWebSocket {
 
       if (this.isOpen) break
 
-      await this._setupWs()
+      if (!this.mockFail) {
+        await this._setupWs()
+      }
 
       if (this.isOpen) break
 

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -16,6 +16,29 @@ export const ws = new AutoReconnectWebSocket(
   }
 )
 
+/*
+ * デバッグ用
+ *
+ * Chromeのdev toolsでwebsocketを切れないため。
+ * 1. Networkタブから`offline`にする
+ * 2. `closeWs()`をconsoleで実行
+ * 3. オフライン時にやりたいことをする
+ * 4. Networkタブから`online`に戻す
+ * 5. `reconnectWs()`をconsoleで実行
+ */
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).closeWs = () => {
+    ws.mockFail = true
+    ws._ws?.close()
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).reconnectWs = () => {
+    ws.mockFail = false
+    ws.connect()
+  }
+}
+
 export const wsListener = createWebSocketListener(ws)
 wsListener.on('all', event => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/store/domain/messagesView/actions.ts
+++ b/src/store/domain/messagesView/actions.ts
@@ -229,9 +229,10 @@ export const actions = defineActions({
     dispatch.addAndRenderMessage({ message })
   },
   onChannelMessageUpdated(context, message: Message) {
-    const { state, dispatch } = messagesViewActionContext(context)
+    const { state, commit, dispatch } = messagesViewActionContext(context)
     if (state.currentChannelId !== message.channelId) return
     dispatch.updateAndRenderMessageId({ message })
+    commit.updatePinnedMessage(message)
   },
   onChannelMessageDeleted(context, messageId: MessageId) {
     const { commit } = messagesViewActionContext(context)

--- a/src/store/domain/messagesView/listeners.ts
+++ b/src/store/domain/messagesView/listeners.ts
@@ -39,7 +39,6 @@ export const messageListeners = defineSubModuleListeners(
     })
     listener.on('updateMessage', message => {
       dispatch.onChannelMessageUpdated(message)
-      // TODO: ピン止めの内容の更新
     })
     listener.on('deleteMessage', messageId => {
       dispatch.onChannelMessageDeleted(messageId)

--- a/src/store/domain/messagesView/listeners.ts
+++ b/src/store/domain/messagesView/listeners.ts
@@ -25,7 +25,7 @@ export const wsListeners = defineSubModuleListeners(
       })
     })
 
-    // TODO: websocketのreconnect時の再取得
+    // 再接続時の再取得はmessagesFetcherで行う
   }
 )
 

--- a/src/store/domain/messagesView/mutations.ts
+++ b/src/store/domain/messagesView/mutations.ts
@@ -1,7 +1,7 @@
 import { defineMutations } from 'direct-vuex'
 import { ChannelId, MessageId, ClipFolderId } from '@/types/entity-ids'
 import { S } from './state'
-import { Pin, ChannelViewer } from '@traptitech/traq'
+import { Pin, ChannelViewer, Message } from '@traptitech/traq'
 import _store from '@/_store'
 import useCurrentChannelPath from '@/use/currentChannelPath'
 import { EmbeddingOrUrl } from '@traptitech/traq-markdown-it'
@@ -60,6 +60,14 @@ export const mutations = defineMutations<S>()({
   },
   addPinnedMessage(state, message: Pin) {
     state.pinnedMessages.push(message)
+  },
+  updatePinnedMessage(state, message: Message) {
+    const index = state.pinnedMessages.findIndex(
+      element => element.message.id === message.id
+    )
+    if (index > -1) {
+      state.pinnedMessages[index].message = message
+    }
   },
   removePinnedMessage(state, messageId: MessageId) {
     const index = state.pinnedMessages.findIndex(

--- a/src/store/entities/listeners.ts
+++ b/src/store/entities/listeners.ts
@@ -42,7 +42,10 @@ export const listeners = defineListeners(
       dispatch.fetchClipFolder({ clipFolderId: id })
     })
     listener.on('CLIP_FOLDER_UPDATED', ({ id }) => {
-      dispatch.fetchClipFolder({ clipFolderId: id })
+      dispatch.fetchClipFolder({
+        clipFolderId: id,
+        cacheStrategy: 'forceFetch'
+      })
     })
     listener.on('CLIP_FOLDER_DELETED', ({ id }) => {
       dispatch.deleteClipFolders(id)

--- a/src/store/entities/messages/listeners.ts
+++ b/src/store/entities/messages/listeners.ts
@@ -12,7 +12,10 @@ export const listeners = defineSubModuleListeners(
       messageMitt.emit('addMessage', message)
     })
     listener.on('MESSAGE_UPDATED', async ({ id }) => {
-      const message = await dispatch.fetchMessage({ messageId: id })
+      const message = await dispatch.fetchMessage({
+        messageId: id,
+        force: true
+      })
       messageMitt.emit('updateMessage', message)
     })
     listener.on('MESSAGE_DELETED', ({ id }) => {


### PR DESCRIPTION
#1699 の一部
もろもろの修正とか

- メッセージの再取得処理 refs #534
  - チャンネルは実装、クリップフォルダはとりあえず未実装、wsのデバッグ用関数を追加した
- メッセージの編集後にメッセージが更新されていなかった
- クリップフォルダの変更後に表示が更新されていなかった
- ピン止めの内容の更新
  - これは新機能
