### PR TITLE
🎨 コードブロック折り畳むように

### DIFF
--- a/src/assets/icons/down.svg
+++ b/src/assets/icons/down.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_8701_28864)">
+    <path d="M7.41 8.58984L12 13.1698L16.59 8.58984L18 9.99984L12 15.9998L6 9.99984L7.41 8.58984Z" fill="#333333" />
+  </g>
+  <defs>
+    <clipPath id="clip0_8701_28864">
+      <rect width="24" height="24" fill="white" />
+    </clipPath>
+  </defs>
+</svg>

--- a/src/assets/icons/up.svg
+++ b/src/assets/icons/up.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_8870_28914)">
+    <path d="M16.59 15.4102L12 10.8302L7.41 15.4102L6 14.0002L12 8.00016L18 14.0002L16.59 15.4102Z" fill="#333333" />
+  </g>
+  <defs>
+    <clipPath id="clip0_8870_28914">
+      <rect width="24" height="24" fill="white" transform="translate(24 24) rotate(180)" />
+    </clipPath>
+  </defs>
+</svg>

--- a/src/assets/mdi.ts
+++ b/src/assets/mdi.ts
@@ -78,7 +78,7 @@ import {
   mdiStop,
   mdiCrown,
   mdiFormatTitle,
-  mdiCloseCircle
+  mdiCloseCircle,
 } from '@mdi/js'
 
 interface MdiIconsMapping {
@@ -165,7 +165,7 @@ const mdi: MdiIconsMapping = {
   'music-note': mdiMusicNote,
   stop: mdiStop,
   crown: mdiCrown,
-  'format-title': mdiFormatTitle
+  'format-title': mdiFormatTitle,
 }
 
 export default mdi

--- a/src/assets/mdi.ts
+++ b/src/assets/mdi.ts
@@ -78,7 +78,7 @@ import {
   mdiStop,
   mdiCrown,
   mdiFormatTitle,
-  mdiCloseCircle,
+  mdiCloseCircle
 } from '@mdi/js'
 
 interface MdiIconsMapping {
@@ -165,7 +165,7 @@ const mdi: MdiIconsMapping = {
   'music-note': mdiMusicNote,
   stop: mdiStop,
   crown: mdiCrown,
-  'format-title': mdiFormatTitle,
+  'format-title': mdiFormatTitle
 }
 
 export default mdi

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -1,8 +1,5 @@
 <template>
-  <button
-    :class="$style.button"
-    :data-background="background"
-  >
+  <button :class="$style.button" :data-background="background">
     <a-icon
       v-if="showIcon"
       :name="isFold ? 'down' : 'up'"
@@ -55,7 +52,7 @@ withDefaults(defineProps<Props>(), {
     background-color: $theme-ui-tertiary-default;
   }
 
-  & .icon {
+  .icon {
     margin-left: -12px;
   }
 }

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -1,5 +1,8 @@
 <template>
-  <button :class="$style.button" :data-background="background">
+  <button
+    :class="$style.button"
+    :data-background="background"
+  >
     <a-icon
       v-if="showIcon"
       :name="isFold ? 'down' : 'up'"

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -20,7 +20,7 @@ interface Props extends ButtonHTMLAttributes {
 }
 
 withDefaults(defineProps<Props>(), {
-  showIcon: true,
+  showIcon: false,
   background: 'tertiary'
 })
 </script>

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -1,8 +1,5 @@
 <template>
-  <button
-    :class="$style.button"
-    :data-background="background"
-  >
+  <button :class="$style.button" :data-background="background">
     <a-icon
       v-if="showIcon"
       :name="isFold ? 'down' : 'up'"

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -1,0 +1,62 @@
+<template>
+  <button
+    :class="$style.button"
+    :data-background="background"
+  >
+    <a-icon
+      v-if="showIcon"
+      :name="isFold ? 'down' : 'up'"
+      :class="$style['icon']"
+    />
+    {{ isFold ? 'さらに表示' : '折りたたむ' }}
+  </button>
+</template>
+
+<script setup lang="ts">
+import type { ButtonHTMLAttributes } from 'vue'
+import AIcon from '/@/components/UI/AIcon.vue'
+
+interface Props extends ButtonHTMLAttributes {
+  showIcon?: boolean
+  background?: 'primary' | 'secondary' | 'tertiary'
+  isFold: boolean
+}
+
+withDefaults(defineProps<Props>(), {
+  showIcon: true,
+  background: 'tertiary'
+})
+</script>
+
+<style lang="scss" module>
+.button {
+  cursor: pointer;
+
+  display: flex;
+  gap: 4px;
+  align-items: center;
+
+  font-weight: bold;
+  border-radius: 4px;
+  padding: 0 24px;
+  min-height: 24px;
+  font-size: 12px;
+  line-height: 1.5;
+  width: fit-content;
+
+  color: $theme-text-primary-default;
+  &[data-background='primary'] {
+    background-color: $theme-ui-primary-default;
+  }
+  &[data-background='secondary'] {
+    background-color: $theme-ui-secondary-default;
+  }
+  &[data-background='tertiary'] {
+    background-color: $theme-ui-tertiary-default;
+  }
+
+  & .icon {
+    margin-left: -12px;
+  }
+}
+</style>

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -55,10 +55,10 @@ const toggle = (e: MouseEvent) => {
 
     pre {
       max-height: calc(6em + 32px);
-      -webkit-mask-image: linear-gradient(black 0% 40%, transparent 100%);
-      mask-image: linear-gradient(black 0% 40%, transparent 100%);
+      -webkit-mask-image: linear-gradient(black 0% 60%, transparent 100%);
+      mask-image: linear-gradient(black 0% 60%, transparent 100%);
     }
-    box-shadow: 0 0 0 2px var(--markdown-code-background) inset;
+    background: var(--markdown-code-background);
   }
 
   .button {

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -19,7 +19,7 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
 
-const MAX_LINES = 6
+const MAX_LINES = 5
 
 const props = defineProps<{
   wrapClass?: string
@@ -28,11 +28,15 @@ const props = defineProps<{
 
 const isFold = ref(true)
 
-const isLong = computed(() => {
+const line_count = computed(() => {
   const content = props.preContent.textContent
-  if (content === null) return false
+  if (content === null) return 0
   const lines = content.split('\n')
-  return lines.length > MAX_LINES
+  return lines.length - (lines.at(-1) === '' ? 1 : 0) // 末尾の改行は行数に含めない
+})
+
+const isLong = computed(() => {
+  return line_count.value > MAX_LINES
 })
 
 const unfold = (e: MouseEvent) => {

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -7,10 +7,10 @@
   >
     <div :class="wrapClass" v-html="preContent.outerHTML" />
     <button :class="[$style.button, $style['fold-button']]" @click="fold">
-      折りたたむ ↑
+      <a-icon name="up" /> 折りたたむ
     </button>
     <button :class="[$style.button, $style['unfold-button']]" @click="unfold">
-      さらに表示 ↓
+      <a-icon name="down" />さらに表示
     </button>
   </div>
   <div v-else :class="wrapClass" v-html="preContent.outerHTML" />
@@ -18,6 +18,7 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
+import AIcon from '/@/components/UI/AIcon.vue'
 
 const MAX_LINES = 5
 
@@ -67,7 +68,9 @@ const fold = (e: MouseEvent) => {
   }
 
   .button {
-    display: block;
+    display: flex;
+    gap: 4px;
+    align-items: center;
     cursor: pointer;
     position: absolute;
     bottom: 24px;
@@ -78,10 +81,17 @@ const fold = (e: MouseEvent) => {
     color: $theme-text-primary-default;
     font-weight: bold;
     border-radius: 4px;
-    padding: 4px 24px;
+    padding: 0 24px;
+    min-height: 24px;
+    font-size: 12px;
+    line-height: 1.5;
     width: fit-content;
 
     transition: all 0.15s ease-out;
+
+    & > svg {
+      margin-left: -12px;
+    }
   }
 
   @media (any-hover: hover) {

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -10,7 +10,7 @@
       折りたたむ ↑
     </button>
     <button :class="[$style.button, $style['unfold-button']]" @click="unfold">
-      クリックして展開 ↓
+      クリックして展開 ({{ line_count }} 行) ↓
     </button>
   </div>
   <div v-else :class="wrapClass" v-html="preContent.outerHTML" />

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -1,0 +1,107 @@
+<template>
+  <div
+    v-if="isLong"
+    :class="[$style.wrap]"
+    :data-is-fold="isFold"
+    @click="unfold"
+  >
+    <div :class="wrapClass" v-html="preContent.outerHTML" />
+    <button :class="[$style.button, $style['fold-button']]" @click="fold">
+      折りたたむ ↑
+    </button>
+    <button :class="[$style.button, $style['unfold-button']]" @click="unfold">
+      クリックして展開 ↓
+    </button>
+  </div>
+  <div v-else :class="wrapClass" v-html="preContent.outerHTML" />
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+const MAX_LINES = 6
+
+const props = defineProps<{
+  wrapClass?: string
+  preContent: HTMLPreElement
+}>()
+
+const isFold = ref(true)
+
+const isLong = computed(() => {
+  const content = props.preContent.textContent
+  if (content === null) return false
+  const lines = content.split('\n')
+  return lines.length > MAX_LINES
+})
+
+const unfold = (e: MouseEvent) => {
+  if (!isFold.value) return
+  isFold.value = false
+  e.stopPropagation()
+}
+const fold = (e: MouseEvent) => {
+  if (isFold.value) return
+  isFold.value = true
+  e.stopPropagation()
+}
+</script>
+
+<style lang="scss" module>
+.wrap {
+  position: relative;
+  overflow: hidden;
+  &[data-is-fold='true'] {
+    cursor: pointer;
+
+    pre {
+      max-height: calc(6em + 32px);
+      -webkit-mask-image: linear-gradient(black 0% 40%, transparent 100%);
+      mask-image: linear-gradient(black 0% 40%, transparent 100%);
+    }
+    box-shadow: 0 0 0 2px var(--markdown-code-background) inset;
+  }
+
+  .button {
+    display: block;
+    cursor: pointer;
+    position: absolute;
+    bottom: 24px;
+    margin: auto;
+    left: 0;
+    right: 0;
+    background-color: $theme-ui-secondary-default;
+    color: $theme-background-primary-default;
+    border-radius: 9999999px;
+    padding: 4px 12px;
+    width: fit-content;
+
+    transition: all 0.15s ease-out;
+  }
+
+  @media (hover: hover) {
+    .button {
+      transform: translateY(calc(100% + 24px));
+      opacity: 0;
+    }
+
+    &:hover {
+      .button {
+        transform: translateY(0);
+        opacity: 1;
+      }
+    }
+  }
+
+  &[data-is-fold='true'] {
+    .fold-button {
+      display: none;
+    }
+  }
+  &[data-is-fold='false'] {
+    .unfold-button {
+      display: none;
+    }
+  }
+}
+</style>

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -79,7 +79,7 @@ const fold = (e: MouseEvent) => {
     transition: all 0.15s ease-out;
   }
 
-  @media (hover: hover) {
+  @media (any-hover: hover) {
     .button {
       transform: translateY(-8px);
       opacity: 0;

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -5,20 +5,28 @@
     :data-is-fold="isFold"
     @click="unfold"
   >
-    <div :class="wrapClass" v-html="preContent.outerHTML" />
+    <div ref="preWrapRef" :class="wrapClass" v-html="preContent.outerHTML" />
     <fold-button
       show-icon
       :is-fold="isFold"
       :class="$style.button"
+      :aria-controls="foldBlockId"
+      :aria-expanded="!isFold"
       @click="toggle"
     />
   </div>
-  <div v-else :class="wrapClass" v-html="preContent.outerHTML" />
+  <div
+    v-else
+    ref="preWrapRef"
+    :class="wrapClass"
+    v-html="preContent.outerHTML"
+  />
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import FoldButton from '/@/components/UI/FoldButton.vue'
+import { randomString } from '/@/lib/basic/randomString'
 
 const MAX_LINES = 5
 
@@ -39,6 +47,18 @@ const line_count = computed(() => {
 const isLong = computed(() => {
   return line_count.value > MAX_LINES
 })
+
+const preWrapRef = ref<HTMLDivElement>()
+
+const foldBlockId = randomString()
+const applyId = () => {
+  if (!isLong.value) return
+  if (preWrapRef.value === undefined) return
+  const pre = preWrapRef.value.querySelector('pre')
+  if (pre === null) return
+  pre.id = foldBlockId
+}
+onMounted(applyId)
 
 const unfold = (e: MouseEvent) => {
   if (!isFold.value) return

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -6,7 +6,12 @@
     @click="unfold"
   >
     <div :class="wrapClass" v-html="preContent.outerHTML" />
-    <fold-button :is-fold="isFold" :class="$style.button" @click="toggle" />
+    <fold-button
+      show-icon
+      :is-fold="isFold"
+      :class="$style.button"
+      @click="toggle"
+    />
   </div>
   <div v-else :class="wrapClass" v-html="preContent.outerHTML" />
 </template>

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -6,19 +6,14 @@
     @click="unfold"
   >
     <div :class="wrapClass" v-html="preContent.outerHTML" />
-    <button :class="[$style.button, $style['fold-button']]" @click="fold">
-      <a-icon name="up" /> 折りたたむ
-    </button>
-    <button :class="[$style.button, $style['unfold-button']]" @click="unfold">
-      <a-icon name="down" />さらに表示
-    </button>
+    <fold-button :is-fold="isFold" :class="$style.button" @click="toggle" />
   </div>
   <div v-else :class="wrapClass" v-html="preContent.outerHTML" />
 </template>
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import AIcon from '/@/components/UI/AIcon.vue'
+import FoldButton from '/@/components/UI/FoldButton.vue'
 
 const MAX_LINES = 5
 
@@ -45,9 +40,8 @@ const unfold = (e: MouseEvent) => {
   isFold.value = false
   e.stopPropagation()
 }
-const fold = (e: MouseEvent) => {
-  if (isFold.value) return
-  isFold.value = true
+const toggle = (e: MouseEvent) => {
+  isFold.value = !isFold.value
   e.stopPropagation()
 }
 </script>
@@ -68,30 +62,13 @@ const fold = (e: MouseEvent) => {
   }
 
   .button {
-    display: flex;
-    gap: 4px;
-    align-items: center;
-    cursor: pointer;
     position: absolute;
     bottom: 24px;
     margin: auto;
     left: 0;
     right: 0;
-    background-color: $theme-ui-tertiary-default;
-    color: $theme-text-primary-default;
-    font-weight: bold;
-    border-radius: 4px;
-    padding: 0 24px;
-    min-height: 24px;
-    font-size: 12px;
-    line-height: 1.5;
-    width: fit-content;
 
     transition: all 0.15s ease-out;
-
-    & > svg {
-      margin-left: -12px;
-    }
   }
 
   @media (any-hover: hover) {
@@ -105,17 +82,6 @@ const fold = (e: MouseEvent) => {
         transform: translateY(0);
         opacity: 1;
       }
-    }
-  }
-
-  &[data-is-fold='true'] {
-    .fold-button {
-      display: none;
-    }
-  }
-  &[data-is-fold='false'] {
-    .unfold-button {
-      display: none;
     }
   }
 }

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -50,6 +50,11 @@ const toggle = (e: MouseEvent) => {
 .wrap {
   position: relative;
   overflow: hidden;
+  pre {
+    margin-bottom: 0;
+  }
+  margin-bottom: 16px;
+
   &[data-is-fold='true'] {
     cursor: pointer;
 

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -63,7 +63,7 @@ const toggle = (e: MouseEvent) => {
 
   .button {
     position: absolute;
-    bottom: 24px;
+    bottom: 8px;
     margin: auto;
     left: 0;
     right: 0;

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -10,7 +10,7 @@
       折りたたむ ↑
     </button>
     <button :class="[$style.button, $style['unfold-button']]" @click="unfold">
-      クリックして展開 ({{ line_count }} 行) ↓
+      さらに表示 ↓
     </button>
   </div>
   <div v-else :class="wrapClass" v-html="preContent.outerHTML" />
@@ -74,10 +74,11 @@ const fold = (e: MouseEvent) => {
     margin: auto;
     left: 0;
     right: 0;
-    background-color: $theme-ui-secondary-default;
-    color: $theme-background-primary-default;
-    border-radius: 9999999px;
-    padding: 4px 12px;
+    background-color: $theme-ui-tertiary-default;
+    color: $theme-text-primary-default;
+    font-weight: bold;
+    border-radius: 4px;
+    padding: 4px 24px;
     width: fit-content;
 
     transition: all 0.15s ease-out;

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -81,7 +81,7 @@ const fold = (e: MouseEvent) => {
 
   @media (hover: hover) {
     .button {
-      transform: translateY(calc(100% + 24px));
+      transform: translateY(-8px);
       opacity: 0;
     }
 

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -8,10 +8,10 @@
 </template>
 
 <script lang="ts" setup>
-import { createVNode, onMounted, onUpdated, ref, render } from 'vue'
+import { createVNode, onMounted, onUpdated, ref, render, watch } from 'vue'
 import FoldableCodeBlock from './FoldableCodeBlock.vue'
 
-defineProps<{
+const props = defineProps<{
   content: string
 }>()
 
@@ -39,11 +39,22 @@ const applyFoldCodeBlock = () => {
   })
 }
 
+const isUpdated = ref(false)
+
 onMounted(() => {
   applyFoldCodeBlock()
 })
+watch(
+  () => props.content,
+  () => {
+    isUpdated.value = true
+  }
+)
 onUpdated(() => {
-  applyFoldCodeBlock()
+  if (isUpdated.value) {
+    applyFoldCodeBlock()
+    isUpdated.value = false
+  }
 })
 </script>
 

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts" setup>
-import { createVNode, onMounted, onUpdated, ref, render, watch } from 'vue'
+import { createVNode, onMounted, ref, render, watch } from 'vue'
 import FoldableCodeBlock from './FoldableCodeBlock.vue'
 
 const props = defineProps<{
@@ -39,23 +39,18 @@ const applyFoldCodeBlock = () => {
   })
 }
 
-const isUpdated = ref(false)
-
 onMounted(() => {
   applyFoldCodeBlock()
 })
 watch(
   () => props.content,
   () => {
-    isUpdated.value = true
+    applyFoldCodeBlock()
+  },
+  {
+    flush: 'post'
   }
 )
-onUpdated(() => {
-  if (isUpdated.value) {
-    applyFoldCodeBlock()
-    isUpdated.value = false
-  }
-})
 </script>
 
 <style lang="scss" module>

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -1,11 +1,134 @@
 <template>
-  <span class="markdown-body" :class="$style.content" v-html="content" />
+  <span
+    ref="contentRef"
+    class="markdown-body"
+    :class="$style.content"
+    v-html="content"
+  />
 </template>
 
 <script lang="ts" setup>
+import { onMounted, onUpdated, ref } from 'vue'
+
 defineProps<{
   content: string
 }>()
+
+const contentRef = ref<HTMLElement>()
+
+class FoldController {
+  private static readonly maxLines = 6
+
+  private controlledDoms: Array<{
+    target: HTMLElement
+    targetHandler: (e: Event) => void
+    button: HTMLElement
+    buttonHandler: (e: Event) => void
+  }> = []
+
+  /*
+    convert from
+
+    <pre> hoge </pre>
+
+    to
+
+    <div class="fold-wrap" data-is-fold="true">
+      <pre> hoge </pre>
+      <button class="fold-button">折りたたむ ↑</button>
+      <button class="unfold-button">クリックして展開 ↓</button>
+    </div>
+  */
+
+  private unfoldHandler(target: HTMLElement): (e: Event) => void {
+    return e => {
+      if (target.dataset['isFold'] !== 'true') return
+
+      target.dataset['isFold'] = 'false'
+      e.stopPropagation()
+    }
+  }
+
+  private foldHandler(target: HTMLElement): (e: Event) => void {
+    return e => {
+      if (target.dataset['isFold'] !== 'false') return
+
+      target.dataset['isFold'] = 'true'
+      e.stopPropagation()
+    }
+  }
+
+  private release() {
+    this.controlledDoms.forEach(
+      ({ target, targetHandler, button, buttonHandler }) => {
+        target.removeEventListener('click', targetHandler)
+        button.removeEventListener('click', buttonHandler)
+      }
+    )
+    this.controlledDoms = []
+  }
+
+  public update(target: HTMLElement | undefined) {
+    this.release()
+
+    const pre_list = target?.querySelectorAll('pre')
+
+    if (pre_list === undefined || pre_list.length === 0) return
+
+    pre_list.forEach(pre => {
+      {
+        const code = pre.querySelector('code')
+        if (code === null) return
+        const codeText = code.textContent
+        if (codeText === null) return
+
+        const lines = codeText.split('\n').length
+
+        if (lines <= FoldController.maxLines) return
+      }
+
+      const wrap = document.createElement('div')
+      wrap.classList.add('fold-wrap')
+      wrap.dataset['isFold'] = 'true'
+      pre.parentNode?.insertBefore(wrap, pre)
+      wrap.appendChild(pre)
+
+      const wrapHandler = this.unfoldHandler(wrap)
+      wrap.addEventListener('click', wrapHandler)
+
+      const foldButton = document.createElement('button')
+      foldButton.classList.add('fold-button')
+      foldButton.textContent = '折りたたむ ↑'
+
+      const foldButtonHandler = this.foldHandler(wrap)
+      foldButton.addEventListener('click', foldButtonHandler)
+
+      wrap.appendChild(foldButton)
+
+      // 見た目だけのダミー
+      const unfoldButton = document.createElement('button')
+      unfoldButton.classList.add('unfold-button')
+      unfoldButton.textContent = 'クリックして展開 ↓'
+      wrap.appendChild(unfoldButton)
+
+      this.controlledDoms.push({
+        target: wrap,
+        targetHandler: wrapHandler,
+        button: foldButton,
+        buttonHandler: foldButtonHandler
+      })
+    })
+  }
+}
+
+const foldController = new FoldController()
+
+onMounted(() => {
+  foldController.update(contentRef.value)
+})
+onUpdated(() => {
+  foldController.update(contentRef.value)
+})
 </script>
 
 <style lang="scss" module>
@@ -14,5 +137,65 @@ defineProps<{
   overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   line-break: loose;
+}
+</style>
+
+<style lang="scss">
+.markdown-body {
+  div.fold-wrap {
+    position: relative;
+    overflow: hidden;
+    &[data-is-fold='true'] {
+      cursor: pointer;
+      pre {
+        max-height: calc(6em + 32px);
+        -webkit-mask-image: linear-gradient(black 0% 40%, transparent 100%);
+        mask-image: linear-gradient(black 0% 40%, transparent 100%);
+      }
+      box-shadow: 0 0 0 2px var(--markdown-code-background) inset;
+    }
+
+    button {
+      display: block;
+      cursor: pointer;
+      position: absolute;
+      bottom: 24px;
+      margin: auto;
+      left: 0;
+      right: 0;
+      background-color: $theme-ui-secondary-default;
+      color: $theme-background-primary-default;
+      border-radius: 9999999px;
+      padding: 4px 12px;
+      width: fit-content;
+
+      transition: all 0.15s ease-out;
+    }
+
+    @media (hover: hover) {
+      button {
+        transform: translateY(calc(100% + 24px));
+        opacity: 0;
+      }
+
+      &:hover {
+        button {
+          transform: translateY(0);
+          opacity: 1;
+        }
+      }
+    }
+
+    &[data-is-fold='true'] {
+      button.fold-button {
+        display: none;
+      }
+    }
+    &[data-is-fold='false'] {
+      button.unfold-button {
+        display: none;
+      }
+    }
+  }
 }
 </style>

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -19,13 +19,6 @@ const contentRef = ref<HTMLElement>()
 class FoldController {
   private static readonly maxLines = 6
 
-  private controlledDoms: Array<{
-    target: HTMLElement
-    targetHandler: (e: Event) => void
-    button: HTMLElement
-    buttonHandler: (e: Event) => void
-  }> = []
-
   /*
     convert from
 
@@ -58,20 +51,8 @@ class FoldController {
     }
   }
 
-  private release() {
-    this.controlledDoms.forEach(
-      ({ target, targetHandler, button, buttonHandler }) => {
-        target.removeEventListener('click', targetHandler)
-        button.removeEventListener('click', buttonHandler)
-      }
-    )
-    this.controlledDoms = []
-  }
-
   public update(target: HTMLElement | undefined) {
-    this.release()
-
-    const pre_list = target?.querySelectorAll('pre')
+    const pre_list = target?.querySelectorAll(':not(div.fold-wrap) > pre')
 
     if (pre_list === undefined || pre_list.length === 0) return
 
@@ -110,13 +91,6 @@ class FoldController {
       unfoldButton.classList.add('unfold-button')
       unfoldButton.textContent = 'クリックして展開 ↓'
       wrap.appendChild(unfoldButton)
-
-      this.controlledDoms.push({
-        target: wrap,
-        targetHandler: wrapHandler,
-        button: foldButton,
-        buttonHandler: foldButtonHandler
-      })
     })
   }
 }


### PR DESCRIPTION
ref: #801 

一定より長いコードブロックを折りたたむようにしました (画像参照)
閉じているときはコードのどこをクリックしても開き、そうでないときは折りたたむを押して折りたたむように
スマホでは常にボタンが表示されます

:new: FoldButton 部分を新しくコンポーネントに分けました ([Figma](https://www.figma.com/file/6Wme6N24y3GN2jD0vqZWZr/traQ-S-UI?node-id=5379%3A7962&t=WQKC8VcQp3VblRxV-1))
:up: デザイン修正しました
:up: aria 属性軽くつけました

![image](https://user-images.githubusercontent.com/62363188/226586017-f5668f53-561f-4314-905f-02e65357db7b.png)
![image](https://user-images.githubusercontent.com/62363188/226586317-ad689d81-8dea-4ed0-9355-1b16fbea36da.png)
![image](https://user-images.githubusercontent.com/62363188/226586242-dfad11e3-d67f-45b6-b2b6-98a668e625a5.png)
