### PR TITLE
ダークテーマで黒いスタンプが見にくかった

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -108,6 +108,12 @@ type SpecificTheme = {
   mainViewBackground: CSSImageType
   /** サイドバー(右の部分)の背景色 */
   sideBarBackground: CSSImageType
+
+  /**
+   * スタンプに縁をつけるか
+   * @default false
+   */
+  stampEdgeEnable: boolean
 }
 ```
 

--- a/public/defaultTheme.js
+++ b/public/defaultTheme.js
@@ -57,6 +57,9 @@
         primary: '#FFFFFF',
         secondary: '#BAC2C9'
       }
+    },
+    specific: {
+      stampEdgeEnable: true
     }
   }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -68,6 +68,11 @@ const useThemeObserver = () => {
       'dark'
   )
   useHtmlDatasetBoolean('codeHighlight', codeHighlight)
+
+  const stampEdge = computed(
+    () => store.getters.app.themeSettings.currentTheme.specific.stampEdgeEnable
+  )
+  useHtmlDatasetBoolean('stampEdge', stampEdge)
 }
 
 const useEcoModeObserver = () => {

--- a/src/components/UI/AStamp.vue
+++ b/src/components/UI/AStamp.vue
@@ -1,15 +1,15 @@
 <template>
-  <img
-    v-if="imageUrl.length > 0"
-    loading="lazy"
-    :class="$style.container"
-    :style="styles.container"
-    :src="imageUrl"
-    :alt="name"
-    :title="!withoutTitle ? name : undefined"
-    draggable="false"
-  />
-  <div v-else :class="$style.container" :style="styles.container" />
+  <div :class="$style.container" :style="styles.container">
+    <img
+      v-if="imageUrl.length > 0"
+      :class="$style.img"
+      loading="lazy"
+      :src="imageUrl"
+      :alt="name"
+      :title="!withoutTitle ? name : undefined"
+      draggable="false"
+    />
+  </div>
 </template>
 
 <script lang="ts">
@@ -61,5 +61,14 @@ export default defineComponent({
   object-fit: contain;
   user-select: none;
   contain: content; // strictだと縦横比がうまくいかない
+}
+
+.img {
+  html[data-stamp-edge] & {
+    filter: drop-shadow(0.1px 0.1px 0 rgb(255, 255, 255, 0.1))
+      drop-shadow(0.1px -0.1px 0 rgb(255, 255, 255, 0.1))
+      drop-shadow(-0.1px 0.1px 0 rgb(255, 255, 255, 0.1))
+      drop-shadow(-0.1px -0.1px 0 rgb(255, 255, 255, 0.1));
+  }
 }
 </style>

--- a/src/lib/theme/resolve/index.ts
+++ b/src/lib/theme/resolve/index.ts
@@ -70,6 +70,8 @@ const resolveSpecificTheme = (
   sideBarBackground:
     original?.sideBarBackground ?? basic.background.secondary.default,
 
+  stampEdgeEnable: original?.stampEdgeEnable ?? false,
+
   channelHashOpened: basic.background.secondary.border,
   channelUnreadBadgeText: basic.background.secondary.border,
   messageHoverBackground: transparentizeWithFallback(

--- a/src/lib/theme/schema.ts
+++ b/src/lib/theme/schema.ts
@@ -104,7 +104,9 @@ const specificThemeSchema = z.object({
   navigationBarDesktopBackground: CSSImageTypeSchema,
   navigationBarMobileBackground: CSSImageTypeSchema,
   mainViewBackground: CSSImageTypeSchema,
-  sideBarBackground: CSSImageTypeSchema
+  sideBarBackground: CSSImageTypeSchema,
+
+  stampEdgeEnable: z.boolean()
 })
 
 export type BrowserTheme = z.infer<typeof browserThemeSchema>

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -28,3 +28,12 @@ html[data-code-highlight='light'] {
 html[data-code-highlight='dark'] {
   @import 'highlight.js/styles/atom-one-light';
 }
+
+html[data-stamp-edge] {
+  .emoji {
+    filter: drop-shadow(0.1px 0.1px 0 rgb(255, 255, 255, 0.1))
+      drop-shadow(0.1px -0.1px 0 rgb(255, 255, 255, 0.1))
+      drop-shadow(-0.1px 0.1px 0 rgb(255, 255, 255, 0.1))
+      drop-shadow(-0.1px -0.1px 0 rgb(255, 255, 255, 0.1));
+  }
+}

--- a/tests/unit/lib/theme/resolve/index.spec.ts
+++ b/tests/unit/lib/theme/resolve/index.spec.ts
@@ -38,6 +38,7 @@ describe('resolveTheme', () => {
       navigationBarMobileBackground: '#E2E5E9',
       mainViewBackground: '#FFFFFF',
       sideBarBackground: '#F0F2F5',
+      stampEdgeEnable: false,
       channelHashOpened: '#F0F2F5',
       channelUnreadBadgeText: '#F0F2F5',
       loadingSpinnerGapUiSecondary: 'rgba(107, 125, 138, 0.5)',


### PR DESCRIPTION
- before
![image](https://user-images.githubusercontent.com/49056869/156015376-ff7b3962-90a2-42b4-a5c8-dd672e619519.png)
- after
![image](https://user-images.githubusercontent.com/49056869/156015327-0fa1bd7f-904e-414d-9e24-fc870b2b2fca.png)

`specific.stampEdgeEnable`で有効化できる
デフォルトのダークテーマでは有効
