### PR TITLE
「HTMLをマークダウンに変換してから貼り付けますか？」がでる頻度を減らす

### DIFF
--- a/src/components/Main/MainView/MessageInput/use/paste.ts
+++ b/src/components/Main/MainView/MessageInput/use/paste.ts
@@ -58,7 +58,10 @@ const usePaste = (channelId: MessageInputStateKey) => {
       })
     }
 
-    addMarkdownGeneratedFromHtml(dt, event)
+    if (dt.types.includes('text/html')) {
+      await addMarkdownGeneratedFromHtml(dt, event)
+      return
+    }
   }
   return { onPaste }
 }

--- a/src/lib/markdown/turndown.ts
+++ b/src/lib/markdown/turndown.ts
@@ -3,6 +3,7 @@ import { gfm } from 'turndown-plugin-gfm'
 
 export const setupTurndown = () => {
   const turndown = new Turndown({
+    headingStyle: 'atx',
     hr: '---',
     bulletListMarker: '-',
     codeBlockStyle: 'fenced',
@@ -14,8 +15,22 @@ export const setupTurndown = () => {
 }
 
 const setTurndownRules = (td: Turndown) => {
+  td.addRule('url titled link', {
+    filter: node => !!(node.nodeName === 'A' && node.getAttribute('href')),
+    replacement: (content, node) => {
+      const href = (node as HTMLElement).getAttribute('href')
+
+      if (!content || href === content.trim()) {
+        return href ?? ''
+      }
+      return `[${content}](${href})`
+    }
+  })
+
   td.addRule('mark', {
     filter: ['mark'],
     replacement: content => `==${content}==`
   })
+
+  td.remove(['style', 'script'])
 }


### PR DESCRIPTION
マークダウン変換後とプレーンテキストが一致してたときは確認しないように