### PR TITLE
iPad miniのPWAでサービス一覧の表示が崩れる問題を修正

### DIFF
--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -95,10 +95,6 @@ $ephemeralNavigationMinHeight: 64px;
   flex-direction: column;
   height: 100%;
   flex-shrink: 0;
-  overflow: {
-    x: hidden;
-    y: auto;
-  }
   scrollbar-gutter: stable;
 }
 .navigations {


### PR DESCRIPTION
fix: #4000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ナビゲーションバーのスクロール挙動を調整し、縦方向のみスクロールできるようにしました。
  * 横スクロールの抑制設定を見直し、表示の安定性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->