### PR TITLE
メッセージ検索の状態を保持

### DIFF
--- a/src/components/Main/CommandPalette/CommandPalette.vue
+++ b/src/components/Main/CommandPalette/CommandPalette.vue
@@ -3,9 +3,9 @@
     <div :class="$style.container" :data-is-mobile="$boolAttr(isMobile)">
       <command-palette-input />
       <hr v-if="supplementalViewType" :class="$style.separator" />
-      <search-result v-show="supplementalViewType === 'search-result'" />
+      <search-result v-if="supplementalViewType === 'search-result'" />
       <search-suggestion
-        v-show="supplementalViewType === 'search-suggestion'"
+        v-else-if="supplementalViewType === 'search-suggestion'"
       />
     </div>
   </click-outside>

--- a/src/components/Main/CommandPalette/CommandPalette.vue
+++ b/src/components/Main/CommandPalette/CommandPalette.vue
@@ -3,9 +3,9 @@
     <div :class="$style.container" :data-is-mobile="$boolAttr(isMobile)">
       <command-palette-input />
       <hr v-if="supplementalViewType" :class="$style.separator" />
-      <search-result v-if="supplementalViewType === 'search-result'" />
+      <search-result v-show="supplementalViewType === 'search-result'" />
       <search-suggestion
-        v-else-if="supplementalViewType === 'search-suggestion'"
+        v-show="supplementalViewType === 'search-suggestion'"
       />
     </div>
   </click-outside>

--- a/src/components/Main/CommandPalette/CommandPaletteInput.vue
+++ b/src/components/Main/CommandPalette/CommandPaletteInput.vue
@@ -66,7 +66,9 @@ export default defineComponent({
 
     const currentInput = computed({
       get: () => store.currentInput,
-      set: input => setCurrentInput(input)
+      set: input => {
+        setCurrentInput(input)
+      }
     })
 
     const onEsc = () => {

--- a/src/components/Main/CommandPalette/CommandPaletteInput.vue
+++ b/src/components/Main/CommandPalette/CommandPaletteInput.vue
@@ -50,7 +50,8 @@ export default defineComponent({
     const {
       commandPaletteStore: store,
       settleQuery,
-      closeCommandPalette
+      closeCommandPalette,
+      setCurrentInput
     } = useCommandPaletteStore()
 
     watch(
@@ -64,7 +65,7 @@ export default defineComponent({
     )
 
     const onEsc = () => {
-      store.currentInput = ''
+      setCurrentInput('')
     }
 
     const onEnter = () => {

--- a/src/components/Main/CommandPalette/CommandPaletteInput.vue
+++ b/src/components/Main/CommandPalette/CommandPaletteInput.vue
@@ -11,7 +11,7 @@
       </div>
       <input
         ref="inputRef"
-        v-model="store.currentInput"
+        v-model="currentInput"
         :class="$style.input"
         :placeholder="placeholder"
         @keydown.esc="onEsc"
@@ -64,6 +64,11 @@ export default defineComponent({
       }
     )
 
+    const currentInput = computed({
+      get: () => store.currentInput,
+      set: input => setCurrentInput(input)
+    })
+
     const onEsc = () => {
       setCurrentInput('')
     }
@@ -92,6 +97,7 @@ export default defineComponent({
       isMobile,
       inputRef,
       store,
+      currentInput,
       onEsc,
       onEnter,
       placeholder,

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -57,10 +57,7 @@ import {
   watch
 } from 'vue'
 import { MessageId } from '/@/types/entity-ids'
-import {
-  useCommandPaletteInvoker,
-  useCommandPaletteStore
-} from '/@/providers/commandPalette'
+import { useCommandPaletteInvoker } from '/@/providers/commandPalette'
 import PopupSelector, {
   PopupSelectorItem
 } from '/@/components/UI/PopupSelector.vue'
@@ -99,8 +96,6 @@ export default defineComponent({
     Icon
   },
   setup() {
-    const { commandPaletteStore: store, setCurrentScrollTop } =
-      useCommandPaletteStore()
     const {
       executeSearchForCurrentPage,
       fetchingSearchResult,
@@ -109,22 +104,25 @@ export default defineComponent({
       jumpToPage: changePage,
       resetPaging,
       pageCount,
-      currentSortKey
+      currentSortKey,
+      query,
+      currentScrollTop,
+      setCurrentScrollTop
     } = useSearchMessages()
 
     watch(
       // クエリの変更時・ソートキーの変更時・現在のページの変更時に取得する
       computed(
-        () => [store.query, currentSortKey.value, currentPage.value] as const
+        () => [query.value, currentSortKey.value, currentPage.value] as const
       ),
       () => {
-        executeSearchForCurrentPage(store.query)
+        executeSearchForCurrentPage(query.value)
       }
     )
 
     watch(
       // クエリの変更時・ソートキーの変更時はページングをリセット
-      computed(() => [store.query, currentSortKey.value] as const),
+      computed(() => [query.value, currentSortKey.value] as const),
       ([query, key], [oldQuery, oldKey]) => {
         if (query !== oldQuery || key !== oldKey) {
           resetPaging()
@@ -133,7 +131,7 @@ export default defineComponent({
     )
 
     const resultListEle = ref<HTMLElement | null>(null)
-    const queryEntered = computed(() => store.query.length > 0)
+    const queryEntered = computed(() => query.value.length > 0)
 
     const { openMessage } = useMessageOpener()
 
@@ -147,7 +145,7 @@ export default defineComponent({
     // 開くときにスクロール位置を適用
     onMounted(() => {
       if (resultListEle.value) {
-        resultListEle.value.scrollTop = store.currentScrollTop
+        resultListEle.value.scrollTop = currentScrollTop.value
       }
     })
 

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -109,14 +109,13 @@ export default defineComponent({
     } = useSearchMessages()
 
     watch(
-      // マウント時・クエリの変更時・ソートキーの変更時・現在のページの変更時に取得する
+      // クエリの変更時・ソートキーの変更時・現在のページの変更時に取得する
       computed(
         () => [store.query, currentSortKey.value, currentPage.value] as const
       ),
       () => {
         executeSearchForCurrentPage(store.query)
-      },
-      { immediate: true }
+      }
     )
 
     watch(

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -48,14 +48,7 @@
 </template>
 
 <script lang="ts">
-import {
-  computed,
-  defineComponent,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  watch
-} from 'vue'
+import { computed, defineComponent, onMounted, ref, watch } from 'vue'
 import { MessageId } from '/@/types/entity-ids'
 import { useCommandPaletteInvoker } from '/@/providers/commandPalette'
 import PopupSelector, {
@@ -106,9 +99,8 @@ export default defineComponent({
       pageCount,
       currentSortKey,
       query,
-      currentScrollTop,
-      setCurrentScrollTop,
-      executed
+      executed,
+      keepScrollPosition
     } = useSearchMessages()
 
     watch(
@@ -150,19 +142,7 @@ export default defineComponent({
       }
     }
 
-    // 開くときにスクロール位置を適用
-    onMounted(() => {
-      if (resultListEle.value) {
-        resultListEle.value.scrollTop = currentScrollTop.value
-      }
-    })
-
-    // 閉じるときにスクロール位置を保持
-    onBeforeUnmount(() => {
-      if (resultListEle.value) {
-        setCurrentScrollTop(resultListEle.value.scrollTop)
-      }
-    })
+    keepScrollPosition(resultListEle)
 
     return {
       searchResult,

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -55,6 +55,7 @@ import PopupSelector, {
   PopupSelectorItem
 } from '/@/components/UI/PopupSelector.vue'
 import useSearchMessages from './use/searchMessages'
+import useKeepScrollPosition from './use/keepScrollPosition'
 import SearchResultMessageElement from './SearchResultMessageElement.vue'
 import LoadingSpinner from '/@/components/UI/LoadingSpinner.vue'
 import { SearchMessageSortKey } from '/@/lib/searchMessage/queryParser'
@@ -99,8 +100,7 @@ export default defineComponent({
       pageCount,
       currentSortKey,
       query,
-      executed,
-      keepScrollPosition
+      executed
     } = useSearchMessages()
 
     watch(
@@ -142,7 +142,7 @@ export default defineComponent({
       }
     }
 
-    keepScrollPosition(resultListEle)
+    useKeepScrollPosition(resultListEle)
 
     return {
       searchResult,

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -107,7 +107,8 @@ export default defineComponent({
       currentSortKey,
       query,
       currentScrollTop,
-      setCurrentScrollTop
+      setCurrentScrollTop,
+      executed
     } = useSearchMessages()
 
     watch(
@@ -119,6 +120,13 @@ export default defineComponent({
         executeSearchForCurrentPage(query.value)
       }
     )
+
+    onMounted(() => {
+      // 初回マウント時に取得する
+      if (!executed.value) {
+        executeSearchForCurrentPage(query.value)
+      }
+    })
 
     watch(
       // クエリの変更時・ソートキーの変更時はページングをリセット

--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -41,6 +41,7 @@
 <script lang="ts">
 import {
   computed,
+  DeepReadonly,
   defineComponent,
   onBeforeUnmount,
   onMounted,
@@ -112,7 +113,7 @@ export default defineComponent({
   },
   props: {
     message: {
-      type: Object as PropType<Message>,
+      type: Object as PropType<DeepReadonly<Message>>,
       required: true
     },
     currentSortKey: {

--- a/src/components/Main/CommandPalette/SearchSuggestion.vue
+++ b/src/components/Main/CommandPalette/SearchSuggestion.vue
@@ -59,7 +59,8 @@ export default defineComponent({
       commandPaletteStore: store,
       settleQuery,
       historySuggestions,
-      removeHistorySuggestion
+      removeHistorySuggestion,
+      setCurrentInput
     } = useCommandPaletteStore()
     const searchConfirmItem = computed(
       (): SuggestionItem => ({
@@ -69,9 +70,10 @@ export default defineComponent({
     )
     const onSelectQuerySuggestion = (query: string) => {
       if (store.currentInput !== '') {
-        store.currentInput += ' '
+        setCurrentInput(` ${query}`)
+      } else {
+        setCurrentInput(query)
       }
-      store.currentInput += query
       emit('queryInsert')
     }
     const onSelectSuggestion = (item: SuggestionItem) => {
@@ -81,7 +83,7 @@ export default defineComponent({
       }
     }
     const onSelectHistorySuggestion = (label: string) => {
-      store.currentInput = label
+      setCurrentInput(label)
     }
     const onRemoveHistorySuggestion = (label: string) => {
       removeHistorySuggestion(label)

--- a/src/components/Main/CommandPalette/SearchSuggestion.vue
+++ b/src/components/Main/CommandPalette/SearchSuggestion.vue
@@ -60,7 +60,8 @@ export default defineComponent({
       settleQuery,
       historySuggestions,
       removeHistorySuggestion,
-      setCurrentInput
+      setCurrentInput,
+      addCurrentInput
     } = useCommandPaletteStore()
     const searchConfirmItem = computed(
       (): SuggestionItem => ({
@@ -70,7 +71,7 @@ export default defineComponent({
     )
     const onSelectQuerySuggestion = (query: string) => {
       if (store.currentInput !== '') {
-        setCurrentInput(` ${query}`)
+        addCurrentInput(` ${query}`)
       } else {
         setCurrentInput(query)
       }

--- a/src/components/Main/CommandPalette/use/keepScrollPosition.ts
+++ b/src/components/Main/CommandPalette/use/keepScrollPosition.ts
@@ -1,0 +1,23 @@
+import { onBeforeUnmount, onMounted, Ref } from 'vue'
+import { useCommandPaletteStore } from '/@/providers/commandPalette'
+
+const useKeepScrollPosition = (ele: Ref<HTMLElement | null>) => {
+  const { commandPaletteStore: store, setCurrentScrollTop } =
+    useCommandPaletteStore()
+
+  // 開くときにスクロール位置を適用
+  onMounted(() => {
+    if (ele.value) {
+      ele.value.scrollTop = store.searchState.currentScrollTop
+    }
+  })
+
+  // 閉じるときにスクロール位置を保持
+  onBeforeUnmount(() => {
+    if (ele.value) {
+      setCurrentScrollTop(ele.value.scrollTop)
+    }
+  })
+}
+
+export default useKeepScrollPosition

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -77,6 +77,7 @@ const useSearchMessages = () => {
     setCurrentPage,
     setCurrentScrollTop,
     resetPaging,
+    setExecuted,
     commandPaletteStore
   } = useCommandPaletteStore()
 
@@ -87,9 +88,8 @@ const useSearchMessages = () => {
     set: sortKey => setCurrentSortKey(sortKey)
   })
 
-  const { searchResult, currentPage, totalCount, currentScrollTop } = toRefs(
-    commandPaletteStore.searchState
-  )
+  const { executed, searchResult, currentPage, totalCount, currentScrollTop } =
+    toRefs(commandPaletteStore.searchState)
 
   const { sortedMessages } = useSortMessages(searchResult, currentSortKey)
 
@@ -126,6 +126,7 @@ const useSearchMessages = () => {
       )
     )
     fetchingSearchResult.value = false
+    setExecuted(true)
 
     setSearchResult(res.data.hits ?? [])
     setTotalCount(res.data.totalHits ?? 0)
@@ -141,6 +142,7 @@ const useSearchMessages = () => {
     currentSortKey,
     currentScrollTop,
     searchResult: sortedMessages,
+    executed,
 
     pageCount,
     showingRange,

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -1,12 +1,4 @@
-import {
-  ref,
-  computed,
-  Ref,
-  DeepReadonly,
-  toRefs,
-  onMounted,
-  onBeforeUnmount
-} from 'vue'
+import { ref, computed, Ref, DeepReadonly, toRefs } from 'vue'
 import { Message } from '@traptitech/traq'
 import apis from '/@/lib/apis'
 import { compareDateString } from '/@/lib/basic/date'
@@ -82,7 +74,6 @@ const useSearchMessages = () => {
     setTotalCount,
     setCurrentSortKey,
     setCurrentPage,
-    setCurrentScrollTop,
     resetPaging,
     setExecuted,
     commandPaletteStore
@@ -95,8 +86,9 @@ const useSearchMessages = () => {
     set: sortKey => setCurrentSortKey(sortKey)
   })
 
-  const { executed, searchResult, currentPage, totalCount, currentScrollTop } =
-    toRefs(commandPaletteStore.searchState)
+  const { executed, searchResult, currentPage, totalCount } = toRefs(
+    commandPaletteStore.searchState
+  )
 
   const { sortedMessages } = useSortMessages(searchResult, currentSortKey)
 
@@ -139,22 +131,6 @@ const useSearchMessages = () => {
     setTotalCount(res.data.totalHits ?? 0)
   }
 
-  const keepScrollPosition = (ele: Ref<HTMLElement | null>) => {
-    // 開くときにスクロール位置を適用
-    onMounted(() => {
-      if (ele.value) {
-        ele.value.scrollTop = currentScrollTop.value
-      }
-    })
-
-    // 閉じるときにスクロール位置を保持
-    onBeforeUnmount(() => {
-      if (ele.value) {
-        setCurrentScrollTop(ele.value.scrollTop)
-      }
-    })
-  }
-
   return {
     resetPaging,
 
@@ -170,8 +146,7 @@ const useSearchMessages = () => {
     jumpToPage,
 
     fetchingSearchResult,
-    executeSearchForCurrentPage: fetchAndRenderMessagesOnCurrentPageBySearch,
-    keepScrollPosition
+    executeSearchForCurrentPage: fetchAndRenderMessagesOnCurrentPageBySearch
   }
 }
 

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -1,4 +1,4 @@
-import { ref, computed, readonly, ComputedRef, Ref, DeepReadonly } from 'vue'
+import { ref, computed, readonly, Ref, DeepReadonly, toRefs } from 'vue'
 import { Message } from '@traptitech/traq'
 import apis from '/@/lib/apis'
 import { compareDateString } from '/@/lib/basic/date'
@@ -36,8 +36,8 @@ const useSortMessages = (
 
 const usePaging = (
   itemsPerPage: number,
-  currentPage: ComputedRef<number>,
-  totalCount: ComputedRef<number>,
+  currentPage: Ref<number>,
+  totalCount: Ref<number>,
   setCurrentPage: (page: number) => void
 ) => {
   /** 現在のオフセット */
@@ -82,26 +82,15 @@ const useSearchMessages = () => {
 
   const query = computed(() => commandPaletteStore.query)
 
-  /** 現在表示しているページ、0-indexed */
-  const currentPage = computed(
-    () => commandPaletteStore.searchState.currentPage
-  )
-
-  /** 項目の総数 */
-  const totalCount = computed(() => commandPaletteStore.searchState.totalCount)
-
   const currentSortKey = computed({
     get: () => commandPaletteStore.searchState.currentSortKey,
     set: (sortKey: SearchMessageSortKey) => setCurrentSortKey(sortKey)
   })
 
-  const currentScrollTop = computed(
-    () => commandPaletteStore.searchState.currentScrollTop
+  const { searchResult, currentPage, totalCount, currentScrollTop } = toRefs(
+    commandPaletteStore.searchState
   )
 
-  const searchResult = computed(
-    () => commandPaletteStore.searchState.searchResult
-  )
   const { sortedMessages } = useSortMessages(searchResult, currentSortKey)
 
   const { currentOffset, pageCount, showingRange, jumpToPage } = usePaging(

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -84,7 +84,7 @@ const useSearchMessages = () => {
 
   const currentSortKey = computed({
     get: () => commandPaletteStore.searchState.currentSortKey,
-    set: (sortKey: SearchMessageSortKey) => setCurrentSortKey(sortKey)
+    set: sortKey => setCurrentSortKey(sortKey)
   })
 
   const { searchResult, currentPage, totalCount, currentScrollTop } = toRefs(

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -1,4 +1,4 @@
-import { ref, computed, readonly, ComputedRef, Ref } from 'vue'
+import { ref, computed, readonly, ComputedRef, Ref, DeepReadonly } from 'vue'
 import { Message } from '@traptitech/traq'
 import apis from '/@/lib/apis'
 import { compareDateString } from '/@/lib/basic/date'
@@ -8,27 +8,27 @@ import { SearchMessageSortKey } from '/@/lib/searchMessage/queryParser'
 import { useCommandPaletteStore } from '/@/providers/commandPalette'
 
 const useSortMessages = (
-  messages: Ref<Message[]>,
+  messages: Ref<DeepReadonly<Message[]>>,
   currentSortKey: Ref<SearchMessageSortKey>
 ) => {
   const sortedMessages = computed(() => {
     switch (currentSortKey.value) {
       case '-createdAt':
-        return messages.value.sort((m1, m2) =>
-          compareDateString(m1.createdAt, m2.createdAt)
-        )
+        return messages.value
+          .slice()
+          .sort((m1, m2) => compareDateString(m1.createdAt, m2.createdAt))
       case 'updatedAt':
-        return messages.value.sort((m1, m2) =>
-          compareDateString(m1.updatedAt, m2.updatedAt, true)
-        )
+        return messages.value
+          .slice()
+          .sort((m1, m2) => compareDateString(m1.updatedAt, m2.updatedAt, true))
       case '-updatedAt':
-        return messages.value.sort((m1, m2) =>
-          compareDateString(m1.updatedAt, m2.updatedAt)
-        )
+        return messages.value
+          .slice()
+          .sort((m1, m2) => compareDateString(m1.updatedAt, m2.updatedAt))
       default:
-        return messages.value.sort((m1, m2) =>
-          compareDateString(m1.createdAt, m2.createdAt, true)
-        )
+        return messages.value
+          .slice()
+          .sort((m1, m2) => compareDateString(m1.createdAt, m2.createdAt, true))
     }
   })
   return { sortedMessages }

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -1,4 +1,13 @@
-import { ref, computed, readonly, Ref, DeepReadonly, toRefs } from 'vue'
+import {
+  ref,
+  computed,
+  readonly,
+  Ref,
+  DeepReadonly,
+  toRefs,
+  onMounted,
+  onBeforeUnmount
+} from 'vue'
 import { Message } from '@traptitech/traq'
 import apis from '/@/lib/apis'
 import { compareDateString } from '/@/lib/basic/date'
@@ -132,15 +141,29 @@ const useSearchMessages = () => {
     setTotalCount(res.data.totalHits ?? 0)
   }
 
+  const keepScrollPosition = (ele: Ref<HTMLElement | null>) => {
+    // 開くときにスクロール位置を適用
+    onMounted(() => {
+      if (ele.value) {
+        ele.value.scrollTop = currentScrollTop.value
+      }
+    })
+
+    // 閉じるときにスクロール位置を保持
+    onBeforeUnmount(() => {
+      if (ele.value) {
+        setCurrentScrollTop(ele.value.scrollTop)
+      }
+    })
+  }
+
   return {
-    setCurrentScrollTop,
     resetPaging,
 
     query,
     currentPage: readonly(currentPage),
     totalCount: readonly(totalCount),
     currentSortKey,
-    currentScrollTop,
     searchResult: sortedMessages,
     executed,
 
@@ -149,7 +172,8 @@ const useSearchMessages = () => {
     jumpToPage,
 
     fetchingSearchResult,
-    executeSearchForCurrentPage: fetchAndRenderMessagesOnCurrentPageBySearch
+    executeSearchForCurrentPage: fetchAndRenderMessagesOnCurrentPageBySearch,
+    keepScrollPosition
   }
 }
 

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -83,7 +83,9 @@ const useSearchMessages = () => {
 
   const currentSortKey = computed({
     get: () => commandPaletteStore.searchState.currentSortKey,
-    set: sortKey => setCurrentSortKey(sortKey)
+    set: sortKey => {
+      setCurrentSortKey(sortKey)
+    }
   })
 
   const { executed, searchResult, currentPage, totalCount } = toRefs(
@@ -125,8 +127,8 @@ const useSearchMessages = () => {
       )
     )
     fetchingSearchResult.value = false
-    setExecuted(true)
 
+    setExecuted(true)
     setSearchResult(hits)
     setTotalCount(res.data.totalHits ?? 0)
   }

--- a/src/components/Main/CommandPalette/use/searchMessages.ts
+++ b/src/components/Main/CommandPalette/use/searchMessages.ts
@@ -1,7 +1,6 @@
 import {
   ref,
   computed,
-  readonly,
   Ref,
   DeepReadonly,
   toRefs,
@@ -23,21 +22,21 @@ const useSortMessages = (
   const sortedMessages = computed(() => {
     switch (currentSortKey.value) {
       case '-createdAt':
-        return messages.value
-          .slice()
-          .sort((m1, m2) => compareDateString(m1.createdAt, m2.createdAt))
+        return [...messages.value].sort((m1, m2) =>
+          compareDateString(m1.createdAt, m2.createdAt)
+        )
       case 'updatedAt':
-        return messages.value
-          .slice()
-          .sort((m1, m2) => compareDateString(m1.updatedAt, m2.updatedAt, true))
+        return [...messages.value].sort((m1, m2) =>
+          compareDateString(m1.updatedAt, m2.updatedAt, true)
+        )
       case '-updatedAt':
-        return messages.value
-          .slice()
-          .sort((m1, m2) => compareDateString(m1.updatedAt, m2.updatedAt))
+        return [...messages.value].sort((m1, m2) =>
+          compareDateString(m1.updatedAt, m2.updatedAt)
+        )
       default:
-        return messages.value
-          .slice()
-          .sort((m1, m2) => compareDateString(m1.createdAt, m2.createdAt, true))
+        return [...messages.value].sort((m1, m2) =>
+          compareDateString(m1.createdAt, m2.createdAt, true)
+        )
     }
   })
   return { sortedMessages }
@@ -69,9 +68,8 @@ const usePaging = (
 
   return {
     currentOffset,
-    totalCount,
-    pageCount,
     showingRange,
+    pageCount,
     jumpToPage
   }
 }
@@ -137,7 +135,7 @@ const useSearchMessages = () => {
     fetchingSearchResult.value = false
     setExecuted(true)
 
-    setSearchResult(res.data.hits ?? [])
+    setSearchResult(hits)
     setTotalCount(res.data.totalHits ?? 0)
   }
 
@@ -161,8 +159,8 @@ const useSearchMessages = () => {
     resetPaging,
 
     query,
-    currentPage: readonly(currentPage),
-    totalCount: readonly(totalCount),
+    currentPage,
+    totalCount,
     currentSortKey,
     searchResult: sortedMessages,
     executed,

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -167,9 +167,10 @@ export const useCommandPaletteStore = () => {
   }
 
   const resetPaging = () => {
-    commandPaletteStore.searchState.currentPage = 0
+    commandPaletteStore.searchState.executed = false
     commandPaletteStore.searchState.searchResult = []
     commandPaletteStore.searchState.totalCount = 0
+    commandPaletteStore.searchState.currentPage = 0
   }
 
   return {

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -7,22 +7,7 @@ const commandPaletteStoreSymbol: InjectionKey<CommandPaletteStore> = Symbol()
 
 type CommandPaletteMode = 'command' | 'search'
 
-export interface CommandPaletteStore {
-  /**
-   * 表示モード
-   */
-  mode: CommandPaletteMode | undefined
-
-  /**
-   * 決定された入力内容
-   */
-  query: string
-
-  /**
-   * 現在入力中の文字列
-   */
-  currentInput: string
-
+type SearchState = {
   /**
    * 検索結果
    */
@@ -49,16 +34,40 @@ export interface CommandPaletteStore {
   currentScrollTop: number
 }
 
+export interface CommandPaletteStore {
+  /**
+   * 表示モード
+   */
+  mode: CommandPaletteMode | undefined
+
+  /**
+   * 決定された入力内容
+   */
+  query: string
+
+  /**
+   * 現在入力中の文字列
+   */
+  currentInput: string
+
+  /**
+   * 検索の状態
+   */
+  searchState: SearchState
+}
+
 const createCommandPaletteStore = () =>
   reactive<CommandPaletteStore>({
     mode: undefined,
     query: '',
     currentInput: '',
-    totalCount: 0,
-    searchResult: [],
-    currentPage: 0,
-    currentSortKey: 'createdAt',
-    currentScrollTop: 0
+    searchState: {
+      totalCount: 0,
+      searchResult: [],
+      currentPage: 0,
+      currentSortKey: 'createdAt',
+      currentScrollTop: 0
+    }
   })
 
 export const provideCommandPaletteStore = () => {
@@ -110,29 +119,29 @@ export const useCommandPaletteStore = () => {
   }
 
   const setSearchResult = (messages: Message[]) => {
-    commandPaletteStore.searchResult = messages
+    commandPaletteStore.searchState.searchResult = messages
   }
 
   const setTotalCount = (totalCount: number) => {
-    commandPaletteStore.totalCount = totalCount
+    commandPaletteStore.searchState.totalCount = totalCount
   }
 
   const setCurrentSortKey = (sortKey: SearchMessageSortKey) => {
-    commandPaletteStore.currentSortKey = sortKey
+    commandPaletteStore.searchState.currentSortKey = sortKey
   }
 
   const setCurrentPage = (page: number) => {
-    commandPaletteStore.currentPage = page
+    commandPaletteStore.searchState.currentPage = page
   }
 
   const resetPaging = () => {
-    commandPaletteStore.currentPage = 0
-    commandPaletteStore.searchResult = []
-    commandPaletteStore.totalCount = 0
+    commandPaletteStore.searchState.currentPage = 0
+    commandPaletteStore.searchState.searchResult = []
+    commandPaletteStore.searchState.totalCount = 0
   }
 
   const setCurrentScrollTop = (scrollTop: number) => {
-    commandPaletteStore.currentScrollTop = scrollTop
+    commandPaletteStore.searchState.currentScrollTop = scrollTop
   }
 
   return {

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -1,4 +1,6 @@
+import { Message } from '@traptitech/traq'
 import { computed, inject, InjectionKey, provide, reactive } from 'vue'
+import { SearchMessageSortKey } from '/@/lib/searchMessage/queryParser'
 import store from '/@/store'
 
 const commandPaletteStoreSymbol: InjectionKey<CommandPaletteStore> = Symbol()
@@ -20,13 +22,37 @@ export interface CommandPaletteStore {
    * 現在入力中の文字列
    */
   currentInput: string
+
+  /**
+   * 検索結果
+   */
+  searchResult: Message[]
+
+  /**
+   * 項目の総数
+   */
+  totalCount: number
+
+  /**
+   * 現在表示しているページ、0-indexed
+   */
+  currentPage: number
+
+  /**
+   * 現在のソートキー
+   */
+  currentSortKey: SearchMessageSortKey
 }
 
 const createCommandPaletteStore = () =>
   reactive<CommandPaletteStore>({
     mode: undefined,
     query: '',
-    currentInput: ''
+    currentInput: '',
+    totalCount: 0,
+    searchResult: [],
+    currentPage: 0,
+    currentSortKey: 'createdAt'
   })
 
 export const provideCommandPaletteStore = () => {
@@ -41,8 +67,6 @@ const useCommandPaletteBase = () => {
 
   const openCommandPalette = (mode: CommandPaletteMode, initialInput = '') => {
     commandPaletteStore.mode = mode
-    commandPaletteStore.query = ''
-    commandPaletteStore.currentInput = initialInput
   }
   const closeCommandPalette = () => {
     commandPaletteStore.mode = undefined
@@ -79,6 +103,28 @@ export const useCommandPaletteStore = () => {
     store.commit.app.removeSearchHistory(oldHistory)
   }
 
+  const setSearchResult = (messages: Message[]) => {
+    commandPaletteStore.searchResult = messages
+  }
+
+  const setTotalCount = (totalCount: number) => {
+    commandPaletteStore.totalCount = totalCount
+  }
+
+  const setCurrentSortKey = (sortKey: SearchMessageSortKey) => {
+    commandPaletteStore.currentSortKey = sortKey
+  }
+
+  const setCurrentPage = (page: number) => {
+    commandPaletteStore.currentPage = page
+  }
+
+  const resetPaging = () => {
+    commandPaletteStore.currentPage = 0
+    commandPaletteStore.searchResult = []
+    commandPaletteStore.totalCount = 0
+  }
+
   return {
     commandPaletteStore,
     isCommandPaletteShown,
@@ -86,7 +132,12 @@ export const useCommandPaletteStore = () => {
     closeCommandPalette,
     settleQuery,
     historySuggestions,
-    removeHistorySuggestion
+    removeHistorySuggestion,
+    setSearchResult,
+    setTotalCount,
+    setCurrentSortKey,
+    setCurrentPage,
+    resetPaging
   }
 }
 

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -95,7 +95,9 @@ const useCommandPaletteBase = () => {
 
   const openCommandPalette = (mode: CommandPaletteMode, initialInput = '') => {
     commandPaletteStore.mode = mode
-    if (initialInput !== '') commandPaletteStore.currentInput = initialInput
+    if (initialInput !== '') {
+      commandPaletteStore.currentInput = initialInput
+    }
   }
   const closeCommandPalette = () => {
     commandPaletteStore.mode = undefined
@@ -136,6 +138,10 @@ export const useCommandPaletteStore = () => {
     commandPaletteStore.currentInput = currentInput
   }
 
+  const setExecuted = (executed: boolean) => {
+    commandPaletteStore.searchState.executed = executed
+  }
+
   const setSearchResult = (messages: Message[]) => {
     commandPaletteStore.searchState.searchResult = messages
   }
@@ -152,36 +158,33 @@ export const useCommandPaletteStore = () => {
     commandPaletteStore.searchState.currentPage = page
   }
 
+  const setCurrentScrollTop = (scrollTop: number) => {
+    commandPaletteStore.searchState.currentScrollTop = scrollTop
+  }
+
   const resetPaging = () => {
     commandPaletteStore.searchState.currentPage = 0
     commandPaletteStore.searchState.searchResult = []
     commandPaletteStore.searchState.totalCount = 0
   }
 
-  const setCurrentScrollTop = (scrollTop: number) => {
-    commandPaletteStore.searchState.currentScrollTop = scrollTop
-  }
-
-  const setExecuted = (executed: boolean) => {
-    commandPaletteStore.searchState.executed = executed
-  }
-
   return {
     commandPaletteStore: readonly(commandPaletteStore),
-    isCommandPaletteShown,
     openCommandPalette,
     closeCommandPalette,
+
+    isCommandPaletteShown,
     settleQuery,
     historySuggestions,
     removeHistorySuggestion,
     setCurrentInput,
+    setExecuted,
     setSearchResult,
     setTotalCount,
     setCurrentSortKey,
     setCurrentPage,
-    resetPaging,
     setCurrentScrollTop,
-    setExecuted
+    resetPaging
   }
 }
 

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -138,6 +138,10 @@ export const useCommandPaletteStore = () => {
     commandPaletteStore.currentInput = currentInput
   }
 
+  const addCurrentInput = (input: string) => {
+    commandPaletteStore.currentInput += input
+  }
+
   const setExecuted = (executed: boolean) => {
     commandPaletteStore.searchState.executed = executed
   }
@@ -178,6 +182,7 @@ export const useCommandPaletteStore = () => {
     historySuggestions,
     removeHistorySuggestion,
     setCurrentInput,
+    addCurrentInput,
     setExecuted,
     setSearchResult,
     setTotalCount,

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -82,6 +82,7 @@ const useCommandPaletteBase = () => {
 
   const openCommandPalette = (mode: CommandPaletteMode, initialInput = '') => {
     commandPaletteStore.mode = mode
+    if (initialInput !== '') commandPaletteStore.currentInput = initialInput
   }
   const closeCommandPalette = () => {
     commandPaletteStore.mode = undefined

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -16,6 +16,11 @@ type CommandPaletteMode = 'command' | 'search'
 
 type SearchState = {
   /**
+   * 検索を実行したかどうか
+   */
+  executed: boolean
+
+  /**
    * 検索結果
    */
   searchResult: Message[]
@@ -69,6 +74,7 @@ const createCommandPaletteStore = () =>
     query: '',
     currentInput: '',
     searchState: {
+      executed: false,
       totalCount: 0,
       searchResult: [],
       currentPage: 0,
@@ -156,6 +162,10 @@ export const useCommandPaletteStore = () => {
     commandPaletteStore.searchState.currentScrollTop = scrollTop
   }
 
+  const setExecuted = (executed: boolean) => {
+    commandPaletteStore.searchState.executed = executed
+  }
+
   return {
     commandPaletteStore: readonly(commandPaletteStore),
     isCommandPaletteShown,
@@ -170,7 +180,8 @@ export const useCommandPaletteStore = () => {
     setCurrentSortKey,
     setCurrentPage,
     resetPaging,
-    setCurrentScrollTop
+    setCurrentScrollTop,
+    setExecuted
   }
 }
 

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -1,5 +1,12 @@
 import { Message } from '@traptitech/traq'
-import { computed, inject, InjectionKey, provide, reactive } from 'vue'
+import {
+  computed,
+  inject,
+  InjectionKey,
+  provide,
+  reactive,
+  readonly
+} from 'vue'
 import { SearchMessageSortKey } from '/@/lib/searchMessage/queryParser'
 import store from '/@/store'
 
@@ -119,6 +126,10 @@ export const useCommandPaletteStore = () => {
     store.commit.app.removeSearchHistory(oldHistory)
   }
 
+  const setCurrentInput = (currentInput: string) => {
+    commandPaletteStore.currentInput = currentInput
+  }
+
   const setSearchResult = (messages: Message[]) => {
     commandPaletteStore.searchState.searchResult = messages
   }
@@ -146,13 +157,14 @@ export const useCommandPaletteStore = () => {
   }
 
   return {
-    commandPaletteStore,
+    commandPaletteStore: readonly(commandPaletteStore),
     isCommandPaletteShown,
     openCommandPalette,
     closeCommandPalette,
     settleQuery,
     historySuggestions,
     removeHistorySuggestion,
+    setCurrentInput,
     setSearchResult,
     setTotalCount,
     setCurrentSortKey,

--- a/src/providers/commandPalette.ts
+++ b/src/providers/commandPalette.ts
@@ -42,6 +42,11 @@ export interface CommandPaletteStore {
    * 現在のソートキー
    */
   currentSortKey: SearchMessageSortKey
+
+  /**
+   * スクロール位置
+   */
+  currentScrollTop: number
 }
 
 const createCommandPaletteStore = () =>
@@ -52,7 +57,8 @@ const createCommandPaletteStore = () =>
     totalCount: 0,
     searchResult: [],
     currentPage: 0,
-    currentSortKey: 'createdAt'
+    currentSortKey: 'createdAt',
+    currentScrollTop: 0
   })
 
 export const provideCommandPaletteStore = () => {
@@ -125,6 +131,10 @@ export const useCommandPaletteStore = () => {
     commandPaletteStore.totalCount = 0
   }
 
+  const setCurrentScrollTop = (scrollTop: number) => {
+    commandPaletteStore.currentScrollTop = scrollTop
+  }
+
   return {
     commandPaletteStore,
     isCommandPaletteShown,
@@ -137,7 +147,8 @@ export const useCommandPaletteStore = () => {
     setTotalCount,
     setCurrentSortKey,
     setCurrentPage,
-    resetPaging
+    resetPaging,
+    setCurrentScrollTop
   }
 }
 


### PR DESCRIPTION
close #2096

- 検索に関する状態をproviderに置くようにしました
  - こんな感じでいいのかあまり自信がないです
- マウント時に検索を実行しないようにしました
  - `SearchResult` の切り替えが `v-if` だと描画のタイミング的に初回の検索が実行されなかったので、`v-show` を使うようにしました
- スクロール位置を保持するようにしました
  - `SearchResult.vue` の `jumpToPage` はミスな気がしたので修正しました 