### PR TITLE
チャンネル検索の拡張

### DIFF
--- a/src/components/Main/Navigation/NavigationContent/Channels.vue
+++ b/src/components/Main/Navigation/NavigationContent/Channels.vue
@@ -35,7 +35,7 @@
 import { defineComponent, computed, Ref } from 'vue'
 import store from '@/store'
 import ChannelList from '@/components/Main/Navigation/ChannelList/ChannelList.vue'
-import useTextFilter from '@/use/textFilter'
+import useChannelFilter from '@/use/channelFilter'
 import { constructTree } from '@/lib/channelTree'
 import ChannelFilter from '../ChannelList/ChannelFilter.vue'
 import { Channel } from '@traptitech/traq'
@@ -44,7 +44,7 @@ import NavigationContentContainer from '@/components/Main/Navigation/NavigationC
 import Icon from '@/components/UI/Icon.vue'
 
 const useChannelListFilter = (channels: Readonly<Ref<readonly Channel[]>>) => {
-  const { textFilterState } = useTextFilter(channels, 'name')
+  const { textFilterState } = useChannelFilter(channels) // useTextFilter(channels, 'name')
   return {
     channelListFilterState: textFilterState
   }

--- a/src/components/Main/Navigation/NavigationContent/Channels.vue
+++ b/src/components/Main/Navigation/NavigationContent/Channels.vue
@@ -44,7 +44,7 @@ import NavigationContentContainer from '@/components/Main/Navigation/NavigationC
 import Icon from '@/components/UI/Icon.vue'
 
 const useChannelListFilter = (channels: Readonly<Ref<readonly Channel[]>>) => {
-  const { textFilterState } = useChannelFilter(channels) // useTextFilter(channels, 'name')
+  const { textFilterState } = useChannelFilter(channels)
   return {
     channelListFilterState: textFilterState
   }

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -43,12 +43,7 @@ export const channelIdToPathString = (
   return simpleChannelPath.map(c => c.name).join('/')
 }
 
-export const checkResult = {
-  none: 0,
-  match: 1,
-  perfect: 2
-} as const
-export type checkResult = typeof checkResult[keyof typeof checkResult]
+export type checkResult = 'none' | 'match' | 'perfect'
 
 interface matchResult {
   perfectMatched: Channel[]
@@ -95,12 +90,12 @@ const channelRecursiveDeepMatching = <T>(
   const nowChannel = channelMap.get(nowChannelId)
   if (nowChannel === undefined) return { perfectMatched: [], matched: [] }
   const check = f(nowChannel, restQuery[0])
-  if (check === checkResult.none) return { perfectMatched: [], matched: [] }
+  if (check === 'none') return { perfectMatched: [], matched: [] }
   if (restQuery.length === 1) {
     if (!targetChannelMap.has(nowChannelId)) {
       return { perfectMatched: [], matched: [] }
     }
-    return stillPerfect && check === checkResult.perfect
+    return stillPerfect && check === 'perfect'
       ? { perfectMatched: [nowChannel], matched: [] }
       : { perfectMatched: [], matched: [nowChannel] }
   }
@@ -111,7 +106,7 @@ const channelRecursiveDeepMatching = <T>(
       restQuery.slice(1) as [T, ...T[]],
       id,
       targetChannelMap,
-      stillPerfect && check === checkResult.perfect
+      stillPerfect && check === 'perfect'
     )
   )
   return {

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -44,9 +44,9 @@ export const channelIdToPathString = (
   return simpleChannelPath.map(c => c.name).join('/')
 }
 
-export type checkResult = 'none' | 'match' | 'perfect'
+export type CheckResult = 'none' | 'match' | 'perfect'
 
-export interface matchResult<T extends ChannelLike> {
+export interface MatchResult<T extends ChannelLike> {
   perfectMatched: T[]
   matched: T[]
 }
@@ -54,7 +54,7 @@ export interface matchResult<T extends ChannelLike> {
 const checkMatchChannel = (
   channel: ChannelLike,
   query: string
-): checkResult => {
+): CheckResult => {
   if (channel.name === query) return 'perfect'
   if (channel.name.includes(query)) return 'match'
   return 'none'
@@ -71,7 +71,7 @@ export const channelDeepMatching = <T extends ChannelLike>(
   channelMap: ReadonlyMap<ChannelId, T>,
   querys: readonly [string, ...string[]],
   targetChannelMap: ReadonlySet<ChannelId> = new Set(channelMap.keys())
-): matchResult<T> => {
+): MatchResult<T> => {
   const results = [...channelMap.values()].map(channel =>
     channelRecursiveDeepMatching(
       channelMap,
@@ -92,7 +92,7 @@ const channelRecursiveDeepMatching = <T extends ChannelLike>(
   nowChannelId: ChannelId,
   targetChannelMap: ReadonlySet<ChannelId>,
   stillPerfect = true
-): matchResult<T> => {
+): MatchResult<T> => {
   const nowChannel = channelMap.get(nowChannelId)
   if (nowChannel === undefined) return { perfectMatched: [], matched: [] }
   const check = checkMatchChannel(nowChannel, restQuery[0])

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -46,7 +46,7 @@ export const channelIdToPathString = (
 
 export type checkResult = 'none' | 'match' | 'perfect'
 
-interface matchResult<T extends ChannelLike> {
+export interface matchResult<T extends ChannelLike> {
   perfectMatched: T[]
   matched: T[]
 }

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -95,8 +95,10 @@ const channelRecursiveDeepMatching = <T extends ChannelLike>(
 ): MatchResult<T> => {
   const nowChannel = channelMap.get(nowChannelId)
   if (nowChannel === undefined) return { perfectMatched: [], matched: [] }
+
   const check = checkMatchChannel(nowChannel, restQuery[0])
   if (check === 'none') return { perfectMatched: [], matched: [] }
+
   if (restQuery.length === 1) {
     if (!targetChannelMap.has(nowChannelId)) {
       return { perfectMatched: [], matched: [] }
@@ -105,6 +107,7 @@ const channelRecursiveDeepMatching = <T extends ChannelLike>(
       ? { perfectMatched: [nowChannel], matched: [] }
       : { perfectMatched: [], matched: [nowChannel] }
   }
+
   const res = nowChannel.children.map(id =>
     channelRecursiveDeepMatching(
       channelMap,

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -69,7 +69,7 @@ const checkMatchChannel = (
  */
 export const channelDeepMatching = <T extends ChannelLike>(
   channelMap: ReadonlyMap<ChannelId, T>,
-  querys: [string, ...string[]],
+  querys: readonly [string, ...string[]],
   targetChannelMap: ReadonlySet<ChannelId> = new Set(channelMap.keys())
 ): matchResult<T> => {
   const results = [...channelMap.values()].map(channel =>
@@ -88,7 +88,7 @@ export const channelDeepMatching = <T extends ChannelLike>(
 
 const channelRecursiveDeepMatching = <T extends ChannelLike>(
   channelMap: ReadonlyMap<ChannelId, T>,
-  restQuery: [string, ...string[]],
+  restQuery: readonly [string, ...string[]],
   nowChannelId: ChannelId,
   targetChannelMap: ReadonlySet<ChannelId>,
   stillPerfect = true

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -2,6 +2,7 @@ import { count } from '@/lib/util/string'
 import { ChannelId } from '@/types/entity-ids'
 import { Channel } from '@traptitech/traq'
 import { dmParentUuid } from '@/lib/util/uuid'
+import { ChannelLike } from './channelTree'
 
 const MAX_CHANNEL_DEPTH = 5
 const MAX_CHANNEL_PATH_SLASHES = MAX_CHANNEL_DEPTH - 1
@@ -45,29 +46,35 @@ export const channelIdToPathString = (
 
 export type checkResult = 'none' | 'match' | 'perfect'
 
-interface matchResult {
-  perfectMatched: Channel[]
-  matched: Channel[]
+interface matchResult<T extends ChannelLike> {
+  perfectMatched: T[]
+  matched: T[]
+}
+
+const checkMatchChannel = (
+  channel: ChannelLike,
+  query: string
+): checkResult => {
+  if (channel.name === query) return 'perfect'
+  if (channel.name.includes(query)) return 'match'
+  return 'none'
 }
 
 /**
  * 連続するチャンネルに対し、連続する条件を満たすようなチャンネルを得る関数
  * @param channelMap チャンネルの id とチャンネル情報を対応付ける map
- * @param f 判定する関数
  * @param querys 連続するクエリ
  * @param targetChannelMap 対象のチャンネルの map
  * @returns 条件を満たすようなチャンネルの配列
  */
-export const channelDeepMatching = <T>(
-  channelMap: ReadonlyMap<ChannelId, Channel>,
-  f: (channel: Channel, query: T) => checkResult,
-  querys: [T, ...T[]],
+export const channelDeepMatching = <T extends ChannelLike>(
+  channelMap: ReadonlyMap<ChannelId, T>,
+  querys: [string, ...string[]],
   targetChannelMap: ReadonlySet<ChannelId> = new Set(channelMap.keys())
-): matchResult => {
+): matchResult<T> => {
   const results = [...channelMap.values()].map(channel =>
     channelRecursiveDeepMatching(
       channelMap,
-      f,
       querys,
       channel.id,
       targetChannelMap
@@ -79,17 +86,16 @@ export const channelDeepMatching = <T>(
   }
 }
 
-const channelRecursiveDeepMatching = <T>(
-  channelMap: ReadonlyMap<ChannelId, Channel>,
-  f: (channel: Channel, query: T) => checkResult,
-  restQuery: [T, ...T[]],
+const channelRecursiveDeepMatching = <T extends ChannelLike>(
+  channelMap: ReadonlyMap<ChannelId, T>,
+  restQuery: [string, ...string[]],
   nowChannelId: ChannelId,
   targetChannelMap: ReadonlySet<ChannelId>,
   stillPerfect = true
-): matchResult => {
+): matchResult<T> => {
   const nowChannel = channelMap.get(nowChannelId)
   if (nowChannel === undefined) return { perfectMatched: [], matched: [] }
-  const check = f(nowChannel, restQuery[0])
+  const check = checkMatchChannel(nowChannel, restQuery[0])
   if (check === 'none') return { perfectMatched: [], matched: [] }
   if (restQuery.length === 1) {
     if (!targetChannelMap.has(nowChannelId)) {
@@ -102,8 +108,7 @@ const channelRecursiveDeepMatching = <T>(
   const res = nowChannel.children.map(id =>
     channelRecursiveDeepMatching(
       channelMap,
-      f,
-      restQuery.slice(1) as [T, ...T[]],
+      restQuery.slice(1) as [string, ...string[]],
       id,
       targetChannelMap,
       stillPerfect && check === 'perfect'

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -40,11 +40,13 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
 
         const channel = store.state.entities.channelsMap.get(id)
         if (channel === undefined) return
-        if (targetChannelIds.value.has(channel.id))
+        // targetChannel に存在していたら検索結果に入れる
+        if (targetChannelIds.value.has(channel.id)) {
           // 完全一致していたら fullMatched に入れる
-          (channel.name.toLowerCase() === query ? fullMatched : matched).push(
+          ;(channel.name.toLowerCase() === query ? fullMatched : matched).push(
             channel
           )
+        }
         for (const child of channel.children) {
           recursiveMatching(child)
         }
@@ -58,7 +60,6 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
         queryRest: [string, ...string[]] = queryArr
       ) => {
         if (matchedChannel.has(id)) return
-
         const channel = store.state.entities.channelsMap.get(id)
         if (channel === undefined) return
         if (queryRest.length === 1) {
@@ -91,6 +92,7 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
             .forEach(item => recursiveMatching(item.id))
           return [...fullMatched, ...matched]
         }
+
         for (const [id, channel] of store.state.entities.channelsMap) {
           const keyValue = channel.name.toLowerCase()
           if (keyValue.includes(query)) recursiveMatching(id)

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -8,9 +8,7 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
     () => new Set(targetChannels.value.map(channel => channel.id))
   )
   const oneLetterChannels = computed(() =>
-    [...store.state.entities.channelsMap.values()].filter(
-      channel => channel.name.length === 1
-    )
+    targetChannels.value.filter(channel => channel.name.length === 1)
   )
 
   const state = reactive({
@@ -24,14 +22,17 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
         .toLowerCase()
         .split(/[\/\\]/) as [string, ...string[]] // split の返り値は空配列にはならないのでキャストできる
 
+      if (query.length === 1 && queryArr.length === 1) {
+        // query が真に１文字のときは完全一致のみ
+        return oneLetterChannels.value.filter(channel => channel.name === query)
+      }
+
       const { perfectMatched: fullMatched, matched } = channelDeepMatching(
         store.state.entities.channelsMap,
         queryArr,
         targetChannelIds.value
       )
-      return query.length === 1 && queryArr.length === 1
-        ? [...fullMatched] // query が真に 1 文字のときは完全一致のみ
-        : [...fullMatched, ...matched]
+      return [...fullMatched, ...matched]
     })
   })
   const setQuery = (query: string) => {

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -2,12 +2,12 @@ import store from '@/store'
 import { Channel } from '@traptitech/traq'
 import { reactive, computed, Ref } from 'vue'
 
-const useChannelFilter = (items: Ref<readonly Channel[]>) => {
-  const itemsMap = computed(
-    () => new Map(items.value.map(item => [item.id, item]))
+const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
+  const targetChannelIds = computed(
+    () => new Set(targetChannels.value.map(channel => channel.id))
   )
   const oneLetterChannels = computed(() =>
-    Array.from(store.state.entities.channelsMap)
+    [...store.state.entities.channelsMap]
       .map(([_, channel]) => channel)
       .filter(channel => channel.name.length === 1)
   )
@@ -16,7 +16,7 @@ const useChannelFilter = (items: Ref<readonly Channel[]>) => {
     query: '',
     filteredItems: computed((): readonly Channel[] => {
       if (state.query.length === 0) {
-        return items.value
+        return targetChannels.value
       }
       const query = state.query.toLowerCase()
       const queryArr: [string, ...string[]] = state.query
@@ -40,7 +40,7 @@ const useChannelFilter = (items: Ref<readonly Channel[]>) => {
 
         const channel = store.state.entities.channelsMap.get(id)
         if (channel === undefined) return
-        if (itemsMap.value.has(channel.id))
+        if (targetChannelIds.value.has(channel.id))
           // 完全一致していたら fullMatched に入れる
           (channel.name.toLowerCase() === query ? fullMatched : matched).push(
             channel

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -26,7 +26,7 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
       /**
        * 既にマッチしたチャンネルの id をもつ
        */
-      const matchedChannel: Set<string> = new Set()
+      const matchedChannelIds: Set<string> = new Set()
 
       const fullMatched: Channel[] = []
       const matched: Channel[] = []
@@ -35,8 +35,8 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
        *  親チャンネルから子チャンネルたちを再帰的にマッチさせていく
        */
       const recursiveMatching = (id: string) => {
-        if (matchedChannel.has(id)) return
-        matchedChannel.add(id)
+        if (matchedChannelIds.has(id)) return
+        matchedChannelIds.add(id)
 
         const channel = store.state.entities.channelsMap.get(id)
         if (channel === undefined) return
@@ -59,7 +59,7 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
         id: string,
         queryRest: [string, ...string[]] = queryArr
       ) => {
-        if (matchedChannel.has(id)) return
+        if (matchedChannelIds.has(id)) return
         const channel = store.state.entities.channelsMap.get(id)
         if (channel === undefined) return
         if (queryRest.length === 1) {

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -1,7 +1,7 @@
 import store from '@/store'
 import { Channel } from '@traptitech/traq'
 import { reactive, computed, Ref } from 'vue'
-import { checkResult, channelDeepMatching } from '@/lib/channel'
+import { channelDeepMatching } from '@/lib/channel'
 
 const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
   const targetChannelIds = computed(
@@ -24,15 +24,8 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
         .toLowerCase()
         .split(/[\/\\]/) as [string, ...string[]] // split の返り値は空配列にはならないのでキャストできる
 
-      const matchCheck = (channel: Channel, query: string): checkResult => {
-        if (channel.name === query) return checkResult.perfect
-        if (channel.name.includes(query)) return checkResult.match
-        return checkResult.none
-      }
-
       const { perfectMatched: fullMatched, matched } = channelDeepMatching(
         store.state.entities.channelsMap,
-        matchCheck,
         queryArr,
         targetChannelIds.value
       )

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -7,9 +7,9 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
     () => new Set(targetChannels.value.map(channel => channel.id))
   )
   const oneLetterChannels = computed(() =>
-    [...store.state.entities.channelsMap]
-      .map(([_, channel]) => channel)
-      .filter(channel => channel.name.length === 1)
+    [...store.state.entities.channelsMap.values()].filter(
+      channel => channel.name.length === 1
+    )
   )
 
   const state = reactive({
@@ -100,7 +100,7 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
         return [...fullMatched, ...matched]
       }
 
-      for (const [id, channel] of store.state.entities.channelsMap) {
+      for (const id of store.state.entities.channelsMap.keys()) {
         recursiveMatchingWithSlash(id)
       }
       return [...fullMatched, ...matched] // fullMatched は 空のはずだけど一応

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -1,0 +1,120 @@
+import store from '@/store'
+import { Channel } from '@traptitech/traq'
+import { reactive, computed, Ref } from 'vue'
+
+const useChannelFilter = (items: Ref<readonly Channel[]>) => {
+  const itemsMap = computed(
+    () => new Map(items.value.map(item => [item.id, item]))
+  )
+  const oneLetterChannels = computed(() =>
+    Array.from(store.state.entities.channelsMap)
+      .map(([_, channel]) => channel)
+      .filter(channel => channel.name.length === 1)
+  )
+
+  const state = reactive({
+    query: '',
+    filteredItems: computed((): readonly Channel[] => {
+      if (state.query.length === 0) {
+        return items.value
+      }
+      const query = state.query.toLowerCase()
+      const queryArr: [string, ...string[]] = state.query
+        .toLowerCase()
+        .split(/[\/\\]/) as [string, ...string[]] // split の返り値は空配列にはならないのでキャストできる
+
+      // チャンネル情報とすでにマッチしたか を情報に持つ
+      const channelWithMatchRecord = Object.fromEntries(
+        Array.from(store.state.entities.channelsMap).map(([id, item]) => [
+          id,
+          {
+            isMatched: false,
+            channel: item
+          }
+        ])
+      )
+
+      const fullMatched: Channel[] = []
+      const matched: Channel[] = []
+
+      /**
+       *  親チャンネルから子チャンネルたちを再帰的にマッチさせていく
+       */
+      const recursiveMatching = (id: string) => {
+        if (channelWithMatchRecord[id] === undefined) return
+        const { isMatched, channel } = channelWithMatchRecord[id]
+        if (isMatched) return
+        channelWithMatchRecord[id].isMatched = true
+        if (itemsMap.value.has(channel.id))
+          // 完全一致していたら fullMatched に入れる
+          (channel.name.toLowerCase() === query ? fullMatched : matched).push(
+            channel
+          )
+        for (const child of channel.children) {
+          recursiveMatching(child)
+        }
+      }
+
+      /**
+       *  / 区切りのクエリに対し再帰的にマッチさせていく
+       */
+      const recursiveMatchingWithSlash = (
+        id: string,
+        queryRest: [string, ...string[]] = queryArr
+      ) => {
+        if (channelWithMatchRecord[id] === undefined) return
+        const { isMatched, channel } = channelWithMatchRecord[id]
+        if (isMatched) return
+        if (queryRest.length === 1) {
+          // 最後のひとつは前方一致
+          if (!channel.name.startsWith(queryRest[0])) return
+          recursiveMatching(id)
+          return
+        }
+        // 以下 queryRest は [string, string, ...string[]] とみなせる
+        if (queryRest.length === queryArr.length) {
+          // 最初の一つは後方一致
+          if (!channel.name.endsWith(queryRest[0])) return
+        } else {
+          // 間のやつは完全一致
+          if (channel.name !== queryRest[0]) return
+        }
+
+        for (const child of channel.children)
+          recursiveMatchingWithSlash(
+            child,
+            queryRest.slice(1) as [string, ...string[]] // queryRest.length > 1 なので slice しても [string, ...string[]] とみなせる
+          )
+      }
+
+      // queryが区切り文字を含まない場合
+      if (queryArr.length === 1) {
+        if (state.query.length === 1) {
+          oneLetterChannels.value
+            .filter(item => item.name.toLowerCase() === query)
+            .forEach(item => recursiveMatching(item.id))
+          return [...fullMatched, ...matched]
+        }
+        for (const [id, channel] of store.state.entities.channelsMap) {
+          const keyValue = channel.name.toLowerCase()
+          if (keyValue.includes(query)) recursiveMatching(id)
+        }
+        return [...fullMatched, ...matched]
+      }
+
+      for (const [id, channel] of store.state.entities.channelsMap) {
+        recursiveMatchingWithSlash(id)
+      }
+      return [...fullMatched, ...matched] // fullMatched は 空のはずだけど一応
+    })
+  })
+  const setQuery = (query: string) => {
+    state.query = query
+  }
+  return {
+    textFilterState: state,
+    setQuery
+  }
+}
+
+export default useChannelFilter

--- a/src/use/channelFilter.ts
+++ b/src/use/channelFilter.ts
@@ -1,6 +1,7 @@
 import store from '@/store'
 import { Channel } from '@traptitech/traq'
 import { reactive, computed, Ref } from 'vue'
+import { checkResult, channelDeepMatching } from '@/lib/channel'
 
 const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
   const targetChannelIds = computed(
@@ -23,87 +24,21 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
         .toLowerCase()
         .split(/[\/\\]/) as [string, ...string[]] // split の返り値は空配列にはならないのでキャストできる
 
-      /**
-       * 既にマッチしたチャンネルの id をもつ
-       */
-      const matchedChannelIds: Set<string> = new Set()
-
-      const fullMatched: Channel[] = []
-      const matched: Channel[] = []
-
-      /**
-       *  親チャンネルから子チャンネルたちを再帰的にマッチさせていく
-       */
-      const recursiveMatching = (id: string) => {
-        if (matchedChannelIds.has(id)) return
-        matchedChannelIds.add(id)
-
-        const channel = store.state.entities.channelsMap.get(id)
-        if (channel === undefined) return
-        // targetChannel に存在していたら検索結果に入れる
-        if (targetChannelIds.value.has(channel.id)) {
-          // 完全一致していたら fullMatched に入れる
-          ;(channel.name.toLowerCase() === query ? fullMatched : matched).push(
-            channel
-          )
-        }
-        for (const child of channel.children) {
-          recursiveMatching(child)
-        }
+      const matchCheck = (channel: Channel, query: string): checkResult => {
+        if (channel.name === query) return checkResult.perfect
+        if (channel.name.includes(query)) return checkResult.match
+        return checkResult.none
       }
 
-      /**
-       *  / 区切りのクエリに対し再帰的にマッチさせていく
-       */
-      const recursiveMatchingWithSlash = (
-        id: string,
-        queryRest: [string, ...string[]] = queryArr
-      ) => {
-        if (matchedChannelIds.has(id)) return
-        const channel = store.state.entities.channelsMap.get(id)
-        if (channel === undefined) return
-        if (queryRest.length === 1) {
-          // 最後のひとつは前方一致
-          if (!channel.name.startsWith(queryRest[0])) return
-          recursiveMatching(id)
-          return
-        }
-        // 以下 queryRest は [string, string, ...string[]] とみなせる
-        if (queryRest.length === queryArr.length) {
-          // 最初の一つは後方一致
-          if (!channel.name.endsWith(queryRest[0])) return
-        } else {
-          // 間のやつは完全一致
-          if (channel.name !== queryRest[0]) return
-        }
-
-        for (const child of channel.children)
-          recursiveMatchingWithSlash(
-            child,
-            queryRest.slice(1) as [string, ...string[]] // queryRest.length > 1 なので slice しても [string, ...string[]] とみなせる
-          )
-      }
-
-      // queryが区切り文字を含まない場合
-      if (queryArr.length === 1) {
-        if (state.query.length === 1) {
-          oneLetterChannels.value
-            .filter(item => item.name.toLowerCase() === query)
-            .forEach(item => recursiveMatching(item.id))
-          return [...fullMatched, ...matched]
-        }
-
-        for (const [id, channel] of store.state.entities.channelsMap) {
-          const keyValue = channel.name.toLowerCase()
-          if (keyValue.includes(query)) recursiveMatching(id)
-        }
-        return [...fullMatched, ...matched]
-      }
-
-      for (const id of store.state.entities.channelsMap.keys()) {
-        recursiveMatchingWithSlash(id)
-      }
-      return [...fullMatched, ...matched] // fullMatched は 空のはずだけど一応
+      const { perfectMatched: fullMatched, matched } = channelDeepMatching(
+        store.state.entities.channelsMap,
+        matchCheck,
+        queryArr,
+        targetChannelIds.value
+      )
+      return query.length === 1 && queryArr.length === 1
+        ? [...fullMatched] // query が真に 1 文字のときは完全一致のみ
+        : [...fullMatched, ...matched]
     })
   })
   const setQuery = (query: string) => {

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -3,7 +3,7 @@ import { matchResult, channelDeepMatching } from '@/lib/channel'
 import { ChannelLike } from '@/lib/channelTree'
 
 describe('channelDeepMatching', () => {
-  it('one empry query', () => {
+  it('one empty query', () => {
     expect(sortResult(channelDeepMatching(channelMap, ['']))).toEqual(
       sortResult({
         perfectMatched: [],

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -105,7 +105,7 @@ describe('channelDeepMatching', () => {
       matched: []
     })
   })
-  it('three empry query', () => {
+  it('three empty query', () => {
     expectResultToBeSame(channelDeepMatching(channelMap, ['', '', '']), {
       perfectMatched: [],
       matched: [

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -133,6 +133,48 @@ describe('channelDeepMatching', () => {
       }
     )
   })
+
+  it('one empty query on star channels', () => {
+    expectResultToBeSame(channelDeepMatching(channelMap, [''], starChannels), {
+      perfectMatched: [],
+      matched: [
+        '77524bb3-0aed-4f7e-153b-c3706945be11',
+        '7ae96689-7720-14a3-33d9-476ba1e7194f',
+        '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+        '38a5e796-f380-38fd-a1c8-92949a38caad'
+      ]
+    })
+  })
+  it('one query on star channels', () => {
+    expectResultToBeSame(
+      channelDeepMatching(channelMap, ['ge'], starChannels),
+      {
+        perfectMatched: [],
+        matched: [
+          '7ae96689-7720-14a3-33d9-476ba1e7194f',
+          '38a5e796-f380-38fd-a1c8-92949a38caad'
+        ]
+      }
+    )
+  })
+  it('two query on star channels', () => {
+    expectResultToBeSame(
+      channelDeepMatching(channelMap, ['ge', ''], starChannels),
+      {
+        perfectMatched: [],
+        matched: ['2570dac4-21b0-282f-f2ef-f8462ea17d8b']
+      }
+    )
+  })
+  it('three query on star channels', () => {
+    expectResultToBeSame(
+      channelDeepMatching(channelMap, ['b', 'a', 'ge'], starChannels),
+      {
+        perfectMatched: [],
+        matched: ['38a5e796-f380-38fd-a1c8-92949a38caad']
+      }
+    )
+  })
 })
 
 const sortResult = <T extends ChannelLike>(

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -4,172 +4,133 @@ import { ChannelLike } from '@/lib/channelTree'
 
 describe('channelDeepMatching', () => {
   it('one empty query', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: [
-          'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
-          '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
-          'c9d4d957-141d-5ca2-0557-04589ca9187a',
-          '231da375-5246-731a-8e59-0d08c3c1f138',
-          '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
-          '77524bb3-0aed-4f7e-153b-c3706945be11',
-          '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
-          '7ae96689-7720-14a3-33d9-476ba1e7194f',
-          '3648304b-a229-415c-b2c9-1cf72b7a2188',
-          '43f92228-719a-901d-00df-40c32a042fd9',
-          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
-          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
-          'd80eeee8-9ec8-1063-f47b-2c54813725b1',
-          'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
-          'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
-          '12d1455f-ec59-36f0-7609-799cfa5fc68f',
-          'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
-          '38a5e796-f380-38fd-a1c8-92949a38caad',
-          '066f3f2b-5775-4963-aed5-78307e4e8122',
-          '346973d0-895e-80bd-c3aa-86f482dd69ce'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['']), {
+      perfectMatched: [],
+      matched: [
+        'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+        '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+        'c9d4d957-141d-5ca2-0557-04589ca9187a',
+        '231da375-5246-731a-8e59-0d08c3c1f138',
+        '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+        '77524bb3-0aed-4f7e-153b-c3706945be11',
+        '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+        '7ae96689-7720-14a3-33d9-476ba1e7194f',
+        '3648304b-a229-415c-b2c9-1cf72b7a2188',
+        '43f92228-719a-901d-00df-40c32a042fd9',
+        '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+        '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+        'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+        'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+        'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+        '12d1455f-ec59-36f0-7609-799cfa5fc68f',
+        'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+        '38a5e796-f380-38fd-a1c8-92949a38caad',
+        '066f3f2b-5775-4963-aed5-78307e4e8122',
+        '346973d0-895e-80bd-c3aa-86f482dd69ce'
+      ]
+    })
   })
   it('one query matching', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['gen']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: [
-          'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
-          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
-          '38a5e796-f380-38fd-a1c8-92949a38caad'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['gen']), {
+      perfectMatched: [],
+      matched: [
+        'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+        '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+        '38a5e796-f380-38fd-a1c8-92949a38caad'
+      ]
+    })
   })
   it('one query matching with full match', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['gene']))).toEqual(
-      sortResult({
-        perfectMatched: [
-          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
-          '38a5e796-f380-38fd-a1c8-92949a38caad'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined),
-        matched: ['e45a34fe-2d2b-1f41-83fd-3d345fdd9df0']
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['gene']), {
+      perfectMatched: [
+        '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+        '38a5e796-f380-38fd-a1c8-92949a38caad'
+      ],
+      matched: ['e45a34fe-2d2b-1f41-83fd-3d345fdd9df0']
+    })
   })
   it('two empty query', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['', '']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: [
-          '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
-          'c9d4d957-141d-5ca2-0557-04589ca9187a',
-          '231da375-5246-731a-8e59-0d08c3c1f138',
-          '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
-          '77524bb3-0aed-4f7e-153b-c3706945be11',
-          '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
-          '7ae96689-7720-14a3-33d9-476ba1e7194f',
-          '3648304b-a229-415c-b2c9-1cf72b7a2188',
-          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
-          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
-          'd80eeee8-9ec8-1063-f47b-2c54813725b1',
-          'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
-          'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
-          'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
-          '38a5e796-f380-38fd-a1c8-92949a38caad',
-          '066f3f2b-5775-4963-aed5-78307e4e8122',
-          '346973d0-895e-80bd-c3aa-86f482dd69ce'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['', '']), {
+      perfectMatched: [],
+      matched: [
+        '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+        'c9d4d957-141d-5ca2-0557-04589ca9187a',
+        '231da375-5246-731a-8e59-0d08c3c1f138',
+        '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+        '77524bb3-0aed-4f7e-153b-c3706945be11',
+        '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+        '7ae96689-7720-14a3-33d9-476ba1e7194f',
+        '3648304b-a229-415c-b2c9-1cf72b7a2188',
+        '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+        '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+        'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+        'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+        'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+        'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+        '38a5e796-f380-38fd-a1c8-92949a38caad',
+        '066f3f2b-5775-4963-aed5-78307e4e8122',
+        '346973d0-895e-80bd-c3aa-86f482dd69ce'
+      ]
+    })
   })
   it('two query with parent only', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['gen', '']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: [
-          '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
-          '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
-          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
-          '066f3f2b-5775-4963-aed5-78307e4e8122'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['gen', '']), {
+      perfectMatched: [],
+      matched: [
+        '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+        '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+        '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+        '066f3f2b-5775-4963-aed5-78307e4e8122'
+      ]
+    })
   })
   it('two query with child only', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['', 'gen']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: [
-          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
-          '38a5e796-f380-38fd-a1c8-92949a38caad'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['', 'gen']), {
+      perfectMatched: [],
+      matched: [
+        '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+        '38a5e796-f380-38fd-a1c8-92949a38caad'
+      ]
+    })
   })
   it('two query with parent & child', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['gen', 'a']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: ['27a2ec88-d2d2-8b16-4e48-87577be2cdd3']
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['gen', 'a']), {
+      perfectMatched: [],
+      matched: ['27a2ec88-d2d2-8b16-4e48-87577be2cdd3']
+    })
   })
   it('none match two query', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['zzz', 'z']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: []
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['zzz', 'z']), {
+      perfectMatched: [],
+      matched: []
+    })
   })
   it('three empry query', () => {
-    expect(sortResult(channelDeepMatching(channelMap, ['', '', '']))).toEqual(
-      sortResult({
-        perfectMatched: [],
-        matched: [
-          'c9d4d957-141d-5ca2-0557-04589ca9187a',
-          '231da375-5246-731a-8e59-0d08c3c1f138',
-          '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
-          '77524bb3-0aed-4f7e-153b-c3706945be11',
-          '7ae96689-7720-14a3-33d9-476ba1e7194f',
-          '3648304b-a229-415c-b2c9-1cf72b7a2188',
-          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
-          'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
-          'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
-          '38a5e796-f380-38fd-a1c8-92949a38caad',
-          '066f3f2b-5775-4963-aed5-78307e4e8122',
-          '346973d0-895e-80bd-c3aa-86f482dd69ce'
-        ]
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
-    )
+    expectResultToBeSame(channelDeepMatching(channelMap, ['', '', '']), {
+      perfectMatched: [],
+      matched: [
+        'c9d4d957-141d-5ca2-0557-04589ca9187a',
+        '231da375-5246-731a-8e59-0d08c3c1f138',
+        '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+        '77524bb3-0aed-4f7e-153b-c3706945be11',
+        '7ae96689-7720-14a3-33d9-476ba1e7194f',
+        '3648304b-a229-415c-b2c9-1cf72b7a2188',
+        '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+        'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+        'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+        '38a5e796-f380-38fd-a1c8-92949a38caad',
+        '066f3f2b-5775-4963-aed5-78307e4e8122',
+        '346973d0-895e-80bd-c3aa-86f482dd69ce'
+      ]
+    })
   })
   it('four query', () => {
-    expect(
-      sortResult(channelDeepMatching(channelMap, ['gen', 'c', 'd', 'r']))
-    ).toEqual(
-      sortResult({
+    expectResultToBeSame(
+      channelDeepMatching(channelMap, ['gen', 'c', 'd', 'r']),
+      {
         perfectMatched: [],
         matched: ['231da375-5246-731a-8e59-0d08c3c1f138']
-          .map(id => channelMap.get(id))
-          .filter(isNotUndefined)
-      })
+      }
     )
   })
 })
@@ -177,10 +138,32 @@ describe('channelDeepMatching', () => {
 const sortResult = <T extends ChannelLike>(
   result: matchResult<T>
 ): matchResult<T> => ({
-  perfectMatched: result.perfectMatched.sort(),
-  matched: result.matched.sort()
+  perfectMatched: result.perfectMatched.sort((a: T, b: T) =>
+    a.id < b.id ? 1 : -1
+  ),
+  matched: result.matched.sort((a: T, b: T) => (a.id < b.id ? 1 : -1))
 })
 const isNotUndefined = <T>(x: T): x is Exclude<T, undefined> => x !== undefined
+
+interface matchResultIds {
+  perfectMatched: string[]
+  matched: string[]
+}
+
+const expectResultToBeSame = (
+  expected: matchResult<ChannelLike>,
+  result: matchResultIds
+) =>
+  expect(sortResult(expected)).toEqual(
+    sortResult({
+      perfectMatched: result.perfectMatched
+        .map(id => channelMap.get(id))
+        .filter(isNotUndefined),
+      matched: result.matched
+        .map(id => channelMap.get(id))
+        .filter(isNotUndefined)
+    })
+  )
 
 /*
 general (e45a34fe-2d2b-1f41-83fd-3d345fdd9df0)

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -1,0 +1,425 @@
+import { ChannelId } from '@/types/entity-ids'
+import { matchResult, channelDeepMatching } from '@/lib/channel'
+import { ChannelLike } from '@/lib/channelTree'
+
+describe('channelDeepMatching', () => {
+  it('one empry query', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: [
+          'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+          '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+          'c9d4d957-141d-5ca2-0557-04589ca9187a',
+          '231da375-5246-731a-8e59-0d08c3c1f138',
+          '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+          '77524bb3-0aed-4f7e-153b-c3706945be11',
+          '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+          '7ae96689-7720-14a3-33d9-476ba1e7194f',
+          '3648304b-a229-415c-b2c9-1cf72b7a2188',
+          '43f92228-719a-901d-00df-40c32a042fd9',
+          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+          'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+          'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+          'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+          '12d1455f-ec59-36f0-7609-799cfa5fc68f',
+          'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+          '38a5e796-f380-38fd-a1c8-92949a38caad',
+          '066f3f2b-5775-4963-aed5-78307e4e8122',
+          '346973d0-895e-80bd-c3aa-86f482dd69ce'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('one query matching', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['gen']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: [
+          'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+          '38a5e796-f380-38fd-a1c8-92949a38caad'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('one query matching with full match', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['gene']))).toEqual(
+      sortResult({
+        perfectMatched: [
+          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+          '38a5e796-f380-38fd-a1c8-92949a38caad'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined),
+        matched: ['e45a34fe-2d2b-1f41-83fd-3d345fdd9df0']
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('two empty query', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['', '']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: [
+          '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+          'c9d4d957-141d-5ca2-0557-04589ca9187a',
+          '231da375-5246-731a-8e59-0d08c3c1f138',
+          '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+          '77524bb3-0aed-4f7e-153b-c3706945be11',
+          '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+          '7ae96689-7720-14a3-33d9-476ba1e7194f',
+          '3648304b-a229-415c-b2c9-1cf72b7a2188',
+          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+          'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+          'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+          'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+          'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+          '38a5e796-f380-38fd-a1c8-92949a38caad',
+          '066f3f2b-5775-4963-aed5-78307e4e8122',
+          '346973d0-895e-80bd-c3aa-86f482dd69ce'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('two query with parent only', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['gen', '']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: [
+          '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+          '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+          '066f3f2b-5775-4963-aed5-78307e4e8122'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('two query with child only', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['', 'gen']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: [
+          '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+          '38a5e796-f380-38fd-a1c8-92949a38caad'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('two query with parent & child', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['gen', 'a']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: ['27a2ec88-d2d2-8b16-4e48-87577be2cdd3']
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('none match two query', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['zzz', 'z']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: []
+      })
+    )
+  })
+  it('three empry query', () => {
+    expect(sortResult(channelDeepMatching(channelMap, ['', '', '']))).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: [
+          'c9d4d957-141d-5ca2-0557-04589ca9187a',
+          '231da375-5246-731a-8e59-0d08c3c1f138',
+          '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+          '77524bb3-0aed-4f7e-153b-c3706945be11',
+          '7ae96689-7720-14a3-33d9-476ba1e7194f',
+          '3648304b-a229-415c-b2c9-1cf72b7a2188',
+          '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+          'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+          'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+          '38a5e796-f380-38fd-a1c8-92949a38caad',
+          '066f3f2b-5775-4963-aed5-78307e4e8122',
+          '346973d0-895e-80bd-c3aa-86f482dd69ce'
+        ]
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+  it('four query', () => {
+    expect(
+      sortResult(channelDeepMatching(channelMap, ['gen', 'c', 'd', 'r']))
+    ).toEqual(
+      sortResult({
+        perfectMatched: [],
+        matched: ['231da375-5246-731a-8e59-0d08c3c1f138']
+          .map(id => channelMap.get(id))
+          .filter(isNotUndefined)
+      })
+    )
+  })
+})
+
+const sortResult = <T extends ChannelLike>(
+  result: matchResult<T>
+): matchResult<T> => ({
+  perfectMatched: result.perfectMatched.sort(),
+  matched: result.matched.sort()
+})
+const isNotUndefined = <T>(x: T): x is Exclude<T, undefined> => x !== undefined
+
+// general (e45a34fe-2d2b-1f41-83fd-3d345fdd9df0)
+// // exective (0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1)
+// // // unders (c9d4d957-141d-5ca2-0557-04589ca9187a)
+// // // // relations (231da375-5246-731a-8e59-0d08c3c1f138)
+// // // // // hoge (522cfa75-5729-92ab-78d9-4dd0ef98ecec)
+// // // // // fuga ★ (77524bb3-0aed-4f7e-153b-c3706945be11)
+// // a (27a2ec88-d2d2-8b16-4e48-87577be2cdd3)
+// // // hoge ★ (7ae96689-7720-14a3-33d9-476ba1e7194f)
+// // // // fuga (3648304b-a229-415c-b2c9-1cf72b7a2188)
+
+// a (43f92228-719a-901d-00df-40c32a042fd9)
+// // gene (680a82fc-3a97-62bc-c977-8ac14f9049d3)
+// // // b ★ (2570dac4-21b0-282f-f2ef-f8462ea17d8b)
+// // hoge (d80eeee8-9ec8-1063-f47b-2c54813725b1)
+// // // b (b5a49916-f1e6-b452-546c-3f4ef8843bc5)
+// // // // fuga (ce93eaec-203e-e7fa-b112-609b4a7f7e0f)
+
+// b (12d1455f-ec59-36f0-7609-799cfa5fc68f)
+// // a (fb1cecc8-8cbc-33c3-d895-c724fcbf7039)
+// // // gene ★ (38a5e796-f380-38fd-a1c8-92949a38caad)
+// // // // hoge (066f3f2b-5775-4963-aed5-78307e4e8122)
+// // // // // fuga (346973d0-895e-80bd-c3aa-86f482dd69ce)
+
+const starChannels = new Set<string>([
+  '77524bb3-0aed-4f7e-153b-c3706945be11',
+  '7ae96689-7720-14a3-33d9-476ba1e7194f',
+  '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+  '38a5e796-f380-38fd-a1c8-92949a38caad'
+])
+
+const channelMap = new Map<ChannelId, ChannelLike>([
+  [
+    'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+    {
+      id: 'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+      name: 'general',
+      parentId: null,
+      children: [
+        '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+        '27a2ec88-d2d2-8b16-4e48-87577be2cdd3'
+      ],
+      archived: false
+    }
+  ],
+  [
+    '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+    {
+      id: '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+      name: 'exective',
+      parentId: 'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+      children: ['c9d4d957-141d-5ca2-0557-04589ca9187a'],
+      archived: false
+    }
+  ],
+  [
+    'c9d4d957-141d-5ca2-0557-04589ca9187a',
+    {
+      id: 'c9d4d957-141d-5ca2-0557-04589ca9187a',
+      name: 'unders',
+      parentId: '0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1',
+      children: ['231da375-5246-731a-8e59-0d08c3c1f138'],
+      archived: false
+    }
+  ],
+  [
+    '231da375-5246-731a-8e59-0d08c3c1f138',
+    {
+      id: '231da375-5246-731a-8e59-0d08c3c1f138',
+      name: 'relations',
+      parentId: 'c9d4d957-141d-5ca2-0557-04589ca9187a',
+      children: [
+        '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+        '77524bb3-0aed-4f7e-153b-c3706945be11'
+      ],
+      archived: false
+    }
+  ],
+  [
+    '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+    {
+      id: '522cfa75-5729-92ab-78d9-4dd0ef98ecec',
+      name: 'hoge',
+      parentId: '231da375-5246-731a-8e59-0d08c3c1f138',
+      children: [],
+      archived: false
+    }
+  ],
+  [
+    '77524bb3-0aed-4f7e-153b-c3706945be11',
+    {
+      id: '77524bb3-0aed-4f7e-153b-c3706945be11',
+      name: 'fuga',
+      parentId: '231da375-5246-731a-8e59-0d08c3c1f138',
+      children: [],
+      archived: false
+    }
+  ],
+  [
+    '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+    {
+      id: '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+      name: 'a',
+      parentId: 'e45a34fe-2d2b-1f41-83fd-3d345fdd9df0',
+      children: ['7ae96689-7720-14a3-33d9-476ba1e7194f'],
+      archived: false
+    }
+  ],
+  [
+    '7ae96689-7720-14a3-33d9-476ba1e7194f',
+    {
+      id: '7ae96689-7720-14a3-33d9-476ba1e7194f',
+      name: 'hoge',
+      parentId: '27a2ec88-d2d2-8b16-4e48-87577be2cdd3',
+      children: ['3648304b-a229-415c-b2c9-1cf72b7a2188'],
+      archived: false
+    }
+  ],
+  [
+    '3648304b-a229-415c-b2c9-1cf72b7a2188',
+    {
+      id: '3648304b-a229-415c-b2c9-1cf72b7a2188',
+      name: 'fuga',
+      parentId: '7ae96689-7720-14a3-33d9-476ba1e7194f',
+      children: [],
+      archived: false
+    }
+  ],
+  [
+    '43f92228-719a-901d-00df-40c32a042fd9',
+    {
+      id: '43f92228-719a-901d-00df-40c32a042fd9',
+      name: 'a',
+      parentId: null,
+      children: [
+        '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+        'd80eeee8-9ec8-1063-f47b-2c54813725b1'
+      ],
+      archived: false
+    }
+  ],
+  [
+    '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+    {
+      id: '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+      name: 'gene',
+      parentId: '43f92228-719a-901d-00df-40c32a042fd9',
+      children: ['2570dac4-21b0-282f-f2ef-f8462ea17d8b'],
+      archived: false
+    }
+  ],
+  [
+    '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+    {
+      id: '2570dac4-21b0-282f-f2ef-f8462ea17d8b',
+      name: 'b',
+      parentId: '680a82fc-3a97-62bc-c977-8ac14f9049d3',
+      children: [],
+      archived: false
+    }
+  ],
+  [
+    'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+    {
+      id: 'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+      name: 'hoge',
+      parentId: '43f92228-719a-901d-00df-40c32a042fd9',
+      children: ['b5a49916-f1e6-b452-546c-3f4ef8843bc5'],
+      archived: false
+    }
+  ],
+  [
+    'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+    {
+      id: 'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+      name: 'b',
+      parentId: 'd80eeee8-9ec8-1063-f47b-2c54813725b1',
+      children: ['ce93eaec-203e-e7fa-b112-609b4a7f7e0f'],
+      archived: false
+    }
+  ],
+  [
+    'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+    {
+      id: 'ce93eaec-203e-e7fa-b112-609b4a7f7e0f',
+      name: 'fuga',
+      parentId: 'b5a49916-f1e6-b452-546c-3f4ef8843bc5',
+      children: [],
+      archived: false
+    }
+  ],
+  [
+    '12d1455f-ec59-36f0-7609-799cfa5fc68f',
+    {
+      id: '12d1455f-ec59-36f0-7609-799cfa5fc68f',
+      name: 'b',
+      parentId: null,
+      children: ['fb1cecc8-8cbc-33c3-d895-c724fcbf7039'],
+      archived: false
+    }
+  ],
+  [
+    'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+    {
+      id: 'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+      name: 'a',
+      parentId: '12d1455f-ec59-36f0-7609-799cfa5fc68f',
+      children: ['38a5e796-f380-38fd-a1c8-92949a38caad'],
+      archived: false
+    }
+  ],
+  [
+    '38a5e796-f380-38fd-a1c8-92949a38caad',
+    {
+      id: '38a5e796-f380-38fd-a1c8-92949a38caad',
+      name: 'gene',
+      parentId: 'fb1cecc8-8cbc-33c3-d895-c724fcbf7039',
+      children: ['066f3f2b-5775-4963-aed5-78307e4e8122'],
+      archived: false
+    }
+  ],
+  [
+    '066f3f2b-5775-4963-aed5-78307e4e8122',
+    {
+      id: '066f3f2b-5775-4963-aed5-78307e4e8122',
+      name: 'hoge',
+      parentId: '38a5e796-f380-38fd-a1c8-92949a38caad',
+      children: ['346973d0-895e-80bd-c3aa-86f482dd69ce'],
+      archived: false
+    }
+  ],
+  [
+    '346973d0-895e-80bd-c3aa-86f482dd69ce',
+    {
+      id: '346973d0-895e-80bd-c3aa-86f482dd69ce',
+      name: 'fuga',
+      parentId: '066f3f2b-5775-4963-aed5-78307e4e8122',
+      children: [],
+      archived: false
+    }
+  ]
+])

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -182,29 +182,28 @@ const sortResult = <T extends ChannelLike>(
 })
 const isNotUndefined = <T>(x: T): x is Exclude<T, undefined> => x !== undefined
 
-// general (e45a34fe-2d2b-1f41-83fd-3d345fdd9df0)
-// // exective (0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1)
-// // // unders (c9d4d957-141d-5ca2-0557-04589ca9187a)
-// // // // relations (231da375-5246-731a-8e59-0d08c3c1f138)
-// // // // // hoge (522cfa75-5729-92ab-78d9-4dd0ef98ecec)
-// // // // // fuga ★ (77524bb3-0aed-4f7e-153b-c3706945be11)
-// // a (27a2ec88-d2d2-8b16-4e48-87577be2cdd3)
-// // // hoge ★ (7ae96689-7720-14a3-33d9-476ba1e7194f)
-// // // // fuga (3648304b-a229-415c-b2c9-1cf72b7a2188)
-
-// a (43f92228-719a-901d-00df-40c32a042fd9)
-// // gene (680a82fc-3a97-62bc-c977-8ac14f9049d3)
-// // // b ★ (2570dac4-21b0-282f-f2ef-f8462ea17d8b)
-// // hoge (d80eeee8-9ec8-1063-f47b-2c54813725b1)
-// // // b (b5a49916-f1e6-b452-546c-3f4ef8843bc5)
-// // // // fuga (ce93eaec-203e-e7fa-b112-609b4a7f7e0f)
-
-// b (12d1455f-ec59-36f0-7609-799cfa5fc68f)
-// // a (fb1cecc8-8cbc-33c3-d895-c724fcbf7039)
-// // // gene ★ (38a5e796-f380-38fd-a1c8-92949a38caad)
-// // // // hoge (066f3f2b-5775-4963-aed5-78307e4e8122)
-// // // // // fuga (346973d0-895e-80bd-c3aa-86f482dd69ce)
-
+/*
+general (e45a34fe-2d2b-1f41-83fd-3d345fdd9df0)
+  / exective (0dd14681-c0ad-1ba2-2ff3-a4ad90f773d1)
+    / unders (c9d4d957-141d-5ca2-0557-04589ca9187a)
+      / relations (231da375-5246-731a-8e59-0d08c3c1f138)
+        / hoge (522cfa75-5729-92ab-78d9-4dd0ef98ecec)
+        / fuga ★ (77524bb3-0aed-4f7e-153b-c3706945be11)
+  / a (27a2ec88-d2d2-8b16-4e48-87577be2cdd3)
+    / hoge ★ (7ae96689-7720-14a3-33d9-476ba1e7194f)
+      / fuga (3648304b-a229-415c-b2c9-1cf72b7a2188)
+a (43f92228-719a-901d-00df-40c32a042fd9)
+  / gene (680a82fc-3a97-62bc-c977-8ac14f9049d3)
+    / b ★ (2570dac4-21b0-282f-f2ef-f8462ea17d8b)
+  / hoge (d80eeee8-9ec8-1063-f47b-2c54813725b1)
+    / b (b5a49916-f1e6-b452-546c-3f4ef8843bc5)
+      / fuga (ce93eaec-203e-e7fa-b112-609b4a7f7e0f)
+b (12d1455f-ec59-36f0-7609-799cfa5fc68f)
+  / a (fb1cecc8-8cbc-33c3-d895-c724fcbf7039)
+    / gene ★ (38a5e796-f380-38fd-a1c8-92949a38caad)
+      / hoge (066f3f2b-5775-4963-aed5-78307e4e8122)
+        / fuga (346973d0-895e-80bd-c3aa-86f482dd69ce)
+*/
 const starChannels = new Set<string>([
   '77524bb3-0aed-4f7e-153b-c3706945be11',
   '7ae96689-7720-14a3-33d9-476ba1e7194f',

--- a/tests/unit/lib/channel.spec.ts
+++ b/tests/unit/lib/channel.spec.ts
@@ -1,5 +1,5 @@
 import { ChannelId } from '@/types/entity-ids'
-import { matchResult, channelDeepMatching } from '@/lib/channel'
+import { MatchResult, channelDeepMatching } from '@/lib/channel'
 import { ChannelLike } from '@/lib/channelTree'
 
 describe('channelDeepMatching', () => {
@@ -136,8 +136,8 @@ describe('channelDeepMatching', () => {
 })
 
 const sortResult = <T extends ChannelLike>(
-  result: matchResult<T>
-): matchResult<T> => ({
+  result: MatchResult<T>
+): MatchResult<T> => ({
   perfectMatched: result.perfectMatched.sort((a: T, b: T) =>
     a.id < b.id ? 1 : -1
   ),
@@ -145,14 +145,14 @@ const sortResult = <T extends ChannelLike>(
 })
 const isNotUndefined = <T>(x: T): x is Exclude<T, undefined> => x !== undefined
 
-interface matchResultIds {
+interface MatchResultIds {
   perfectMatched: string[]
   matched: string[]
 }
 
 const expectResultToBeSame = (
-  expected: matchResult<ChannelLike>,
-  result: matchResultIds
+  expected: MatchResult<ChannelLike>,
+  result: MatchResultIds
 ) =>
   expect(sortResult(expected)).toEqual(
     sortResult({


### PR DESCRIPTION
fix #1161 
- 先祖チャンネルがマッチするとき、その子孫も再帰的にマッチさせるようにしました
- ``/`` が存在するような query にも対応するようにしました
