### PR TITLE
iOSアプリの廃止告知バナーにPWA版の詳細情報へのリンクを追加

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -108,7 +108,8 @@
     showQrCodeButton: true,
     tooLargeFileMessage: '大きい%sの共有にはDriveを使用してください',
     showWidgetCopyButton: true,
-    inlineReplyDisableChannels: ['#general', '#random']
+    inlineReplyDisableChannels: ['#general', '#random'],
+    iosPwaInfoLink: 'https://wiki.trap.jp/SysAd/docs/traQ-S/PWA'
   }
 
   self.traQConfig = config

--- a/src/components/Main/MainView/MainView.vue
+++ b/src/components/Main/MainView/MainView.vue
@@ -1,8 +1,10 @@
 <template>
   <div :class="$style.container">
     <div v-if="iosAppFlag" :class="$style.iosAppIsDeprecated">
-      現在お使いのiOSアプリ版traQは2024/04/01を以て廃止され、2024/06/01には動作しなくなります。引き続き利用するにはPWA版に移行してください。なお、PWA版は動作にiOS
-      16.4を要求します。
+      {{ iosAppDeprecatedMessage }}
+      <div v-if="iosPwaInfoLink">
+        PWA版について: <a :href="iosPwaInfoLink">{{ iosPwaInfoLink }}</a>
+      </div>
     </div>
     <div id="header" :class="$style.headerContainer"></div>
     <div :class="$style.layoutContainer" :data-layout="layout">
@@ -21,6 +23,10 @@ import SecondaryViewSelector from './SecondaryViewSelector.vue'
 import { isIOSApp } from '/@/lib/dom/browser'
 
 const iosAppFlag = isIOSApp(window)
+const iosAppDeprecatedMessage =
+  '現在お使いのiOSアプリ版traQは2024/04/01を以て廃止され、2024/06/01には動作しなくなります。引き続き利用するにはPWA版に移行してください。なお、PWA版は動作にiOS 16.4を要求します。'
+
+const iosPwaInfoLink = window.traQConfig.iosPwaInfoLink
 
 const { layout } = useMainViewStore()
 

--- a/src/components/Main/MainView/MainView.vue
+++ b/src/components/Main/MainView/MainView.vue
@@ -24,7 +24,7 @@ import { isIOSApp } from '/@/lib/dom/browser'
 
 const iosAppFlag = isIOSApp(window)
 const iosAppDeprecatedMessage =
-  '現在お使いのiOSアプリ版traQは2024/04/01を以て廃止され、2024/06/01には動作しなくなります。引き続き利用するにはPWA版に移行してください。なお、PWA版は動作にiOS 16.4を要求します。'
+  '現在お使いのiOSアプリ版traQは2023/04/01を以て廃止され、2023/06/01には動作しなくなります。引き続き利用するにはPWA版に移行してください。なお、PWA版は動作にiOS 16.4を要求します。'
 
 const iosPwaInfoLink = window.traQConfig.iosPwaInfoLink
 

--- a/src/components/Main/MainView/MainView.vue
+++ b/src/components/Main/MainView/MainView.vue
@@ -3,7 +3,10 @@
     <div v-if="iosAppFlag" :class="$style.iosAppIsDeprecated">
       {{ iosAppDeprecatedMessage }}
       <div v-if="iosPwaInfoLink">
-        PWA版について: <a :href="iosPwaInfoLink">{{ iosPwaInfoLink }}</a>
+        PWA版について:
+        <a :href="iosPwaInfoLink" :class="$style.iosPwaInfoLink">{{
+          iosPwaInfoLink
+        }}</a>
       </div>
     </div>
     <div id="header" :class="$style.headerContainer"></div>
@@ -51,6 +54,10 @@ onBeforeUnmount(() => {
   z-index: $z-index-header;
   padding: 16px;
   background-color: $theme-accent-error-default;
+}
+
+.iosPwaInfoLink {
+  text-decoration: underline;
 }
 
 .headerContainer {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -106,6 +106,12 @@ export type Config = Readonly<{
    * @example ['#general', '#random']
    */
   inlineReplyDisableChannels?: string[]
+
+  /**
+   * iOSアプリの廃止告知バーナーに載せるPWAについてのリンク
+   * 省略時はリンクへの誘導テキストが載らない
+   */
+  iosPwaInfoLink?: string
 }>
 
 declare global {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -108,7 +108,7 @@ export type Config = Readonly<{
   inlineReplyDisableChannels?: string[]
 
   /**
-   * iOSアプリの廃止告知バーナーに載せるPWAについてのリンク
+   * iOSアプリの廃止告知バナーに載せるPWAについてのリンク
    * 省略時はリンクへの誘導テキストが載らない
    */
   iosPwaInfoLink?: string


### PR DESCRIPTION
現在のiOSアプリの廃止告知バナーの情報だけだと「PWA」のことを知らない人は対応の仕方がわからないので、詳細ページへのリンクを貼れるようにした

traPにおいては詳細ページがwikiに書かれているので、configを介してリンクの指定をできるようにした