### PR TITLE
katexの表示がバグってるのを修正

### DIFF
--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -61,5 +61,6 @@ watch(
   overflow-wrap: anywhere;
   line-break: loose;
   overflow-x: scroll;
+  overflow-y: hidden;
 }
 </style>

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -55,12 +55,9 @@ watch(
 
 <style lang="scss" module>
 .content {
-  display: block;
   word-break: normal;
   overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   line-break: loose;
-  overflow-x: scroll;
-  overflow-y: hidden;
 }
 </style>

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -55,9 +55,11 @@ watch(
 
 <style lang="scss" module>
 .content {
+  display: block;
   word-break: normal;
   overflow-wrap: break-word; // for Safari
   overflow-wrap: anywhere;
   line-break: loose;
+  overflow-x: scroll;
 }
 </style>

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -39,9 +39,3 @@ html[data-stamp-edge='true'] {
       drop-shadow(-0.1px -0.1px 0 rgb(255, 255, 255, 0.1));
   }
 }
-
-.markdown-body .katex {
-  display: inline-block;
-  max-width: 100%;
-  overflow: scroll;
-}


### PR DESCRIPTION
close https://github.com/traPtitech/traQ_S-UI/issues/3892

y方向のがちょっと無理矢理になっちゃったかも

スマホ
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/46bb3e70-b27e-4270-81a7-7060dd3a2646)
パソコン
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/45f582d2-fe4b-44c7-b393-ddaf6a9f25ed)
