### PR TITLE
objectstorage以外を利用している場合のダウンロードの修正

### DIFF
--- a/src/components/UI/FileDescription.vue
+++ b/src/components/UI/FileDescription.vue
@@ -21,7 +21,7 @@
       name="download"
       :size="24"
       :class="$style.dl"
-      @click="onFileDownloadLinkClick"
+      @click.prevent="onFileDownloadLinkClick"
     />
   </div>
 </template>

--- a/src/lib/apis.ts
+++ b/src/lib/apis.ts
@@ -26,7 +26,8 @@ const apis = new Apis(
   })
 )
 
-export const buildFilePath = (fileId: FileId) => `${BASE_PATH}/files/${fileId}`
+export const buildFilePath = (fileId: FileId, withDlParam = false) =>
+  `${BASE_PATH}/files/${fileId}${withDlParam ? '?dl=1' : ''}`
 
 export const buildUserIconPath = (userIconFileId: FileId) =>
   `${BASE_PATH}/files/${userIconFileId}`

--- a/src/use/fileLink.ts
+++ b/src/use/fileLink.ts
@@ -9,7 +9,7 @@ const useFileLink = (props: { fileId: FileId }) => {
     router.push(fileLink.value)
   }
   const onFileDownloadLinkClick = () => {
-    window.open(buildFilePath(props.fileId), '_blank')
+    location.href = buildFilePath(props.fileId, true)
   }
   return { fileLink, onFileLinkClick, onFileDownloadLinkClick }
 }


### PR DESCRIPTION
ファイルの保存先にobjectstorage以外を利用していたときにダウンロードがうまくいかない可能性があったのを修正した

もしかしたら traPtitech/traQ-iOS#28 も直るかも
