### PR TITLE
過去のメッセージ閲覧中はそのチャンネルの新規メッセージを未読にする

### DIFF
--- a/src/components/Main/MainView/ClipsView/use/clipsFetcher.ts
+++ b/src/components/Main/MainView/ClipsView/use/clipsFetcher.ts
@@ -1,7 +1,7 @@
 import useMessageFetcher from '@/components/Main/MainView/MessagesScroller/use/messagesFetcher'
 import store from '@/store'
 import { MessageId, ClipFolderId } from '@/types/entity-ids'
-import { reactive, Ref, watch, onMounted } from 'vue'
+import { reactive, Ref, watch, onMounted, onActivated } from 'vue'
 
 const fetchLimit = 50
 
@@ -36,9 +36,6 @@ const useClipsFetcher = (props: {
     return clips.map(clip => clip.message.id)
   }
 
-  // クリップフォルダは、wsの再接続時にうまく取得ができないので、
-  // 自動で再取得するのはあきらめる
-
   const messagesFetcher = useMessageFetcher(
     {},
     fetchFormerMessages,
@@ -50,6 +47,8 @@ const useClipsFetcher = (props: {
   onMounted(() => {
     reset()
     messagesFetcher.init()
+
+    store.dispatch.domain.messagesView.syncViewState()
   })
   watch(
     () => props.clipFolderId,
@@ -61,6 +60,14 @@ const useClipsFetcher = (props: {
       messagesFetcher.init()
     }
   )
+
+  onActivated(() => {
+    // 一応送りなおす
+    store.dispatch.domain.messagesView.syncViewState()
+  })
+
+  // クリップフォルダは、wsの再接続時にうまく取得ができないので、
+  // 自動で再取得するのはあきらめる
 
   return messagesFetcher
 }

--- a/src/components/Main/MainView/MessageInput/use/editingStatus.ts
+++ b/src/components/Main/MainView/MessageInput/use/editingStatus.ts
@@ -2,19 +2,27 @@ import { watch, Ref, onMounted, computed } from 'vue'
 import { changeViewState } from '@/lib/websocket'
 import { ChannelId, DMChannelId } from '@/types/entity-ids'
 import { ChannelViewState } from '@traptitech/traq'
+import store from '@/store'
 
 const useEditingStatus = (
   channelId: Ref<ChannelId | DMChannelId>,
   isTextEmpty: Ref<boolean>,
   isFocused: Ref<boolean>
 ) => {
-  const isEditing = computed(() => !isTextEmpty.value && isFocused.value)
+  const isEditing = computed(
+    () =>
+      !isTextEmpty.value &&
+      isFocused.value &&
+      // 最新メッセージ閲覧中以外は入力中にしない(入力中にすると未読に追加されなくなるため)
+      store.state.domain.messagesView.shouldRetriveMessageCreateEvent
+  )
 
   const change = (isEditing: boolean) => {
-    changeViewState(
-      channelId.value,
-      isEditing ? ChannelViewState.Editing : ChannelViewState.Monitoring
-    )
+    if (isEditing) {
+      changeViewState(channelId.value, ChannelViewState.Editing)
+    } else {
+      store.dispatch.domain.messagesView.syncViewState()
+    }
   }
 
   onMounted(() => {

--- a/src/store/domain/me/actions.ts
+++ b/src/store/domain/me/actions.ts
@@ -69,8 +69,11 @@ export const actions = defineActions({
   },
   onMessageCreated(context, message: Message) {
     const { rootState, getters, commit, rootGetters } = meActionContext(context)
-    // 見ているチャンネルは未読に追加しない
-    if (rootState.domain.messagesView.currentChannelId === message.channelId)
+    // 最新の投稿を見ているチャンネルは未読に追加しない
+    if (
+      rootState.domain.messagesView.currentChannelId === message.channelId &&
+      rootState.domain.messagesView.shouldRetriveMessageCreateEvent
+    )
       return
     // 自分の投稿は未読に追加しない
     if (rootGetters.domain.me.myId === message.userId) return


### PR DESCRIPTION
- 過去のメッセージ閲覧中はそのチャンネルの新規メッセージを未読にする fix #1783 
- さらに最新メッセージを表示するまではそのチャンネルを未読のままにする close #636 
- 過去のメッセージ閲覧中は入力状態にならないように

---

## 実装メモ refs #1751 

1. store/ui.mainViewでchannelにセット
2. store/domain.messagesView.changeCurrentChannelで未読表示の追加
3. 上で`currentChannelId`がつくので、`messageFetcher`のinitが発火
    - 新規メッセージ読み込みの場合はここで`setShouldRetriveMessageCreateEvent(true)`を呼び出す
4. 過去メッセージ読み込みの場合は最新にたどり着いたときに`channelMessageFetcher`で`setShouldRetriveMessageCreateEvent(true)`を呼び出す

|状態|`ChannelViewState`|WSからの新規メッセージの扱い|サーバーでの未読の扱い|クライアントでの未読の扱い|
|---|---|---|---|---|
|過去メッセージ閲覧中|`None`<br>(メッセージ入力中は`Editing`)|処理しない|追加される|追加する<br>`store/domain.me.onMessageCreated`|
|最新メッセージ閲覧中|`Monitoring`<br>(メッセージ入力中は`Editing`)|処理する|追加されない|追加しない<br>`store/domain.me.onMessageCreated`|

過去メッセージ閲覧中 => 最新メッセージ閲覧中: `ChannelViewState`を変更するとともに`setShouldRetriveMessageCreateEvent(true)`を呼び出す(この中でチャンネルの既読を行う)

`ChannelViewState`は`props.channelId`と`messagesFetcher.isReachedLatest`に同期

### 設定画面
- 過去メッセージ閲覧中 => 設定画面 =(再取得)=> 過去メッセージ閲覧中
- 最新メッセージ閲覧中 => 設定画面 =(再取得)=> 最新メッセージ閲覧中
- 最新メッセージ閲覧中 => 設定画面 =(再取得)=> 過去メッセージ閲覧中

設定画面のときは`ChannelViewState`は`null`(設定画面の`mount`時に変更)
再取得はWSの再接続と同じ`loadNewMessages`(この中で`setShouldRetriveMessageCreateEvent`が呼び出される)
