### PR TITLE
iOSのPWAで表示が壊れる問題の修正

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListVideo.vue
@@ -49,6 +49,7 @@ const { fileMeta, fileRawPath, canShow } = useFileMeta(props)
     display: block;
     max-width: 100%;
     max-height: 450px;
+    min-width: min(300px, 100%);
   }
 }
 .overlay {

--- a/src/components/Modal/FileModal/FileModal.vue
+++ b/src/components/Modal/FileModal/FileModal.vue
@@ -1,6 +1,6 @@
 <template>
   <click-outside stop @click-outside="clearModal">
-    <div v-if="fileMeta">
+    <div v-if="fileMeta" :class="$style.fileContainer">
       <file-modal-image v-if="fileType === 'image'" :file-id="fileMeta.id" />
       <file-modal-video
         v-else-if="fileType === 'video'"
@@ -35,3 +35,9 @@ const fileIdState = reactive({
 const { fileMeta, fileType } = useFileMeta(fileIdState)
 const { clearModal } = useModalStore()
 </script>
+
+<style module lang="scss">
+.fileContainer {
+  height: 100%;
+}
+</style>

--- a/src/components/Modal/FileModal/FileModalImage.vue
+++ b/src/components/Modal/FileModal/FileModalImage.vue
@@ -32,7 +32,7 @@ const { fileMeta, fileRawPath } = useFileMeta(props)
   @include background-common-black;
   position: relative;
   width: 100vw;
-  height: 100vh;
+  height: 100%;
   max-height: 100%;
   max-width: 60rem;
 }

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -38,7 +38,6 @@ dd {
 }
 
 body {
-  min-height: 100vh;
   scroll-behavior: smooth;
   text-rendering: optimizeSpeed;
   line-height: 1.5;


### PR DESCRIPTION
- スクロールバーが2重に出る問題
- videoが点で表示されて再生できない問題
- ファイルモーダルの上下が見切れる問題
- メッセージ入力欄が下に来すぎている問題
 
を修正。
スマホから手元のサーバーへのアクセスができなかったため、開発者ツールで直接プロパティを変化させて動作を確認。
マージされた後、開発環境のサーバーにアクセスして挙動を確認する必要がありそう。
少なくとも明らかに影響出そうな部分はWindowsのChromeとfirefoxで大きな変化が無いことは確認しました。