### PR TITLE
iOSで無限にロードが走るのを防止する

### DIFF
--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -324,6 +324,8 @@ export default defineComponent({
   // overflow-anchorはデフォルトでautoだが、Safariが対応していないので、
   // 手動で調節しているため明示的に無効化する
   overflow-anchor: none;
+  // iOSで無限にロードが走るのを防止する
+  -webkit-overflow-scrolling: auto;
 }
 
 .messageContainer {


### PR DESCRIPTION
iOS13 Safari13から指定なしで慣性スクロールが有効になったらしい
https://qiita.com/cubkich/items/d192a70856e8bc63c7bc

直るかわからないけど入れてみる
