### PR TITLE
下書き機能

### DIFF
--- a/src/assets/mdi.ts
+++ b/src/assets/mdi.ts
@@ -66,7 +66,8 @@ import {
   mdiEyeOutline,
   mdiEyeOffOutline,
   mdiFilePdf,
-  mdiFileChart
+  mdiFileChart,
+  mdiPencil
 } from '@mdi/js'
 
 interface MdiIconsMapping {
@@ -107,7 +108,8 @@ const mdi: MdiIconsMapping = {
   account: mdiAccount,
   cogs: mdiCogs,
   'brightness-6': mdiBrightness6,
-  pencil: mdiPencilOutline,
+  pencil: mdiPencil,
+  'pencil-outline': mdiPencilOutline,
   'toggle-switch-off': mdiToggleSwitchOff,
   'toggle-switch-on': mdiToggleSwitch,
   'chevron-double': mdiChevronDoubleLeft,

--- a/src/components/Main/MainView/ChannelView/ChannelView.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelView.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, computed, PropType, ref } from 'vue'
+import { defineComponent, computed, PropType, ref, Ref, toRef } from 'vue'
 import { ChannelId } from '@/types/entity-ids'
 import store from '@/store'
 import ChannelViewContent from './ChannelViewContent.vue'
@@ -24,8 +24,8 @@ import ChannelViewFileUploadOverlay from './ChannelViewFileUploadOverlay.vue'
 import { debounce } from 'throttle-debounce'
 import useMessageInputState from '@/providers/messageInputState'
 
-const useDragDrop = () => {
-  const { addFromDataTransfer } = useMessageInputState()
+const useDragDrop = (channelId: Ref<ChannelId>) => {
+  const { addFromDataTransfer } = useMessageInputState(channelId)
 
   // itemsはsafariには存在しない
   const hasFilesOrItems = (dt: DataTransfer) =>
@@ -67,20 +67,17 @@ export default defineComponent({
     ChannelViewContent,
     ChannelViewFileUploadOverlay
   },
-  setup() {
-    const state = reactive({
-      channelMessageIds: computed(
-        () => store.state.domain.messagesView.messageIds
-      ),
-      channelId: computed(
-        () => store.state.domain.messagesView.currentChannelId
-      )
-    })
+  setup(props) {
+    const channelMessageIds = computed(
+      () => store.state.domain.messagesView.messageIds
+    )
 
-    const { isDragging, onDrop, onDragOver } = useDragDrop()
+    const { isDragging, onDrop, onDragOver } = useDragDrop(
+      toRef(props, 'channelId')
+    )
 
     return {
-      state,
+      channelMessageIds,
       isDragging,
       onDrop,
       onDragOver

--- a/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
+++ b/src/components/Main/MainView/MainViewSidebar/ContentEditor.vue
@@ -19,7 +19,7 @@
       :class="$style.button"
     >
       <icon v-if="isEditing" width="20" height="20" name="check" mdi />
-      <icon v-else width="20" height="20" name="pencil" mdi />
+      <icon v-else width="20" height="20" name="pencil-outline" mdi />
     </button>
   </div>
 </template>

--- a/src/components/Main/MainView/MessageElement/MessageHeader.vue
+++ b/src/components/Main/MainView/MessageElement/MessageHeader.vue
@@ -8,7 +8,7 @@
       v-if="createdAt !== updatedAt"
       :class="$style.editIcon"
       :size="16"
-      name="pencil"
+      name="pencil-outline"
       mdi
     />
   </div>

--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -9,7 +9,10 @@
       <div>アーカイブチャンネルのため、投稿できません</div>
     </div>
     <template v-else>
-      <message-input-file-list :class="$style.fileList" />
+      <message-input-file-list
+        :class="$style.fileList"
+        :channel-id="channelId"
+      />
       <message-input-typing-users :typing-users="typingUsers" />
       <message-input-key-guide :show="showKeyGuide" />
       <message-input-upload-progress v-if="isPosting" :progress="progress" />
@@ -21,6 +24,7 @@
         <message-input-text-area
           ref="textareaRef"
           v-model="state.text"
+          :channel-id="channelId"
           :is-posting="isPosting"
           @focus="onFocus"
           @blur="onBlur"
@@ -88,8 +92,9 @@ export default defineComponent({
   },
   setup(props) {
     const { isMobile } = useIsMobile()
-    const { state, isEmpty } = useMessageInputState()
-    const { addAttachment, destroy } = useAttachments()
+    const channelId = toRef(props, 'channelId')
+    const { state, isEmpty, isTextEmpty } = useMessageInputState(channelId)
+    const { addAttachment, destroy } = useAttachments(channelId)
     const {
       isModifierKeyPressed,
       onModifierKeyDown,
@@ -106,13 +111,9 @@ export default defineComponent({
     )
 
     const { isFocused, onFocus, onBlur } = useFocus()
-    useEditingStatus(
-      computed(() => props.channelId),
-      state,
-      isFocused
-    )
+    useEditingStatus(channelId, isTextEmpty, isFocused)
 
-    const { postMessage, isPosting, progress } = usePostMessage(props)
+    const { postMessage, isPosting, progress } = usePostMessage(channelId)
 
     const typingUsers = computed(
       () => store.getters.domain.messagesView.typingUsers

--- a/src/components/Main/MainView/MessageInput/MessageInputFileList.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileList.vue
@@ -11,17 +11,28 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType, toRef } from 'vue'
 import MessageInputFileListItem from './MessageInputFileListItem.vue'
-import useMessageInputState from '@/providers/messageInputState'
+import useMessageInputState, {
+  VirtualChannelId
+} from '@/providers/messageInputState'
+import { ChannelId } from '@/types/entity-ids'
 
 export default defineComponent({
   name: 'MessageInputFileList',
   components: {
     MessageInputFileListItem
   },
-  setup() {
-    const { state, removeAttachmentAt } = useMessageInputState()
+  props: {
+    channelId: {
+      type: String as PropType<ChannelId | VirtualChannelId>,
+      required: true
+    }
+  },
+  setup(props) {
+    const { state, removeAttachmentAt } = useMessageInputState(
+      toRef(props, 'channelId')
+    )
     return { state, removeAttachmentAt }
   }
 })

--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -22,12 +22,15 @@ import {
   SetupContext,
   Ref,
   computed,
-  nextTick
+  nextTick,
+  PropType,
+  toRef
 } from 'vue'
 import useSendKeyWatcher from './use/sendKeyWatcher'
 import TextareaAutosize from '@/components/UI/TextareaAutosize.vue'
 import useModelSyncer from '@/use/modelSyncer'
 import useMessageInputState from '@/providers/messageInputState'
+import { ChannelId } from '@/types/entity-ids'
 
 const useFocus = (context: SetupContext) => {
   const onFocus = () => {
@@ -60,10 +63,13 @@ const useLineBreak = (
   return { insertLineBreak }
 }
 
-const usePaste = () => {
-  const { addAttachment } = useMessageInputState()
+const usePaste = (channelId: Ref<ChannelId>) => {
+  const { addAttachment } = useMessageInputState(channelId)
 
   const onPaste = (event: ClipboardEvent) => {
+    // メッセージ編集の場合などは無視
+    if (channelId.value === '') return
+
     const dt = event?.clipboardData
     if (dt) {
       Array.from(dt.files).forEach(file => {
@@ -82,6 +88,10 @@ export default defineComponent({
   props: {
     modelValue: {
       type: String,
+      default: ''
+    },
+    channelId: {
+      type: String as PropType<ChannelId>,
       default: ''
     },
     isPosting: {
@@ -105,7 +115,7 @@ export default defineComponent({
     )
 
     const { onFocus, onBlur } = useFocus(context)
-    const { onPaste } = usePaste()
+    const { onPaste } = usePaste(toRef(props, 'channelId'))
 
     return {
       value,

--- a/src/components/Main/MainView/MessageInput/use/attachments.ts
+++ b/src/components/Main/MainView/MessageInput/use/attachments.ts
@@ -1,7 +1,9 @@
-import useMessageInputState from '@/providers/messageInputState'
+import useMessageInputState, {
+  MessageInputStateKey
+} from '@/providers/messageInputState'
 
-const useAttachments = () => {
-  const { addAttachment } = useMessageInputState()
+const useAttachments = (channelId: MessageInputStateKey) => {
+  const { addAttachment } = useMessageInputState(channelId)
 
   const input = document.createElement('input')
   input.type = 'file'

--- a/src/components/Main/MainView/MessageInput/use/editingStatus.ts
+++ b/src/components/Main/MainView/MessageInput/use/editingStatus.ts
@@ -5,10 +5,10 @@ import { ChannelViewState } from '@traptitech/traq'
 
 const useEditingStatus = (
   channelId: Ref<ChannelId | DMChannelId>,
-  textStatus: { text: string },
+  isTextEmpty: Ref<boolean>,
   isFocused: Ref<boolean>
 ) => {
-  const isEditing = computed(() => textStatus.text !== '' && isFocused.value)
+  const isEditing = computed(() => !isTextEmpty.value && isFocused.value)
 
   const change = (isEditing: boolean) => {
     changeViewState(

--- a/src/components/Main/Navigation/DesktopNavigation.vue
+++ b/src/components/Main/Navigation/DesktopNavigation.vue
@@ -83,6 +83,7 @@ $ephemeralNavigationMinHeight: 64px;
   display: flex;
   width: 100%;
   height: 100%;
+  contain: strict;
 }
 .selector {
   display: flex;

--- a/src/components/Main/Navigation/EphemeralNavigationContent/CollapseContent.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/CollapseContent.vue
@@ -1,0 +1,69 @@
+<template>
+  <div :class="$style.container">
+    <div
+      :class="$style.expandButton"
+      :data-is-expanded="$boolAttr(isExpanded)"
+      @click="toggleExpanded"
+    >
+      <icon :class="$style.expandIcon" name="chevron-up" mdi />
+    </div>
+    <div :class="$style.list" :data-is-expanded="$boolAttr(isExpanded)">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import Icon from '@/components/UI/Icon.vue'
+
+const useExpanded = () => {
+  const isExpanded = ref(false)
+  const toggleExpanded = () => {
+    isExpanded.value = !isExpanded.value
+  }
+  return { isExpanded, toggleExpanded }
+}
+
+export default defineComponent({
+  name: 'CollapseContent',
+  components: {
+    Icon
+  },
+  setup() {
+    const { isExpanded, toggleExpanded } = useExpanded()
+
+    return { isExpanded, toggleExpanded }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1;
+  min-height: 0;
+}
+.expandButton {
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+}
+.expandIcon {
+  transform: rotate(0);
+  transition: transform 0.5s;
+  .expandButton[data-is-expanded] & {
+    transform: rotate(0.5turn);
+  }
+}
+.list {
+  padding: 0 12px 8px 12px;
+  max-height: 120px;
+  overflow: scroll;
+  transition: 0.5s max-height ease-out;
+  &[data-is-expanded] {
+    max-height: 600px;
+  }
+}
+</style>

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/Drafts.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/Drafts.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <drafts-details-panel :input-channels="inputChannels" />
+    <drafts-title-panel />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { useMessageInputStates } from '@/providers/messageInputState'
+import DraftsTitlePanel from './DraftsTitlePanel.vue'
+import DraftsDetailsPanel from './DraftsDetailsPanel.vue'
+
+export default defineComponent({
+  name: 'Drafts',
+  components: {
+    DraftsDetailsPanel,
+    DraftsTitlePanel
+  },
+  setup() {
+    const { inputChannels } = useMessageInputStates()
+    return { inputChannels }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  transition: all 0.3s ease;
+}
+.control {
+  flex: 0 1 64px;
+}
+</style>

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/DraftsDetailsPanel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/DraftsDetailsPanel.vue
@@ -1,0 +1,45 @@
+<template>
+  <collapse-content>
+    <drafts-details-panel-channel
+      :class="$style.channel"
+      v-for="[channelId, state] in inputChannels"
+      :key="channelId"
+      :state="state"
+      :channel-id="channelId"
+    />
+  </collapse-content>
+</template>
+
+<script lang="ts">
+import { MessageInputState } from '@/providers/messageInputState'
+import { ChannelId } from '@/types/entity-ids'
+import { defineComponent, PropType } from 'vue'
+import CollapseContent from '../CollapseContent.vue'
+import DraftsDetailsPanelChannel from './DraftsDetailsPanelChannel.vue'
+
+export default defineComponent({
+  name: 'DraftsDetailsPanel',
+  components: {
+    CollapseContent,
+    DraftsDetailsPanelChannel
+  },
+  props: {
+    inputChannels: {
+      type: Array as PropType<Array<[ChannelId, MessageInputState]>>,
+      required: true
+    }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.channel {
+  margin: 8px 0;
+  &:first-child {
+    margin-top: 0;
+  }
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+</style>

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/DraftsDetailsPanelChannel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/DraftsDetailsPanelChannel.vue
@@ -1,0 +1,77 @@
+<template>
+  <div :class="$style.container" @click="changeChannel">
+    <div :class="$style.state">
+      <icon v-if="hasAttachments" name="file" mdi :class="$style.icon" />
+      <div :class="$style.text" v-html="renderedContent"></div>
+    </div>
+    <div :class="$style.channelPath">{{ channelPath }}</div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, PropType, ref, watchEffect } from 'vue'
+import { MessageInputState } from '@/providers/messageInputState'
+import { ChannelId } from '@/types/entity-ids'
+import useChannelPath from '@/use/channelPath'
+import Icon from '@/components/UI/Icon.vue'
+import { changeChannelById } from '@/router/channel'
+import { renderInline } from '@/lib/markdown/markdown'
+
+export default defineComponent({
+  name: 'InputStateChannel',
+  components: {
+    Icon
+  },
+  props: {
+    channelId: {
+      type: String as PropType<ChannelId>,
+      required: true
+    },
+    state: {
+      type: Object as PropType<MessageInputState>,
+      required: true
+    }
+  },
+  setup(props) {
+    const { channelIdToPathString } = useChannelPath()
+
+    const changeChannel = () => {
+      changeChannelById(props.channelId)
+    }
+
+    const channelPath = computed(() =>
+      channelIdToPathString(props.channelId, true)
+    )
+    const hasAttachments = computed(() => props.state.attachments.length > 0)
+
+    const renderedContent = ref()
+    watchEffect(async () => {
+      const { renderedText } = await renderInline(props.state.text)
+      renderedContent.value = renderedText
+    })
+
+    return { changeChannel, channelPath, hasAttachments, renderedContent }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  cursor: pointer;
+}
+.state {
+  display: flex;
+}
+.icon {
+  flex-shrink: 0;
+}
+.text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.channelPath {
+  @include color-text-secondary;
+  @include size-caption;
+}
+</style>

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/DraftsTitlePanel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Drafts/DraftsTitlePanel.vue
@@ -1,0 +1,43 @@
+<template>
+  <div :class="$style.container">
+    <icon :class="$style.icon" name="pencil" mdi />
+    <div :class="$style.title">下書き</div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import Icon from '@/components/UI/Icon.vue'
+
+export default defineComponent({
+  name: 'DraftsTitlePanel',
+  components: {
+    Icon
+  }
+})
+</script>
+
+<style lang="scss" module>
+.container {
+  @include color-ui-secondary;
+  display: flex;
+  width: 100%;
+  padding: 12px;
+  align-items: center;
+  border-top: {
+    style: solid;
+    width: 2px;
+    color: $theme-background-secondary;
+  }
+}
+.icon {
+  margin-right: 12px;
+}
+.title {
+  font: {
+    size: 0.875rem;
+    weight: bold;
+  }
+  user-select: none;
+}
+</style>

--- a/src/components/Main/Navigation/EphemeralNavigationContent/EphemeralNavigationContent.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/EphemeralNavigationContent.vue
@@ -1,6 +1,7 @@
 <template>
   <ephemeral-navigation-content-container :transparent="transparent">
     <qall v-if="currentEphemeralNavigation === 'qall'" />
+    <drafts v-else-if="currentEphemeralNavigation === 'drafts'" />
   </ephemeral-navigation-content-container>
 </template>
 
@@ -9,12 +10,14 @@ import { defineComponent, PropType } from 'vue'
 import { EphemeralNavigationItemType } from '@/components/Main/Navigation/use/navigationConstructor'
 import EphemeralNavigationContentContainer from './EphemeralNavigationContentContainer.vue'
 import Qall from './Qall/Qall.vue'
+import Drafts from './Drafts/Drafts.vue'
 
 export default defineComponent({
   name: 'EphemeralNavigationContent',
   components: {
     EphemeralNavigationContentContainer,
-    Qall
+    Qall,
+    Drafts
   },
   props: {
     currentEphemeralNavigation: String as PropType<EphemeralNavigationItemType>,

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/Qall.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/Qall.vue
@@ -1,8 +1,7 @@
 <template>
-  <div v-if="currentChannel" :class="$style.container">
+  <div v-if="currentChannel">
     <qall-details-panel />
     <qall-control-panel
-      :class="$style.control"
       :status="status"
       :channel-id="currentChannel"
       :is-mic-muted="isMicMuted"
@@ -52,15 +51,3 @@ export default defineComponent({
   }
 })
 </script>
-
-<style lang="scss" module>
-.container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  transition: all 0.3s ease;
-}
-.control {
-  flex: 0 1 64px;
-}
-</style>

--- a/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanel.vue
+++ b/src/components/Main/Navigation/EphemeralNavigationContent/Qall/QallDetailsPanel.vue
@@ -1,60 +1,41 @@
 <template>
-  <div :class="$style.container">
-    <div
-      :class="$style.expandButton"
-      :data-is-expanded="$boolAttr(isExpanded)"
-      @click="toggleExpanded"
-    >
-      <icon :class="$style.expandIcon" name="chevron-up" mdi />
-    </div>
-    <div :class="$style.list" :data-is-expanded="$boolAttr(isExpanded)">
-      <qall-details-panel-user
-        v-if="me"
-        :class="$style.slider"
-        :key="me"
-        :user-id="me"
-        :mic-muted="mutedUsers.has(me)"
-        :show-tune-button="!showVolumeTune"
-        :show-tune-done-button="showVolumeTune"
-        @tune="toggleVolumeTune(true)"
-        @tune-done="toggleVolumeTune(false)"
-        disabled
-      />
-      <qall-details-panel-user
-        v-for="id in users"
-        :class="$style.slider"
-        :key="id"
-        :user-id="id"
-        :mic-muted="mutedUsers.has(id)"
-        :show-volume-control="showVolumeTune"
-      />
-    </div>
-  </div>
+  <collapse-content>
+    <qall-details-panel-user
+      v-if="me"
+      :class="$style.slider"
+      :key="me"
+      :user-id="me"
+      :mic-muted="mutedUsers.has(me)"
+      :show-tune-button="!showVolumeTune"
+      :show-tune-done-button="showVolumeTune"
+      @tune="toggleVolumeTune(true)"
+      @tune-done="toggleVolumeTune(false)"
+      disabled
+    />
+    <qall-details-panel-user
+      v-for="id in users"
+      :class="$style.slider"
+      :key="id"
+      :user-id="id"
+      :mic-muted="mutedUsers.has(id)"
+      :show-volume-control="showVolumeTune"
+    />
+  </collapse-content>
 </template>
 
 <script lang="ts">
 import { defineComponent, computed, ref } from 'vue'
 import store from '@/store'
 import QallDetailsPanelUser from './QallDetailsPanelUser.vue'
-import Icon from '@/components/UI/Icon.vue'
-
-const useExpanded = () => {
-  const isExpanded = ref(false)
-  const toggleExpanded = () => {
-    isExpanded.value = !isExpanded.value
-  }
-  return { isExpanded, toggleExpanded }
-}
+import CollapseContent from '../CollapseContent.vue'
 
 export default defineComponent({
   name: 'QallDetailsPanel',
   components: {
-    Icon,
+    CollapseContent,
     QallDetailsPanelUser
   },
   setup() {
-    const { isExpanded, toggleExpanded } = useExpanded()
-
     const showVolumeTune = ref(false)
     const toggleVolumeTune = (show: boolean) => {
       showVolumeTune.value = show
@@ -72,8 +53,6 @@ export default defineComponent({
     )
 
     return {
-      isExpanded,
-      toggleExpanded,
       users,
       me,
       mutedUsers,

--- a/src/components/Main/Navigation/use/navigationConstructor.ts
+++ b/src/components/Main/Navigation/use/navigationConstructor.ts
@@ -12,7 +12,7 @@ export type NavigationItemType =
  *
  * 「選択しない」を許すのでnullable
  */
-export type EphemeralNavigationItemType = 'qall' | undefined
+export type EphemeralNavigationItemType = 'qall' | 'drafts' | undefined
 
 // TODO: 言語系リソースの置き場所
 export const navigationTypeNameMap: Record<NavigationItemType, string> = {
@@ -27,7 +27,8 @@ export const ephemeralNavigationTypeNameMap: Record<
   NonNullable<EphemeralNavigationItemType>,
   string
 > = {
-  qall: 'Qall'
+  qall: 'Qall',
+  drafts: '下書き一覧'
 }
 
 export const {

--- a/src/components/Main/Navigation/use/navigationSelectorEntry.ts
+++ b/src/components/Main/Navigation/use/navigationSelectorEntry.ts
@@ -6,6 +6,7 @@ import {
 } from './navigationConstructor'
 import { ThemeClaim } from '@/lib/styles'
 import { isDefined } from '@/lib/util/array'
+import { useMessageInputStates } from '@/providers/messageInputState'
 
 export type NavigationSelectorEntry = {
   type: NavigationItemType
@@ -59,10 +60,17 @@ export const ephemeralItems: Record<
     iconName: 'phone',
     iconMdi: true,
     colorClaim: (_, common) => common.ui.qall
+  },
+  drafts: {
+    type: 'drafts',
+    iconName: 'pencil',
+    iconMdi: true
   }
 }
 
 const useNavigationSelectorEntry = () => {
+  const { hasInputChannel } = useMessageInputStates()
+
   const unreadChannels = computed(() => [
     ...store.state.domain.me.unreadChannelsMap.values()
   ])
@@ -84,9 +92,10 @@ const useNavigationSelectorEntry = () => {
     return !!store.getters.domain.rtc.qallSession
   })
   const ephemeralEntries = computed(() =>
-    [hasActiveQallSession.value ? ephemeralItems.qall : undefined].filter(
-      isDefined
-    )
+    [
+      hasActiveQallSession.value ? ephemeralItems.qall : undefined,
+      hasInputChannel.value ? ephemeralItems.drafts : undefined
+    ].filter(isDefined)
   )
 
   return {

--- a/src/components/Settings/StampTab/Stamp.vue
+++ b/src/components/Settings/StampTab/Stamp.vue
@@ -4,7 +4,7 @@
     <div v-if="!isSelected" :class="$style.notSelected">
       <p>:{{ stamp.name }}:</p>
       <icon
-        name="pencil"
+        name="pencil-outline"
         mdi
         :size="20"
         @click="onStartEdit"

--- a/src/components/ShareTarget/ShareTargetForm.vue
+++ b/src/components/ShareTarget/ShareTargetForm.vue
@@ -3,7 +3,7 @@
     <form-selector
       :class="$style.item"
       label="投稿先チャンネル"
-      v-model="channelState.channelId"
+      v-model="channelId"
       :options="channelOptions"
     />
     <share-target-message-input :class="[$style.item, $style.input]" />
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, reactive, watch } from 'vue'
+import { defineComponent, computed, watch, ref } from 'vue'
 import FormSelector from '@/components/UI/FormSelector.vue'
 import store from '@/store'
 import { nullUuid } from '@/lib/util/uuid'
@@ -26,6 +26,7 @@ import FormButton from '@/components/UI/FormButton.vue'
 import usePostMessage from '@/components/Main/MainView/MessageInput/use/postMessage'
 import useChannelOptions from '@/use/channelOptions'
 import useMessageInputState from '@/providers/messageInputState'
+import { ChannelId } from '@/types/entity-ids'
 
 export default defineComponent({
   name: 'ShareTargetForm',
@@ -49,13 +50,11 @@ export default defineComponent({
     store.dispatch.entities.fetchChannels()
     const { channelOptions } = useChannelOptions('-----')
 
-    const channelState = reactive({
-      channelId: nullUuid
-    })
+    const channelId = ref<ChannelId>(nullUuid)
     watch(
       homeChannelId,
       newVal => {
-        channelState.channelId = newVal
+        channelId.value = newVal
       },
       { immediate: true }
     )
@@ -65,7 +64,7 @@ export default defineComponent({
     store.dispatch.entities.fetchUserGroups()
 
     // FIXME: 親子関係なのにprovide-injectを乱用してるの微妙
-    const { state } = useMessageInputState()
+    const { state } = useMessageInputState('share-target')
     watch(
       () => props.defaultText,
       newVal => {
@@ -73,7 +72,7 @@ export default defineComponent({
       },
       { immediate: true }
     )
-    const { postMessage, isPosting } = usePostMessage(channelState)
+    const { postMessage, isPosting } = usePostMessage(channelId, 'share-target')
     const post = async () => {
       const posted = await postMessage()
       if (posted) {
@@ -81,7 +80,7 @@ export default defineComponent({
       }
     }
 
-    return { channelState, state, channelOptions, post, isPosting }
+    return { channelId, state, channelOptions, post, isPosting }
   }
 })
 </script>

--- a/src/components/ShareTarget/ShareTargetMessageInput.vue
+++ b/src/components/ShareTarget/ShareTargetMessageInput.vue
@@ -23,7 +23,10 @@
           />
         </div>
       </div>
-      <message-input-file-list :class="$style.fileList" />
+      <message-input-file-list
+        :class="$style.fileList"
+        channel-id="share-target"
+      />
     </div>
   </div>
 </template>
@@ -61,8 +64,8 @@ export default defineComponent({
     }
   },
   setup(props, context) {
-    const { state, isEmpty } = useMessageInputState()
-    const { addAttachment, destroy } = useAttachments()
+    const { state, isEmpty } = useMessageInputState('share-target')
+    const { addAttachment, destroy } = useAttachments('share-target')
 
     onBeforeUnmount(() => {
       destroy()

--- a/src/components/UI/MessagePanel/MessagePanel.vue
+++ b/src/components/UI/MessagePanel/MessagePanel.vue
@@ -20,7 +20,7 @@
         v-if="message.createdAt !== message.updatedAt"
         :class="$style.editIcon"
         :size="16"
-        name="pencil"
+        name="pencil-outline"
         mdi
       />
     </div>

--- a/src/providers/messageInputState.ts
+++ b/src/providers/messageInputState.ts
@@ -1,8 +1,18 @@
-import { provide, inject, reactive, computed, InjectionKey } from 'vue'
+import {
+  provide,
+  inject,
+  reactive,
+  computed,
+  InjectionKey,
+  Ref,
+  unref,
+  watch
+} from 'vue'
 import { AttachmentType, mimeToFileType } from '@/lib/util/file'
 import config from '@/config'
 import { canResize, resize } from '@/lib/resize'
 import { convertToDataUrl } from '@/lib/resize/dataurl'
+import { ChannelId } from '@/types/entity-ids'
 
 const IMAGE_SIZE_LIMIT = 20 * 1000 * 1000 // 20MB
 const FILE_SIZE_LIMIT = 30 * 1000 * 1000 // 30MB
@@ -16,9 +26,20 @@ const FILE_MAX_SIZE_EXCEEDED_MESSAGE = `画像サイズは30MBまでです\n${co
   'ファイル'
 )}`
 
-const messageInputStateSymbol: InjectionKey<MessageInputState> = Symbol()
+const messageInputStateSymbol: InjectionKey<MessageInputStates> = Symbol()
 
-interface MessageInputState {
+/**
+ * ChannelIdの代わりに一意となるもの
+ *
+ * share-target: Web Share Target APIで使う画面で利用
+ */
+const VIRTUAL_IDS = ['share-target'] as const
+export type VirtualChannelId = typeof VIRTUAL_IDS[number]
+const virtualIds: ReadonlySet<string> = new Set(VIRTUAL_IDS)
+
+type MessageInputStates = Map<ChannelId | VirtualChannelId, MessageInputState>
+
+export interface MessageInputState {
   text: string
   attachments: Attachment[]
 }
@@ -30,21 +51,70 @@ export type Attachment = {
 }
 
 const createMessageInputState = () => {
-  return reactive<MessageInputState>({
-    text: '',
-    attachments: []
-  })
+  return reactive<MessageInputStates>(new Map())
 }
 
 export const provideMessageInputState = () => {
   provide(messageInputStateSymbol, createMessageInputState())
 }
 
-const useMessageInputState = () => {
-  const state = inject(messageInputStateSymbol)
-  if (!state) {
+export const useMessageInputStates = () => {
+  const states = inject(messageInputStateSymbol)
+  if (!states) {
     throw new Error('useMessageInputState() was called without provider.')
   }
+
+  const inputChannels = computed(() =>
+    [...states].filter(([id]) => !virtualIds.has(id))
+  )
+  const hasInputChannel = computed(() => inputChannels.value.length > 0)
+
+  return { inputChannels, hasInputChannel }
+}
+
+export type MessageInputStateKey = Ref<ChannelId> | VirtualChannelId
+
+const useMessageInputState = (channelId: MessageInputStateKey) => {
+  const states = inject(messageInputStateSymbol)
+  if (!states) {
+    throw new Error('useMessageInputState() was called without provider.')
+  }
+
+  const getStore = () => states.get(unref(channelId))
+  const setStore = (v: MessageInputState) => {
+    // 空のときは削除、空でないときはセット
+    if (v && (v.text !== '' || v.attachments.length > 0)) {
+      // コピーしないと参照が変わらないから上書きされる
+      // toRawしちゃうとreactiveで包めなくなるので、そうはしない
+      states.set(unref(channelId), { ...v })
+    } else {
+      states.delete(unref(channelId))
+    }
+  }
+
+  const state: MessageInputState = reactive(
+    getStore() ?? { text: '', attachments: [] }
+  )
+  watch(
+    () => getStore(),
+    v => {
+      if (v) {
+        state.text = v.text
+        state.attachments = v.attachments
+      } else {
+        state.text = ''
+        state.attachments = []
+      }
+    },
+    { deep: true }
+  )
+  watch(
+    state,
+    v => {
+      setStore(v)
+    },
+    { deep: true }
+  )
 
   const isTextEmpty = computed(() => state.text === '')
   const isAttachmentEmpty = computed(() => state.attachments.length === 0)

--- a/src/use/textModelSyncer.ts
+++ b/src/use/textModelSyncer.ts
@@ -17,7 +17,7 @@ const useTextModelSyncer = (
   const value = useModelSyncer(props, context, onUpdate)
   const onComposition = (e: CompositionEvent) => {
     onUpdate?.(e.data)
-    context.emit('update:modelValue', e.data)
+    context.emit('update:modelValue', value.value)
   }
 
   return { value, onComposition }

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -60,6 +60,7 @@ import useMainViewLayout from './use/mainViewLayout'
 import useRouteWatcher from './use/routeWatcher'
 import useInitialFetch from './use/initialFetch'
 import useToastStore from '@/providers/toastStore'
+import { useMessageInputStates } from '@/providers/messageInputState'
 
 const useStyles = (
   mainViewPosition: Readonly<Ref<number>>,
@@ -73,6 +74,19 @@ const useStyles = (
       transform: `translateX(${sidebarPosition.value}px)`
     }))
   })
+
+const useDraftConfirmer = () => {
+  const { hasInputChannel } = useMessageInputStates()
+  window.addEventListener('beforeunload', event => {
+    if (hasInputChannel.value) {
+      const unloadMessage =
+        'このまま終了すると下書きが削除されます。本当に終了しますか？'
+      event.preventDefault()
+      event.returnValue = unloadMessage
+      return unloadMessage
+    }
+  })
+}
 
 const NotFound = defineAsyncComponent(
   () => import(/* webpackChunkName: "NotFound" */ '@/views/NotFound.vue')
@@ -112,6 +126,8 @@ export default defineComponent({
     const hideOuter = computed(
       () => isMobile.value && isNavCompletelyAppeared.value
     )
+
+    useDraftConfirmer()
 
     const { routeWatcherState, triggerRouteParamChange } = useRouteWatcher()
     useInitialFetch(() => {


### PR DESCRIPTION
- 入力状態をチャンネル別に保持するように close #699
- 下書き一覧を表示するように
- 下書きによって幅が変わるのを一時的に対処
  - Safariでは直らないのでまた今度直す => #1784 
- 下書きがある状態でリロードしようとしたら確認する
- 入力中の文字が変換中の文字で上書き表示されることがあった
  - たぶんここ以外影響はない

![image](https://user-images.githubusercontent.com/49056869/104132200-102a5200-53bf-11eb-9714-eee52501d753.png)
