### PR TITLE
検索フォームを空にして再検索したときの挙動を修正

### DIFF
--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -96,9 +96,7 @@ watch(
 
 onMounted(() => {
   // 初回マウント時に取得する
-  if (!executed.value) {
-    executeSearchForCurrentPage(query.value)
-  }
+  executeSearchForCurrentPage(query.value)
 })
 
 const resultListEle = ref<HTMLElement | null>(null)

--- a/src/components/Main/CommandPalette/SearchResult.vue
+++ b/src/components/Main/CommandPalette/SearchResult.vue
@@ -78,8 +78,7 @@ const {
   resetPaging,
   pageCount,
   currentSortKey,
-  query,
-  executed
+  query
 } = useSearchMessages()
 
 watch(
@@ -95,7 +94,7 @@ watch(
 )
 
 onMounted(() => {
-  // 初回マウント時に取得する
+  resetPaging()
   executeSearchForCurrentPage(query.value)
 })
 


### PR DESCRIPTION
fix: #3913