### PR TITLE
モバイルで右サイドバーを閉じるスワイプが効かなかった

### DIFF
--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -281,6 +281,7 @@ $nav-width-ratio: math.div($nav-width-diff, $nav-width-display-width-diff);
 .sidebarPortal {
   width: 100%;
   height: 100%;
+  overflow-x: hidden;
 }
 .mainView {
   width: 100%;


### PR DESCRIPTION
`sidebar-mobile`の `scrollwidth`が320px，`clientwidth`が314px(スクロールバー抜き)になっていたのでスワイプできなかった

pxで指定していいかどうかは:wakarazu: (親も子も絶対値で指定してるから良さそう？)