### PR TITLE
検索結果のいくつかの改善

### DIFF
--- a/src/components/Main/CommandPalette/CommandPaletteInput.vue
+++ b/src/components/Main/CommandPalette/CommandPaletteInput.vue
@@ -101,5 +101,6 @@ export default defineComponent({
 }
 .input {
   @include color-ui-primary;
+  min-width: 0;
 }
 </style>

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -13,16 +13,18 @@
       :class="$style.sortSelector"
       small
     />
-    <div
-      v-for="message in searchResult"
-      :key="message.id"
-      :class="$style.elementContainer"
-    >
-      <search-result-message-element
-        :message="message"
-        :current-sort-key="currentSortKey"
-        @click-open="openMessage"
-      />
+    <div :class="$style.resultList">
+      <div
+        v-for="message in searchResult"
+        :key="message.id"
+        :class="$style.elementContainer"
+      >
+        <search-result-message-element
+          :message="message"
+          :current-sort-key="currentSortKey"
+          @click-open="openMessage"
+        />
+      </div>
     </div>
     <div :class="$style.navigation">
       <div
@@ -155,11 +157,16 @@ export default defineComponent({
 <style lang="scss" module>
 .container {
   @include color-ui-tertiary;
-  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  min-height: 0;
 }
 .sortSelector {
   margin: 1rem;
+}
+.resultList {
+  overflow-y: scroll;
 }
 .elementContainer {
   margin-bottom: 0.5rem;

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -35,7 +35,7 @@
       >
         <icon name="chevron-left" mdi /> 戻る
       </div>
-      <span :class="$style.page" :aria-hidden="isMobile">
+      <span :class="$style.page">
         {{ currentPage + 1 }} / {{ pageCount }} ページ
       </span>
       <div

--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -14,7 +14,10 @@
     </div>
     <div :class="$style.contentContainer">
       <div ref="contentRef" :class="$style.markdownContainer">
-        <message-markdown :message-id="message.id" />
+        <message-markdown
+          :message-id="message.id"
+          @click="toggleSpoilerHandler"
+        />
       </div>
       <search-result-message-file-list
         :v-if="embeddingsState.fileIds.length > 0"
@@ -56,6 +59,7 @@ import useEmbeddings from '@/use/message/embeddings'
 import { Message } from '@traptitech/traq'
 import SearchResultMessageFileList from './SearchResultMessageFileList.vue'
 import { SearchMessageSortKey } from '@/use/searchMessage/queryParser'
+import { toggleSpoiler } from '@/lib/markdown/spoiler'
 
 const maxHeight = 200
 
@@ -83,6 +87,18 @@ const useMessageExpansion = (contentRef: Ref<HTMLElement | undefined>) => {
     expanded.value = !expanded.value
   }
   return { oversized, expanded, onClickExpandButton }
+}
+
+const useSpoilerToggler = () => {
+  const toggleSpoilerHandler = (event: MouseEvent) => {
+    if (!event.target) return
+    const toggled = toggleSpoiler(event.target as HTMLElement)
+    if (toggled) {
+      event.stopPropagation()
+    }
+  }
+
+  return { toggleSpoilerHandler }
 }
 
 export default defineComponent({
@@ -139,6 +155,8 @@ export default defineComponent({
       contentRef
     )
 
+    const { toggleSpoilerHandler } = useSpoilerToggler()
+
     return {
       user,
       channelName,
@@ -148,7 +166,8 @@ export default defineComponent({
       expanded,
       oversized,
       onClickExpandButton,
-      contentRef
+      contentRef,
+      toggleSpoilerHandler
     }
   }
 })

--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -183,6 +183,7 @@ export default defineComponent({
   grid-area: header;
   display: flex;
   align-items: baseline;
+  min-width: 0;
 }
 .displayName {
   @include color-ui-primary;

--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -6,7 +6,12 @@
     @click="onClick"
   >
     <user-icon :class="$style.icon" :size="32" :user-id="message.userId" />
-    <div :class="$style.userName">{{ userName }}</div>
+    <div :class="$style.header">
+      <span :class="$style.displayName">{{
+        user?.displayName ?? 'Unknown'
+      }}</span>
+      <span :class="$style.userName">@{{ user?.name ?? 'unknown' }}</span>
+    </div>
     <div :class="$style.contentContainer">
       <div ref="contentRef" :class="$style.markdownContainer">
         <message-markdown :message-id="message.id" />
@@ -106,8 +111,8 @@ export default defineComponent({
     store.dispatch.entities.fetchUser({ userId: props.message.userId })
 
     const { channelIdToPathString } = useChannelPath()
-    const userName = computed(
-      () => store.state.entities.usersMap.get(props.message.userId)?.name ?? ''
+    const user = computed(() =>
+      store.state.entities.usersMap.get(props.message.userId)
     )
     const channelName = computed(() =>
       channelIdToPathString(props.message.channelId, true)
@@ -135,7 +140,7 @@ export default defineComponent({
     )
 
     return {
-      userName,
+      user,
       channelName,
       date,
       embeddingsState,
@@ -153,13 +158,13 @@ export default defineComponent({
 .container {
   display: grid;
   grid-template-areas:
-    'icon userName'
+    'icon header'
     'icon content'
     'icon channelAndDate';
   grid-template-columns: 32px 1fr;
   &[data-oversized]:not([data-expanded]) {
     grid-template-areas:
-      'icon userName'
+      'icon header'
       'icon content'
       'icon expandButton'
       'icon channelAndDate';
@@ -174,10 +179,33 @@ export default defineComponent({
 .icon {
   grid-area: icon;
 }
-.userName {
+.header {
+  grid-area: header;
+  display: flex;
+  align-items: baseline;
+}
+.displayName {
   @include color-ui-primary;
-  grid-area: userName;
   font-weight: bold;
+  flex: 2;
+  max-width: min-content;
+
+  word-break: keep-all;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.userName {
+  @include color-ui-secondary;
+  @include size-body2;
+  margin-left: 4px;
+  flex: 1;
+  max-width: min-content;
+
+  word-break: keep-all;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 $message-max-height: 200px;

--- a/src/lib/markdown/spoiler.ts
+++ b/src/lib/markdown/spoiler.ts
@@ -1,4 +1,9 @@
+/**
+ * クリックした要素の祖先の.spoilerを探してshown属性をtoggleする
+ * @returns 実際にtoggleしたかどうか
+ */
 export const toggleSpoiler = (element: HTMLElement) => {
   const $spoiler = element.closest('.spoiler')
   $spoiler?.toggleAttribute('shown')
+  return $spoiler !== null
 }


### PR DESCRIPTION
- 検索結果でユーザー表示名を表示
- 画面幅が狭いときの検索結果のスタイルの改善
  - 横が飛び出る箇所がいくつかあった
- 検索結果でspoilerをそのまま表示できるように
- 検索結果のスクロールする部分の変更
  - 並び替え方法を選択する部分とページングの部分は常に表示するように
- 使っていなかったコードの削除