### PR TITLE
メッセージ送信スタイルが「Enterで送信」のときにEnterを押しても送信されないバグの修正

### DIFF
--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -13,7 +13,7 @@
       :data-is-mobile="isMobile"
       :data-is-firefox="firefoxFlag"
       data-testid="message-input-textarea"
-      @before-input="onBeforeInput"
+      @beforeinput="onBeforeInput"
       @keydown="onKeyDown"
       @keyup="onKeyUp"
       @focus="onFocus"

--- a/src/components/Main/MainView/MessageInput/composables/useSendKeyWatcher.ts
+++ b/src/components/Main/MainView/MessageInput/composables/useSendKeyWatcher.ts
@@ -109,7 +109,10 @@ const useSendKeyWatcher = (
    */
   const onBeforeInput = (event: Event) => {
     if (event instanceof InputEvent) {
-      if (!touchDeviceFlag && isSendKeyInput(event, sendWithModifierKey.value)) {
+      if (
+        !touchDeviceFlag &&
+        isSendKeyInput(event, sendWithModifierKey.value)
+      ) {
         event.preventDefault()
         emit('postMessage')
       }

--- a/src/components/Main/MainView/MessageInput/composables/useSendKeyWatcher.ts
+++ b/src/components/Main/MainView/MessageInput/composables/useSendKeyWatcher.ts
@@ -107,10 +107,12 @@ const useSendKeyWatcher = (
    * 既にpreventされているため`beforeinput`イベントは発火しない
    * したがって、これが発火したときは修飾キーが押されていないことが保障されている
    */
-  const onBeforeInput = (event: InputEvent) => {
-    if (!touchDeviceFlag && isSendKeyInput(event, sendWithModifierKey.value)) {
-      event.preventDefault()
-      emit('postMessage')
+  const onBeforeInput = (event: Event) => {
+    if (event instanceof InputEvent) {
+      if (!touchDeviceFlag && isSendKeyInput(event, sendWithModifierKey.value)) {
+        event.preventDefault()
+        emit('postMessage')
+      }
     }
   }
 


### PR DESCRIPTION
bugfix of #3583 
原因: イベント名が `beforeinput` ではなく `before-input` でリスナーが登録されているため、beforeinput イベントを検知できない状態にあった `@before-input="onBeforeInput"` → `@beforeinput="onBeforeInput"` で正しくイベントを拾うようになります

cf. https://developer.mozilla.org/ja/docs/Web/API/HTMLElement/beforeinput_event