### PR TITLE
スタンプピッカーでのカーソル位置に対するスタンプの挿入がうまくいかなかった

### DIFF
--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -99,6 +99,8 @@ const textareaAutosizeRef = ref<{
 }>()
 const textareaRef = computed(() => textareaAutosizeRef.value?.$el)
 
+defineExpose({ textareaAutosizeRef })
+
 const { insertText } = useInsertText(textareaRef)
 const { onPaste } = usePaste(toRef(props, 'channelId'), emit, insertText)
 


### PR DESCRIPTION
fix #3150 