### PR TITLE
PopupNavigatorの改善

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
     <div id="message-menu-popup"></div>
     <div id="stamp-picker-popup"></div>
     <div id="dropdown-suggester-popup"></div>
+    <div id="popup-navigator"></div>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
@@ -59,6 +59,7 @@ $headerHeight: 80px;
 .headerBody {
   width: 100%;
   min-width: 0;
+  user-select: none;
 }
 .headerContainer {
   display: flex;

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
@@ -1,28 +1,7 @@
 <template>
   <header :class="$style.container">
     <div :class="$style.headerContainer">
-      <!-- touchstartをstopしているのはスワイプを無効化するため -->
-      <button
-        v-if="isMobile"
-        :id="mainviewNavigationButtonId"
-        :class="$style.navigationButton"
-        @touchstart.stop="onMouseTouchStart"
-        @mousedown="onMouseTouchStart"
-        @touchend="onMouseTouchEnd"
-        @mouseup="onMouseTouchEnd"
-      >
-        <icon name="traQ" :size="28" />
-        <div v-show="isLongClicking" :class="$style.popupNavigator">
-          <div :class="$style.popupNavigatorItem" @click="movePrev">
-            <icon name="arrow-left" mdi :class="$style.icon" />
-            戻る
-          </div>
-          <div :class="$style.popupNavigatorItem" @click="moveNext">
-            <icon name="arrow-right" mdi :class="$style.icon" />
-            進む
-          </div>
-        </div>
-      </button>
+      <popup-navigator @clickIcon="openNav" />
       <h2 :class="$style.headerBody">
         <slot name="header" />
       </h2>
@@ -32,91 +11,18 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue'
-import Icon from '@/components/UI/Icon.vue'
-import useIsMobile from '@/use/isMobile'
+import { defineComponent } from 'vue'
 import useNavigationController from '@/use/navigationController'
-import { useRouter } from 'vue-router'
-
-const mainviewNavigationButtonId = 'mainview-header-navigation-button'
-
-/**
- * タッチにも対応している
- */
-const useIsLongClicking = (onMouseClick: () => void) => {
-  const isLongClicking = ref(false)
-  let timer = 0
-
-  const onMouseTouchStart = () => {
-    timer = window.setTimeout(() => {
-      isLongClicking.value = true
-    }, 100)
-  }
-  const onMouseTouchEnd = (e: MouseEvent | TouchEvent) => {
-    window.clearTimeout(timer)
-
-    const point = 'changedTouches' in e ? e.changedTouches[0] : e
-    const target = document.elementFromPoint(point.clientX, point.clientY)
-    if (
-      target === null ||
-      target.closest(`#${mainviewNavigationButtonId}`) === null
-    ) {
-      isLongClicking.value = false
-      return
-    }
-
-    if (!isLongClicking.value) {
-      onMouseClick()
-    } else {
-      let t = target
-      while (!(t instanceof HTMLElement)) {
-        if (t.parentElement === null) {
-          throw new Error('Missing HTMLElement parent')
-        }
-        t = t.parentElement
-      }
-      t.click()
-    }
-    isLongClicking.value = false
-  }
-  return { isLongClicking, onMouseTouchStart, onMouseTouchEnd }
-}
-
-const useNavigator = () => {
-  const router = useRouter()
-  const movePrev = () => {
-    router.back()
-  }
-  const moveNext = () => {
-    router.forward()
-  }
-  return { movePrev, moveNext }
-}
+import PopupNavigator from '@/components/Main/PopupNavigatior/PopupNavigator.vue'
 
 export default defineComponent({
   name: 'MainViewHeader',
   components: {
-    Icon
+    PopupNavigator
   },
   setup() {
-    const { isMobile } = useIsMobile()
     const { openNav } = useNavigationController()
-    const {
-      isLongClicking,
-      onMouseTouchStart,
-      onMouseTouchEnd
-    } = useIsLongClicking(openNav)
-    const { movePrev, moveNext } = useNavigator()
-    return {
-      mainviewNavigationButtonId,
-      isLongClicking,
-      onMouseTouchStart,
-      onMouseTouchEnd,
-      movePrev,
-      moveNext,
-      isMobile,
-      openNav
-    }
+    return { openNav }
   }
 })
 </script>
@@ -145,36 +51,6 @@ $headerHeight: 80px;
 .headerContainer {
   display: flex;
   min-width: 0;
-}
-.navigationButton {
-  @include color-ui-primary;
-  position: relative;
-  display: flex;
-  height: 36px;
-  width: 36px;
-  justify-content: center;
-  align-items: center;
-  margin-right: 8px;
-}
-.popupNavigator {
-  @include background-primary;
-  @include drop-shadow-default;
-  position: absolute;
-  top: -8px;
-  left: -8px;
-  border-radius: 4px;
-  user-select: none;
-  white-space: nowrap;
-  z-index: $z-index-header-popup-navigator;
-}
-.popupNavigatorItem {
-  padding: 12px 20px;
-  &:hover {
-    @include background-secondary;
-  }
-}
-.icon {
-  vertical-align: middle;
 }
 .tools {
   flex-shrink: 0;

--- a/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
+++ b/src/components/Main/MainView/MainViewHeader/MainViewHeader.vue
@@ -1,7 +1,11 @@
 <template>
   <header :class="$style.container">
     <div :class="$style.headerContainer">
-      <popup-navigator @clickIcon="openNav" />
+      <popup-navigator
+        v-if="isMobile"
+        :class="$style.icon"
+        @clickIcon="openNav"
+      />
       <h2 :class="$style.headerBody">
         <slot name="header" />
       </h2>
@@ -14,6 +18,7 @@
 import { defineComponent } from 'vue'
 import useNavigationController from '@/use/navigationController'
 import PopupNavigator from '@/components/Main/PopupNavigatior/PopupNavigator.vue'
+import useIsMobile from '@/use/isMobile'
 
 export default defineComponent({
   name: 'MainViewHeader',
@@ -21,8 +26,9 @@ export default defineComponent({
     PopupNavigator
   },
   setup() {
+    const { isMobile } = useIsMobile()
     const { openNav } = useNavigationController()
-    return { openNav }
+    return { isMobile, openNav }
   }
 })
 </script>
@@ -43,6 +49,12 @@ $headerHeight: 80px;
   padding: 16px;
   border-bottom: 2px solid $theme-ui-tertiary;
   contain: layout;
+}
+.icon {
+  @include color-ui-primary;
+  height: 36px;
+  width: 36px;
+  margin-right: 8px;
 }
 .headerBody {
   width: 100%;

--- a/src/components/Main/Navigation/DesktopNavigationSelector.vue
+++ b/src/components/Main/Navigation/DesktopNavigationSelector.vue
@@ -1,8 +1,6 @@
 <template>
   <div :class="$style.container">
-    <div :class="$style.logo" :title="`traQ ${version}`">
-      <icon name="traQ" :size="28" />
-    </div>
+    <popup-navigator :class="$style.logo" :title="`traQ ${version}`" />
     <navigation-selector-item
       v-for="item in entries"
       :key="item.type"
@@ -37,12 +35,15 @@ import {
 } from '@/components/Main/Navigation/use/navigationConstructor'
 import useNavigationSelectorEntry from './use/navigationSelectorEntry'
 import NavigationSelectorItem from '@/components/Main/Navigation/NavigationSelectorItem.vue'
-import Icon from '@/components/UI/Icon.vue'
 import version from '@/lib/env/version'
+import PopupNavigator from '@/components/Main/PopupNavigatior/PopupNavigator.vue'
 
 export default defineComponent({
   name: 'NavigationSelector',
-  components: { NavigationSelectorItem, Icon },
+  components: {
+    PopupNavigator,
+    NavigationSelectorItem
+  },
   props: {
     currentNavigation: {
       type: String as PropType<NavigationItemType>,

--- a/src/components/Main/PopupNavigatior/PopupNavigator.vue
+++ b/src/components/Main/PopupNavigatior/PopupNavigator.vue
@@ -1,0 +1,146 @@
+<template>
+  <!-- touchstartをstopしているのはスワイプを無効化するため -->
+  <button
+    v-if="isMobile"
+    :id="popupNavigatorButtonId"
+    :class="$style.navigationButton"
+    @touchstart.stop="onMouseTouchStart"
+    @mousedown="onMouseTouchStart"
+    @touchend="onMouseTouchEnd"
+    @mouseup="onMouseTouchEnd"
+  >
+    <icon name="traQ" :size="28" />
+    <div v-show="isLongClicking" :class="$style.popupNavigator">
+      <div :class="$style.popupNavigatorItem" @click="movePrev">
+        <icon name="arrow-left" mdi :class="$style.icon" />
+        戻る
+      </div>
+      <div :class="$style.popupNavigatorItem" @click="moveNext">
+        <icon name="arrow-right" mdi :class="$style.icon" />
+        進む
+      </div>
+    </div>
+  </button>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import Icon from '@/components/UI/Icon.vue'
+import useIsMobile from '@/use/isMobile'
+import { useRouter } from 'vue-router'
+
+const popupNavigatorButtonId = 'popup-navigation-button'
+
+/**
+ * タッチにも対応している
+ */
+const useIsLongClicking = (onMouseClick: () => void) => {
+  const isLongClicking = ref(false)
+  let timer = 0
+
+  const onMouseTouchStart = () => {
+    timer = window.setTimeout(() => {
+      isLongClicking.value = true
+    }, 100)
+  }
+  const onMouseTouchEnd = (e: MouseEvent | TouchEvent) => {
+    window.clearTimeout(timer)
+
+    const point = 'changedTouches' in e ? e.changedTouches[0] : e
+    const target = document.elementFromPoint(point.clientX, point.clientY)
+    if (
+      target === null ||
+      target.closest(`#${popupNavigatorButtonId}`) === null
+    ) {
+      isLongClicking.value = false
+      return
+    }
+
+    if (!isLongClicking.value) {
+      onMouseClick()
+    } else {
+      let t = target
+      while (!(t instanceof HTMLElement)) {
+        if (t.parentElement === null) {
+          throw new Error('Missing HTMLElement parent')
+        }
+        t = t.parentElement
+      }
+      t.click()
+    }
+    isLongClicking.value = false
+  }
+  return { isLongClicking, onMouseTouchStart, onMouseTouchEnd }
+}
+
+const useNavigator = () => {
+  const router = useRouter()
+  const movePrev = () => {
+    router.back()
+  }
+  const moveNext = () => {
+    router.forward()
+  }
+  return { movePrev, moveNext }
+}
+
+export default defineComponent({
+  name: 'PopupNavigator',
+  components: {
+    Icon
+  },
+  setup(props, { emit }) {
+    const { isMobile } = useIsMobile()
+    const {
+      isLongClicking,
+      onMouseTouchStart,
+      onMouseTouchEnd
+    } = useIsLongClicking(() => {
+      emit('clickIcon')
+    })
+    const { movePrev, moveNext } = useNavigator()
+    return {
+      popupNavigatorButtonId,
+      isLongClicking,
+      onMouseTouchStart,
+      onMouseTouchEnd,
+      movePrev,
+      moveNext,
+      isMobile
+    }
+  }
+})
+</script>
+
+<style lang="scss" module>
+.navigationButton {
+  @include color-ui-primary;
+  position: relative;
+  display: flex;
+  height: 36px;
+  width: 36px;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+}
+.popupNavigator {
+  @include background-primary;
+  @include drop-shadow-default;
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  border-radius: 4px;
+  user-select: none;
+  white-space: nowrap;
+  z-index: $z-index-header-popup-navigator;
+}
+.popupNavigatorItem {
+  padding: 12px 20px;
+  &:hover {
+    @include background-secondary;
+  }
+}
+.icon {
+  vertical-align: middle;
+}
+</style>


### PR DESCRIPTION
- traQアイコン長押しからの戻る/進むを画面幅が広いときの表示でも利用できるように
- traQアイコン長押しからの戻る/進むを二度目のクリックがない限り閉じないように
- ヘッダー部分のチャンネル名などを選択不可に
