### PR TITLE
ローカルのデバッグ環境のポートを3000(デフォルト)から8080に変更

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ command, mode }) => ({
     }
   },
   server: {
+    port: 8080,
     proxy: {
       '/api/v3': {
         target: DEV_SERVER_PROXY_HOST,


### PR DESCRIPTION
ホットリロード環境を変更、ビルドのプレビュー(Vite特有の機能)に関してはデフォルトの5000のまま
- 8080はVite移行前、つまりVue CLIのデフォルト
- バックエンドデバッグ環境とのポート被りをなくす目的