### PR TITLE
ナビゲーションバーのツールが押している間しか展開されなかった問題を修正

### DIFF
--- a/src/components/Main/Navigation/DesktopToolBox.vue
+++ b/src/components/Main/Navigation/DesktopToolBox.vue
@@ -7,7 +7,8 @@
       :icon-name="tool.iconName"
       :icon-mdi="tool.iconMdi"
       :disabled="tool.disabled"
-      @mousedown="tool.onClick"
+      @mousedown.middle="tool.onClick"
+      @click="tool.onClick"
     />
     <user-icon
       :class="$style.item"

--- a/src/components/Main/Navigation/MobileToolBox.vue
+++ b/src/components/Main/Navigation/MobileToolBox.vue
@@ -8,7 +8,8 @@
         :icon-name="tool.iconName"
         :icon-mdi="tool.iconMdi"
         :disabled="tool.disabled"
-        @mousedown="tool.onClick"
+        @mousedown.middle="tool.onClick"
+        @click="tool.onClick"
       />
     </div>
     <teleport v-if="isServicesShown" :to="`#${teleportTargetName}`">

--- a/src/components/Main/Navigation/use/toolBox.ts
+++ b/src/components/Main/Navigation/use/toolBox.ts
@@ -8,7 +8,7 @@ interface Tool {
   iconName: string
   iconMdi?: true
   disabled?: boolean
-  onClick: (event: MouseEvent) => void
+  onClick: (event: MouseEvent) => void // clickイベント と mousedownイベント&&中央クリック で呼ばれる
 }
 
 const useToolBox = () => {

--- a/src/components/Main/Navigation/use/toolBox.ts
+++ b/src/components/Main/Navigation/use/toolBox.ts
@@ -8,7 +8,10 @@ interface Tool {
   iconName: string
   iconMdi?: true
   disabled?: boolean
-  onClick: (event: MouseEvent) => void // clickイベント と mousedownイベント&&中央クリック で呼ばれる
+  /**
+   * clickイベントと中央クリックでのmousedownイベントで呼ばれる
+   */
+  onClick: (event: MouseEvent) => void
 }
 
 const useToolBox = () => {


### PR DESCRIPTION
左クリックは`@click`に戻し、中央ボタンを使って新しいタブで開く機能は`@mousedown.middle`でハンドリングするようにした
マウスのボタンでまだ想定したハンドリング実装できてないとこあったら言って下さい