### PR TITLE
iOS14.6でIndexDBが使えない問題へのworkaround

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,9 @@ import { mountMitt } from '@/onMount'
 import('katex/dist/katex.css')
 
 !(async () => {
+  // iOS14.6でIndexedDBが使えないタイミングがある問題へのworkaround
+  window.indexedDB
+
   setupGlobalFuncs()
 
   const app = createApp(App)


### PR DESCRIPTION
IndexedDBがlazyに読み込まれるようになったらしく、初期化がうまくいかないのでworkaroundを適用してみる
see: https://developer.apple.com/forums/thread/681201