### PR TITLE
メッセージ検索の改善

### DIFF
--- a/src/components/Main/CommandPalette/composables/useSearchMessages.ts
+++ b/src/components/Main/CommandPalette/composables/useSearchMessages.ts
@@ -69,7 +69,7 @@ const usePaging = (
 const useSearchMessages = () => {
   const limit = 20
   const { parseQuery, toSearchMessageParam } = useQueryParer()
-  const { query, searchState, setSearchResult, resetPaging } =
+  const { query, searchState, setSearchResult, resetPaging, addSearchHistory } =
     useCommandPalette()
   const { extendMessagesMap } = useMessagesStore()
 
@@ -108,7 +108,9 @@ const useSearchMessages = () => {
     }
 
     fetchingSearchResult.value = true
-    const queryObject = await parseQuery(query)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    addSearchHistory(normalizedQuery)
+
     const option = {
       limit,
       offset: currentOffset.value,

--- a/src/composables/searchMessage/useQueryParser.ts
+++ b/src/composables/searchMessage/useQueryParser.ts
@@ -1,4 +1,5 @@
-import type { Ref } from 'vue'
+import type { Ref, ComputedRef } from 'vue'
+import { computed } from 'vue'
 import type { ChannelTree } from '/@/lib/channelTree'
 import { channelPathToId } from '/@/lib/channelTree'
 import type { StoreForParser } from '/@/lib/searchMessage/parserBase'
@@ -14,16 +15,19 @@ import type { Channel, User } from '@traptitech/traq'
 import { channelIdToPathString } from '/@/lib/channel'
 import type { ChannelId } from '/@/types/entity-ids'
 import { useChannelsStore } from '/@/store/entities/channels'
+import { useMeStore } from '/@/store/domain/me'
 
 const getStoreForParser = ({
   primaryView,
   channelsMap,
   channelTree,
+  myUsername,
   fetchUserByName
 }: {
   primaryView: Ref<ViewInformation>
   channelsMap: Ref<ReadonlyMap<ChannelId, Channel>>
   channelTree: Ref<ChannelTree>
+  myUsername: ComputedRef<string | undefined>
   fetchUserByName: (param: { username: string }) => Promise<User | undefined>
 }): StoreForParser => ({
   channelPathToId: path => {
@@ -45,7 +49,8 @@ const getStoreForParser = ({
     return channelId
       ? channelIdToPathString(channelId, channelsMap.value)
       : undefined
-  }
+  },
+  getMyUsername: () => myUsername.value
 })
 
 const useQueryParer = () => {
@@ -53,11 +58,13 @@ const useQueryParer = () => {
   const { channelTree } = useChannelTree()
   const { primaryView } = useMainViewStore()
   const { fetchUserByName } = useUsersStore()
+  const { detail: me } = useMeStore()
   const parseQuery = createQueryParser(
     getStoreForParser({
       primaryView,
       channelsMap,
       channelTree,
+      myUsername: computed(() => me.value?.name),
       fetchUserByName
     })
   )

--- a/src/lib/searchMessage/parserBase.ts
+++ b/src/lib/searchMessage/parserBase.ts
@@ -82,7 +82,7 @@ export const makePrefixedFilterExtractor =
 export type StoreForParser = {
   channelPathToId: ChannelPathToId
   usernameToId: UsernameToId
-  getCurrentChannelId: () => ChannelId | undefined
+  getCurrentChannelPath: () => string | undefined
 }
 
 type ChannelPathToId = (path: string) => ChannelId | undefined

--- a/src/lib/searchMessage/parserBase.ts
+++ b/src/lib/searchMessage/parserBase.ts
@@ -83,6 +83,7 @@ export type StoreForParser = {
   channelPathToId: ChannelPathToId
   usernameToId: UsernameToId
   getCurrentChannelPath: () => string | undefined
+  getMyUsername: () => string | undefined
 }
 
 type ChannelPathToId = (path: string) => ChannelId | undefined
@@ -144,6 +145,7 @@ export const dateParser = <T extends string>(
 }
 
 export const InHereToken = Symbol('in:here')
+export const FromToMeToken = Symbol('from:me / to:me')
 
 export const channelParser = <T extends string>(
   channelPathToId: ChannelPathToId,
@@ -162,10 +164,14 @@ export const channelParser = <T extends string>(
 export const userParser = async <T extends string>(
   usernameToId: UsernameToId,
   extracted: ExtractedFilter<T>
-): Promise<UserId | undefined> => {
+): Promise<UserId | typeof FromToMeToken | undefined> => {
   const username = extracted.body.startsWith('@')
     ? extracted.body.slice(1)
     : extracted.body
+
+  if (username === 'me') {
+    return FromToMeToken
+  }
 
   return usernameToId(username)
 }

--- a/src/lib/searchMessage/parserBase.ts
+++ b/src/lib/searchMessage/parserBase.ts
@@ -95,7 +95,7 @@ type UsernameToId =
  * @typeParam F フィルターの型
  * @typeParam T フィルター種別の型
  * @param parser `extracted`をフィルター種別`type`とみなして変換するパーサー
- * @param filterExtractorMap フィルター種別とextractorのマップ
+ * @param extractor フィルター種別とextractorのマップ
  * @param skipCondition チェックを飛ばす条件 ':'が含まれていない など
  * @returns
  */

--- a/src/lib/searchMessage/queryParser.ts
+++ b/src/lib/searchMessage/queryParser.ts
@@ -196,22 +196,20 @@ const filterOrStringToSearchMessageQuery = (
     case 'after':
     case 'before':
       return {
-        ...emptySearchMessageQueryObject,
         [f.type]: f.value.toISOString()
       }
     case 'in': {
       const channelId = f.value === InHereToken ? currentChannelId : f.value
-      return { ...emptySearchMessageQueryObject, in: channelId }
+      return { in: channelId }
     }
     case 'to':
     case 'from':
     case 'citation':
-      return { ...emptySearchMessageQueryObject, [f.type]: f.value }
+      return { [f.type]: f.value }
     case 'attrFlag':
-      return { ...emptySearchMessageQueryObject, [f.value]: !f.negate }
+      return { [f.value]: !f.negate }
     case 'mediaFlag':
       return {
-        ...emptySearchMessageQueryObject,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         [`has${f.value[0]!.toUpperCase() + f.value.slice(1)}`]: !f.negate
       }

--- a/src/store/app/commandPalette.ts
+++ b/src/store/app/commandPalette.ts
@@ -103,9 +103,6 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
 
   const settleQuery = () => {
     query.value = currentInput.value
-    if (currentInput.value !== '') {
-      addSearchHistory(currentInput.value)
-    }
   }
 
   const addSearchHistory = (newHistory: string) => {
@@ -148,6 +145,7 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
     searchState,
     isCommandPaletteShown,
     settleQuery,
+    addSearchHistory,
     removeSearchHistory,
     openCommandPalette,
     closeCommandPalette,

--- a/tests/unit/lib/searchMessage/queryParser.spec.ts
+++ b/tests/unit/lib/searchMessage/queryParser.spec.ts
@@ -12,6 +12,8 @@ const mockUserId = 'user-id'
 const mockUserName = 'user'
 const mockCurrentChannelPath = 'current/channel'
 const mockCurrentChannelId = 'current-channel-id'
+const mockMyUserId = 'my-user-id'
+const mockMyUsername = 'myUsername'
 
 describe('parseQuery', () => {
   const store: StoreForParser = {
@@ -28,9 +30,13 @@ describe('parseQuery', () => {
       if (username === mockUserName) {
         return mockUserId
       }
+      if (username === mockMyUsername) {
+        return mockMyUserId
+      }
       return undefined
     },
-    getCurrentChannelPath: () => mockCurrentChannelPath
+    getCurrentChannelPath: () => mockCurrentChannelPath,
+    getMyUsername: () => mockMyUsername
   }
   const parseQuery = createQueryParser(store)
 
@@ -88,6 +94,13 @@ describe('parseQuery', () => {
     expect(normalizedQuery).toBe(query)
     expect(queryObject.word).toBe('lorem ipsum')
     expect(queryObject.from).toEqual(mockUserId)
+  })
+  it('can parse query with me', async () => {
+    const query = 'lorem ipsum to:me'
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(`lorem ipsum to:${mockMyUsername}`)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.to).toEqual(mockMyUserId)
   })
   it('can parse query with an invalid prefix', async () => {
     const query = 'invalid:'

--- a/tests/unit/lib/searchMessage/queryParser.spec.ts
+++ b/tests/unit/lib/searchMessage/queryParser.spec.ts
@@ -10,6 +10,7 @@ const mockChannelId = 'channel-id'
 const mockChannelName = 'general'
 const mockUserId = 'user-id'
 const mockUserName = 'user'
+const mockCurrentChannelPath = 'current/channel'
 const mockCurrentChannelId = 'current-channel-id'
 
 describe('parseQuery', () => {
@@ -17,6 +18,9 @@ describe('parseQuery', () => {
     channelPathToId: channelPath => {
       if (channelPath === mockChannelName) {
         return mockChannelId
+      }
+      if (channelPath === mockCurrentChannelPath) {
+        return mockCurrentChannelId
       }
       return undefined
     },
@@ -26,129 +30,149 @@ describe('parseQuery', () => {
       }
       return undefined
     },
-    getCurrentChannelId: () => mockCurrentChannelId
+    getCurrentChannelPath: () => mockCurrentChannelPath
   }
   const parseQuery = createQueryParser(store)
 
   it('can parse query without filter', async () => {
     const query = 'lorem       ipsum'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe('lorem ipsum')
+    expect(queryObject.word).toBe('lorem ipsum')
   })
   it('can parse query with date-filter', async () => {
     const query = 'lorem ipsum after:2021-01-23'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.after).toBe('2021-01-23T00:00:00.000Z')
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.after).toBe('2021-01-23T00:00:00.000Z')
   })
   it('can parse query with in-filter (prefix: `in:`)', async () => {
     const query = `lorem ipsum in:${mockChannelName}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.in).toEqual(mockChannelId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.in).toEqual(mockChannelId)
   })
   it('can parse query with in-filter (prefix: `#`)', async () => {
     const query = `lorem ipsum #${mockChannelName}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.in).toEqual(mockChannelId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.in).toEqual(mockChannelId)
   })
   it('can parse query with in-filter (prefix: `in:#`)', async () => {
     const query = `lorem ipsum in:#${mockChannelName}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.in).toEqual(mockChannelId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.in).toEqual(mockChannelId)
   })
   it('can parse query with in:here', async () => {
     const query = 'lorem ipsum in:here'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.in).toEqual(mockCurrentChannelId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(`lorem ipsum in:${mockCurrentChannelPath}`)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.in).toEqual(mockCurrentChannelId)
   })
   it('can parse query with user-filter without @', async () => {
     const query = `lorem ipsum from:${mockUserName}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.from).toEqual(mockUserId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.from).toEqual(mockUserId)
   })
   it('can parse query with user-filter with @', async () => {
     const query = `lorem ipsum from:@${mockUserName}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.from).toEqual(mockUserId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.from).toEqual(mockUserId)
   })
   it('can parse query with an invalid prefix', async () => {
     const query = 'invalid:'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('invalid:')
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('invalid:')
   })
   it('can parse query with empty prefixes (1)', async () => {
     const query = 'after: in: cite: from:'
-    const parsed = await parseQuery(query)
-    expect(parsed.after).toBeUndefined()
-    expect(parsed.in).toBeUndefined()
-    expect(parsed.from).toBeUndefined()
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.after).toBeUndefined()
+    expect(queryObject.in).toBeUndefined()
+    expect(queryObject.from).toBeUndefined()
   })
   it('can parse query with empty prefixes (2)', async () => {
     const query = '# @'
-    const parsed = await parseQuery(query)
-    expect(parsed.in).toBeUndefined()
-    expect(parsed.from).toBeUndefined()
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.in).toBeUndefined()
+    expect(queryObject.from).toBeUndefined()
   })
   it('can parse query with message-filter (url)', async () => {
     const query = `lorem ipsum cite:${mockMessageUrl}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.citation).toEqual(mockMessageId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.citation).toEqual(mockMessageId)
   })
   it('can parse query with message-filter (not a message url)', async () => {
     const query = 'lorem ipsum cite:https://example.com/a'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum cite:https://example.com/a')
-    expect(parsed.citation).toBeUndefined()
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum cite:https://example.com/a')
+    expect(queryObject.citation).toBeUndefined()
   })
   it('can parse query with message-filter (id)', async () => {
     const query = `lorem ipsum cite:${mockMessageId}`
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.citation).toEqual(mockMessageId)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.citation).toEqual(mockMessageId)
   })
   it('can parse query with media-flag-filter', async () => {
     const query = 'lorem has:image ipsum'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.hasImage).toBe(true)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.hasImage).toBe(true)
   })
   it('can parse query with invalid media-flag-filter', async () => {
     const query = 'lorem has:ipsum'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem has:ipsum')
-    expect(parsed.hasImage).toBeUndefined()
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem has:ipsum')
+    expect(queryObject.hasImage).toBeUndefined()
   })
   it('can parse query with invalid attr-flag-filter', async () => {
     const query = 'lorem ipsum is:bott'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum is:bott')
-    expect(parsed.bot).toBeUndefined()
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum is:bott')
+    expect(queryObject.bot).toBeUndefined()
   })
   it('can parse query with negated flag-filter (not-style)', async () => {
     const query = 'lorem ipsum not:bot'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.bot).toBe(false)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.bot).toBe(false)
   })
   it('can parse query with negated flag-filter (negation-style)', async () => {
     const query = 'lorem ipsum -is:bot'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum')
-    expect(parsed.bot).toBe(false)
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum')
+    expect(queryObject.bot).toBe(false)
   })
   it('can parse query with wrong valued-filter', async () => {
     // @phantomさんは存在しないのでこのクエリはwordに入る
     const query = 'lorem ipsum from:@phantom'
-    const parsed = await parseQuery(query)
-    expect(parsed.word).toBe('lorem ipsum from:@phantom')
-    expect(parsed.from).toBeUndefined()
+    const { normalizedQuery, queryObject } = await parseQuery(query)
+    expect(normalizedQuery).toBe(query)
+    expect(queryObject.word).toBe('lorem ipsum from:@phantom')
+    expect(queryObject.from).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
- `in:here`をチャンネル名で検索履歴に保存するように close https://github.com/traPtitech/traQ_S-UI/issues/2817

- 検索での`from:me`と`to:me`の実装

