### PR TITLE
Follow symbolic links on copy

### DIFF
--- a/build/docker/startup.sh
+++ b/build/docker/startup.sh
@@ -5,7 +5,7 @@
 ###
 echo "Startup: copy default files"
 
-cp -r /app/default/* /usr/share/caddy
+cp -r -L /app/default/* /usr/share/caddy
 
 ###
 # 上書き用ファイル
@@ -15,7 +15,7 @@ echo "Startup: check override files"
 ls /app/override/* >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   echo "Startup: copy override files"
-  cp -r /app/override/* /usr/share/caddy
+  cp -r -L /app/override/* /usr/share/caddy
 fi
 
 ###


### PR DESCRIPTION
k8s上で動かなかったため、startup.sh内のcpでsymlinkの実体をコピーするように修正しました。

> Linux では cp -r でディレクトリをコピーした場合、ディレクトリツリーに含まれるシンボリックリンクは、シンボリックリンクとしてそのままコピーされます。これは、Linux では cp は GNU 版であり、GNU の拡張が入っているためです。
https://qiita.com/komeda-shinji/items/4b25bb04bb1140dc8685

dockerのmountでは動いてたのですが、k8sのconfigmap / secretのmountだと動かなくなるようで、このオプションが必要でした
https://stackoverflow.com/questions/62776362/k8s-configmap-mounted-inside-symbolic-link-to-data-directory