### PR TITLE
引用検索

### DIFF
--- a/src/use/searchMessage/parserBase.ts
+++ b/src/use/searchMessage/parserBase.ts
@@ -160,7 +160,15 @@ export const userParser = <T extends string>(
 export const messageParser = <T extends string>(
   extracted: ExtractedFilter<T>
 ): MessageId | undefined => {
-  const userName = extracted.body.startsWith('@')
-  // TBD
-  return undefined
+  try {
+    const url = new URL(extracted.body)
+    const pathNames = url.pathname.split('/')
+    if (pathNames.length === 3 && pathNames[1] === 'messages') {
+      return pathNames[2]
+    }
+    return undefined
+  } catch {
+    // URLではなかった場合、メッセージIDとして解釈
+    return extracted.body
+  }
 }

--- a/src/use/searchMessage/queryParser.ts
+++ b/src/use/searchMessage/queryParser.ts
@@ -279,6 +279,7 @@ const mergeSearchMessageQueryObject = (
   in: q1.in ?? q2.in,
   to: q1.to ?? q2.to,
   from: q1.from ?? q2.from,
+  citation: q1.citation ?? q2.citation,
   bot: q1.bot ?? q2.bot,
   hasUrl: q1.hasUrl ?? q2.hasUrl,
   hasAttachments: q1.hasAttachments ?? q2.hasAttachments,

--- a/tests/unit/use/searchMessage/queryParser.spec.ts
+++ b/tests/unit/use/searchMessage/queryParser.spec.ts
@@ -1,6 +1,8 @@
 import useQueryParer from '@/use/searchMessage/queryParser'
 import store from '@/store'
 
+const mockMessageId = 'message-id'
+const mockMessageUrl = `https://example.com/messages/${mockMessageId}`
 const mockChannelId = 'channel-id'
 const mockChannelName = 'general'
 const mockUserId = 'user-id'
@@ -65,6 +67,18 @@ describe('parseQuery', () => {
     const parsed = parseQuery(query)
     expect(parsed.word).toEqual(`lorem ipsum`)
     expect(parsed.from).toEqual(mockUserId)
+  })
+  it('can parse query with message-filter (url)', () => {
+    const query = `lorem ipsum cite:${mockMessageUrl}`
+    const parsed = parseQuery(query)
+    expect(parsed.word).toEqual(`lorem ipsum`)
+    expect(parsed.citation).toEqual(mockMessageId)
+  })
+  it('can parse query with message-filter (id)', () => {
+    const query = `lorem ipsum cite:${mockMessageId}`
+    const parsed = parseQuery(query)
+    expect(parsed.word).toEqual(`lorem ipsum`)
+    expect(parsed.citation).toEqual(mockMessageId)
   })
   it('can parse query with flag-filter', () => {
     const query = 'lorem has:image ipsum'


### PR DESCRIPTION
`cite:${messageUrl}`, `cite:${messageId}`, `citation:${messageUrl}`, `citation:${messageId}` で引用メッセージを検索できるようになります