### PR TITLE
ピン留め一覧の背景色が変になっていた

### DIFF
--- a/src/components/Main/MainView/MainViewSidebar/SidebarPinned/SidebarPinnedList.vue
+++ b/src/components/Main/MainView/MainViewSidebar/SidebarPinned/SidebarPinnedList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.container">
+  <div>
     <sidebar-pinned-message
       v-for="message in sortedMessages"
       :key="message.id"
@@ -34,15 +34,14 @@ const sortedMessages = computed(() =>
 </script>
 
 <style lang="scss" module>
-.container {
-  @include color-ui-secondary;
-  @include background-secondary;
-}
 .item + .item {
   margin-top: 16px;
 }
 
 .noPinned {
-  @include color-ui-tertiary;
+  @include color-ui-secondary;
+  @include background-secondary;
+  padding: 8px;
+  border-radius: 4px;
 }
 </style>


### PR DESCRIPTION
- before
  - ![image](https://user-images.githubusercontent.com/49056869/158531183-0651a817-9b21-40c3-8247-98cccbae20d6.png)
  - ![image](https://user-images.githubusercontent.com/49056869/158531202-25068fb9-c7cb-4867-8440-34404eac2123.png)
- after
  - ![image](https://user-images.githubusercontent.com/49056869/158531390-afb2a3fa-7d0b-448e-9d29-890d4a1caedd.png)
  - ![image](https://user-images.githubusercontent.com/49056869/158531425-23e4cd82-4069-4871-9af6-57a841640a59.png)

