### PR TITLE
DMのサイドバーでピン留めのページが表示できなかったのを修正

### DIFF
--- a/src/components/Main/MainView/DMView/DMSidebar/DMSidebarContent.vue
+++ b/src/components/Main/MainView/DMView/DMSidebar/DMSidebarContent.vue
@@ -8,7 +8,7 @@
     <channel-sidebar-pinned
       :pinned-message-length="pinnedMessagesCount"
       :class="$style.item"
-      @open="emit('moveToPinned')"
+      @click-link="emit('moveToPinned')"
     />
     <channel-sidebar-events
       :class="$style.item"


### PR DESCRIPTION
ChannelSidebarPinnedに渡すプロパティの名前を間違えていたため、クリックしてもページが変わらなかった