### PR TITLE
traq-markdown-itのバージョン上げた

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mdi/js": "^7.2.96",
         "@sapphi-red/web-noise-suppressor": "^0.3.3",
         "@traptitech/traq": "^3.11.0-3",
-        "@traptitech/traq-markdown-it": "^6.2.1",
+        "@traptitech/traq-markdown-it": "^6.3.0",
         "autosize": "^6.0.1",
         "cropperjs": "^1.5.13",
         "deepmerge": "^4.3.1",
@@ -3301,9 +3301,9 @@
       }
     },
     "node_modules/@traptitech/traq-markdown-it": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@traptitech/traq-markdown-it/-/traq-markdown-it-6.2.1.tgz",
-      "integrity": "sha512-csJ7S7P09kBHrvZp6AYk7UvBBhiq3lvlXOBg7uSPYJVKaQyQ0i79umchkaGMDLV6KRgI8DWrFUZOtIPsPUUOSg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@traptitech/traq-markdown-it/-/traq-markdown-it-6.3.0.tgz",
+      "integrity": "sha512-66sDdX7AXYve8R41hopuI+3Sxq36facQhN1te0RiLq1BjiGcZQoKbDFeN5zltbe9veBJ6eGiGJoeSdHFK7HBRA==",
       "dependencies": {
         "@traptitech/markdown-it-katex": "^3.5.0",
         "@traptitech/markdown-it-regexp": "^0.5.3",
@@ -13934,9 +13934,9 @@
       }
     },
     "@traptitech/traq-markdown-it": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@traptitech/traq-markdown-it/-/traq-markdown-it-6.2.1.tgz",
-      "integrity": "sha512-csJ7S7P09kBHrvZp6AYk7UvBBhiq3lvlXOBg7uSPYJVKaQyQ0i79umchkaGMDLV6KRgI8DWrFUZOtIPsPUUOSg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@traptitech/traq-markdown-it/-/traq-markdown-it-6.3.0.tgz",
+      "integrity": "sha512-66sDdX7AXYve8R41hopuI+3Sxq36facQhN1te0RiLq1BjiGcZQoKbDFeN5zltbe9veBJ6eGiGJoeSdHFK7HBRA==",
       "requires": {
         "@traptitech/markdown-it-katex": "^3.5.0",
         "@traptitech/markdown-it-regexp": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@mdi/js": "^7.2.96",
     "@sapphi-red/web-noise-suppressor": "^0.3.3",
     "@traptitech/traq": "^3.11.0-3",
-    "@traptitech/traq-markdown-it": "^6.2.1",
+    "@traptitech/traq-markdown-it": "^6.3.0",
     "autosize": "^6.0.1",
     "cropperjs": "^1.5.13",
     "deepmerge": "^4.3.1",


### PR DESCRIPTION
traQの機能に直接関係ある変更はこれです
https://github.com/traPtitech/traq-markdown-it/pull/887

before
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/4d497bf7-e122-4d6d-a6c3-bc8a3eaab896)
after
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/91606929-861a-4ec1-85f6-8b6d71d65b72)