### PR TITLE
3.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traq_s-ui",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "traq_s-ui",
-      "version": "3.16.1",
+      "version": "3.17.0",
       "hasInstallScript": true,
       "dependencies": {
         "@mdi/js": "^7.2.96",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traq_s-ui",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
3.17.0へのアップデート
# 機能追加
- チャンネルトピックの最大文字数が500に増加 #3839 
- 最新のメッセージに飛ぶボタンを実装 #3749 
- グループ一覧でグループがアルファベット順にソートして表示されるように調整 #3742
- タブが最前面に無いときに閲覧状態をnoneにするように調整 #3740
- 未読があるチャンネルを開いた時に未読メッセージから表示する挙動に変更 #3734
- チャンネル移動時にサイドバーが閉じる挙動に変更
- メッセージ検索後にto:meなどのクエリをto:exampleUserIdなどに変更したクエリに書き換えるようになった #3727
- 長いコードブロックが折り畳まれるような機能を追加 #3725 
- お気に入りフィルターが有効状態でも検索にはフィルターがかからないように変更 #3614
- 入力中判定をより厳密なものに変更 #3615

# 修正
- メッセージ送信スタイルが「Enterで送信」のときにEnterを押しても送信されない問題の修正 #3723 
- スタンプ登録/編集時に画像を選択した際に、画像が正方形にトリミングされないことがあった問題の修正 #3720 
- スタンプピッカーで正方形でないスタンプが領域から飛び出す問題を修正 #3719
- 検索モーダルでユーザーのアイコンをクリックした時にページ遷移してしまう問題を修正 #3669 
- スマホでサイドバーが開けなくなることのある問題を修正 #3677 
- 他人に通知を変更されるとリアクティブに状態が変更されないバグの修正 #3545
- 