### PR TITLE
メッセージ検索後にクエリの入力欄をnormalizeしたクエリに書き換える

### DIFF
--- a/src/components/Main/CommandPalette/composables/useSearchMessages.ts
+++ b/src/components/Main/CommandPalette/composables/useSearchMessages.ts
@@ -3,7 +3,7 @@ import { ref, computed } from 'vue'
 import type { Message } from '@traptitech/traq'
 import apis from '/@/lib/apis'
 import { compareDateString } from '/@/lib/basic/date'
-import useQueryParer from '/@/composables/searchMessage/useQueryParser'
+import useQueryParser from '/@/composables/searchMessage/useQueryParser'
 import type { SearchMessageSortKey } from '/@/lib/searchMessage/queryParser'
 import { useCommandPalette } from '/@/store/app/commandPalette'
 import { useMessagesStore } from '/@/store/entities/messages'
@@ -68,7 +68,7 @@ const usePaging = (
 
 const useSearchMessages = () => {
   const limit = 20
-  const { parseQuery, toSearchMessageParam } = useQueryParer()
+  const { parseQuery, toSearchMessageParam } = useQueryParser()
   const { query, searchState, setSearchResult, resetPaging, addSearchHistory } =
     useCommandPalette()
   const { extendMessagesMap } = useMessagesStore()

--- a/src/composables/searchMessage/useQueryParser.ts
+++ b/src/composables/searchMessage/useQueryParser.ts
@@ -53,7 +53,7 @@ const getStoreForParser = ({
   getMyUsername: () => myUsername.value
 })
 
-const useQueryParer = () => {
+const useQueryParser = () => {
   const { channelsMap } = useChannelsStore()
   const { channelTree } = useChannelTree()
   const { primaryView } = useMainViewStore()
@@ -72,4 +72,4 @@ const useQueryParer = () => {
   return { parseQuery, toSearchMessageParam }
 }
 
-export default useQueryParer
+export default useQueryParser

--- a/src/store/app/commandPalette.ts
+++ b/src/store/app/commandPalette.ts
@@ -7,7 +7,7 @@ import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import useIndexedDbValue from '/@/composables/utils/useIndexedDbValue'
 import { isObjectAndHasKey } from '/@/lib/basic/object'
 import { promisifyRequest } from 'idb-keyval'
-import useQueryParer from '/@/composables/searchMessage/useQueryParser'
+import useQueryParser from '/@/composables/searchMessage/useQueryParser'
 
 type CommandPaletteMode = 'command' | 'search'
 
@@ -93,7 +93,7 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
   ) => {
     mode.value = newMode
     if (initialInput !== '' && query.value !== '') {
-      const { parseQuery } = useQueryParer()
+      const { parseQuery } = useQueryParser()
       const { normalizedQuery } = await parseQuery(query.value)
       currentInput.value = normalizedQuery
     } else if (initialInput !== '') {

--- a/src/store/app/commandPalette.ts
+++ b/src/store/app/commandPalette.ts
@@ -7,6 +7,7 @@ import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import useIndexedDbValue from '/@/composables/utils/useIndexedDbValue'
 import { isObjectAndHasKey } from '/@/lib/basic/object'
 import { promisifyRequest } from 'idb-keyval'
+import useQueryParer from '/@/composables/searchMessage/useQueryParser'
 
 type CommandPaletteMode = 'command' | 'search'
 
@@ -86,18 +87,21 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
     initialValue
   )
 
-  const openCommandPalette = (
+  const openCommandPalette = async (
     newMode: CommandPaletteMode,
     initialInput = ''
   ) => {
     mode.value = newMode
-    if (initialInput !== '') {
+    if (initialInput !== '' && query.value !== '') {
+      const { parseQuery } = useQueryParer()
+      const { normalizedQuery } = await parseQuery(query.value)
+      currentInput.value = normalizedQuery
+    } else if (initialInput !== '') {
       currentInput.value = initialInput
     }
   }
   const closeCommandPalette = () => {
     mode.value = undefined
-    currentInput.value = ''
   }
 
   const isCommandPaletteShown = computed(() => mode.value !== undefined)

--- a/src/store/app/commandPalette.ts
+++ b/src/store/app/commandPalette.ts
@@ -87,16 +87,12 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
     initialValue
   )
 
-  const openCommandPalette = async (
+  const openCommandPalette = (
     newMode: CommandPaletteMode,
     initialInput = ''
   ) => {
     mode.value = newMode
-    if (initialInput !== '' && query.value !== '') {
-      const { parseQuery } = useQueryParser()
-      const { normalizedQuery } = await parseQuery(query.value)
-      currentInput.value = normalizedQuery
-    } else if (initialInput !== '') {
+    if (initialInput !== '') {
       currentInput.value = initialInput
     }
   }
@@ -106,8 +102,11 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
 
   const isCommandPaletteShown = computed(() => mode.value !== undefined)
 
-  const settleQuery = () => {
-    query.value = currentInput.value
+  const settleQuery = async () => {
+    const { parseQuery } = useQueryParser()
+    const { normalizedQuery } = await parseQuery(currentInput.value)
+    currentInput.value = normalizedQuery
+    query.value = normalizedQuery
   }
 
   const addSearchHistory = (newHistory: string) => {

--- a/src/store/app/commandPalette.ts
+++ b/src/store/app/commandPalette.ts
@@ -44,6 +44,8 @@ type IndexedDBState = {
 }
 
 const useCommandPalettePinia = defineStore('app/commandPalette', () => {
+  const { parseQuery } = useQueryParser()
+
   /** 表示モード */
   const mode = ref<CommandPaletteMode>()
 
@@ -103,7 +105,6 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
   const isCommandPaletteShown = computed(() => mode.value !== undefined)
 
   const settleQuery = async () => {
-    const { parseQuery } = useQueryParser()
     const { normalizedQuery } = await parseQuery(currentInput.value)
     currentInput.value = normalizedQuery
     query.value = normalizedQuery

--- a/src/store/app/commandPalette.ts
+++ b/src/store/app/commandPalette.ts
@@ -97,6 +97,7 @@ const useCommandPalettePinia = defineStore('app/commandPalette', () => {
   }
   const closeCommandPalette = () => {
     mode.value = undefined
+    currentInput.value = ''
   }
 
   const isCommandPaletteShown = computed(() => mode.value !== undefined)


### PR DESCRIPTION
close https://github.com/traPtitech/traQ_S-UI/issues/3289

これだけでいいんですかね
開発環境で検索が効かないのであれなのですが、検索結果のメッセージをクリックして遷移するときもcloseCommandPaletteを実行しているので問題ないはずです