### PR TITLE
画像を選択した際に、画像が正方形にトリミングされるように

### DIFF
--- a/src/components/Settings/ImageUpload.vue
+++ b/src/components/Settings/ImageUpload.vue
@@ -48,6 +48,7 @@ const cropperDefaultOptions = {
   viewMode: 3,
   aspectRatio: 1,
   autoCropArea: 1,
+  autoCrop: true,
   dragMode: 'move' as const
 } as const
 const acceptImageType = ['image/jpeg', 'image/png', 'image/gif'].join(',')
@@ -79,6 +80,18 @@ const updateImgView = () => {
     : {
         ...cropperDefaultOptions,
         cropend: () => {
+          cropper?.getCroppedCanvas().toBlob((blob: Blob | null) => {
+            if (!blob) return
+
+            emit(
+              'update:modelValue',
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              new File([blob], originalImg.value!.name, { type: blob.type })
+            )
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          }, originalImg.value!.type)
+        },
+        ready: () => {
           cropper?.getCroppedCanvas().toBlob((blob: Blob | null) => {
             if (!blob) return
 

--- a/src/components/Settings/ImageUpload.vue
+++ b/src/components/Settings/ImageUpload.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watchEffect, shallowRef, onUnmounted, computed } from 'vue'
+import { ref, watchEffect, shallowRef, onUnmounted } from 'vue'
 import Cropper from 'cropperjs'
 import FormButton from '/@/components/UI/FormButton.vue'
 import 'cropperjs/dist/cropper.css'

--- a/src/components/Settings/ImageUpload.vue
+++ b/src/components/Settings/ImageUpload.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watchEffect, shallowRef, onUnmounted } from 'vue'
+import { ref, watchEffect, shallowRef, onUnmounted, computed } from 'vue'
 import Cropper from 'cropperjs'
 import FormButton from '/@/components/UI/FormButton.vue'
 import 'cropperjs/dist/cropper.css'
@@ -64,7 +64,7 @@ let cropper: Cropper | undefined
 const imgEle = shallowRef<HTMLImageElement>()
 const cropperNote = ref('')
 
-watchEffect(() => {
+const updateImgView = () => {
   if (!originalImg.value) {
     if (cropper) cropper.destroy()
     return
@@ -99,7 +99,9 @@ watchEffect(() => {
   if (cropper) cropper.destroy()
   cropper = new Cropper(imgEle.value, options)
   cropper.replace(originalImgUrl.value ?? '')
-})
+}
+
+watchEffect(updateImgView)
 
 watchEffect(() => {
   if (!value.value) {

--- a/src/components/Settings/StampTab/NewStamp.vue
+++ b/src/components/Settings/StampTab/NewStamp.vue
@@ -29,37 +29,12 @@ import { ref, computed } from 'vue'
 import apis, { formatResizeError } from '/@/lib/apis'
 import { isValidStampName } from '/@/lib/validate'
 import { useToastStore } from '/@/store/ui/toast'
+import { imageSize } from './imageSize'
 
 /**
  * 拡張子を削る
  */
 const trimExt = (filename: string) => filename.replace(/\.[^.]+$/, '')
-type imgSize = {
-  width: number
-  height: number
-}
-
-const imageSize = async (file: File): Promise<imgSize> => {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-
-    img.onload = () => {
-      const size = {
-        width: img.naturalWidth,
-        height: img.naturalHeight
-      }
-
-      URL.revokeObjectURL(img.src)
-      resolve(size)
-    }
-
-    img.onerror = error => {
-      reject(error)
-    }
-
-    img.src = URL.createObjectURL(file)
-  })
-}
 
 const useStampCreate = (
   newStampName: Ref<string>,

--- a/src/components/Settings/StampTab/StampItem.vue
+++ b/src/components/Settings/StampTab/StampItem.vue
@@ -19,13 +19,11 @@
           prefix=":"
           suffix=":"
           :max-length="32"
-          :class="$style.form"
         />
         <form-selector
           v-model="state.creatorId"
           label="所有者"
           :options="creatorOptions"
-          :class="$style.form"
         />
         <image-upload v-model="newImageData" />
       </div>
@@ -231,9 +229,7 @@ const { isEditing, editStamp } = useStampEdit(
   display: flex;
   flex-flow: row wrap;
   align-items: flex-end;
-}
-.form {
-  margin-right: 12px;
+  gap: 12px;
 }
 .changeButton {
   word-break: keep-all;

--- a/src/components/Settings/StampTab/StampItem.vue
+++ b/src/components/Settings/StampTab/StampItem.vue
@@ -121,8 +121,8 @@ const useStampEdit = (
       isEditing.value = false
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error('スタンプの作成に失敗しました', e)
-      addErrorToast(formatResizeError(e, 'スタンプの作成に失敗しました'))
+      console.error('スタンプの編集に失敗しました', e)
+      addErrorToast(formatResizeError(e, 'スタンプの編集に失敗しました'))
     }
   }
 

--- a/src/components/Settings/StampTab/imageSize.ts
+++ b/src/components/Settings/StampTab/imageSize.ts
@@ -1,0 +1,21 @@
+type imgSize = {
+  width: number
+  height: number
+}
+export const imageSize = async (file: File): Promise<imgSize> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => {
+      const size = {
+        width: img.naturalWidth,
+        height: img.naturalHeight
+      }
+      URL.revokeObjectURL(img.src)
+      resolve(size)
+    }
+    img.onerror = error => {
+      reject(error)
+    }
+    img.src = URL.createObjectURL(file)
+  })
+}


### PR DESCRIPTION
feedbackに上げられていた正方形でないスタンプが作れてしまう問題を修正。現状、「画像が正方形ではありません。編集してください」というErrorToastが出るようにしているが、もう少し良いメッセージがあるかもしれない