### PR TITLE
メッセージのマークダウンプレビューの表示が崩れるバグを修正

### DIFF
--- a/src/components/Main/MainView/MessageInput/MessageInputPreview.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputPreview.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="$style.preview">
-    <markdown-content :data-is-mobile="isMobile" :content="previewRendered" />
+  <div :class="$style.preview" :data-is-mobile="isMobile">
+    <markdown-content :content="previewRendered" />
     <div
       v-for="quoteMessage in quoteMessages"
       :key="quoteMessage.id"

--- a/src/components/Main/MainView/MessageInput/MessageInputPreview.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputPreview.vue
@@ -1,10 +1,6 @@
 <template>
-  <div>
-    <markdown-content
-      :class="$style.preview"
-      :data-is-mobile="isMobile"
-      :content="previewRendered"
-    />
+  <div :class="$style.preview">
+    <markdown-content :data-is-mobile="isMobile" :content="previewRendered" />
     <div
       v-for="quoteMessage in quoteMessages"
       :key="quoteMessage.id"


### PR DESCRIPTION
https://github.com/traPtitech/traQ_S-UI/issues/3288

classをつける場所が違っていて発生してたっぽいので直しました