### PR TITLE
「別タブで開く」のポップアップを削除

### DIFF
--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -105,10 +105,6 @@ const useMarkdownInternalHandler = () => {
     const href = new URL($a.href)
     const linkPath = href.pathname + href.search + href.hash
 
-    if (confirm(`${linkPath}への内部リンクを別タブで開きますか？`)) {
-      return
-    }
-
     event.preventDefault()
     router.push(linkPath)
   }


### PR DESCRIPTION
常に同じタブで開けばよい