### PR TITLE
スタンプ名が入っている状態で画像を選択・変更しても名前が上書きされないように変更

### DIFF
--- a/src/components/Settings/StampTab/NewStamp.vue
+++ b/src/components/Settings/StampTab/NewStamp.vue
@@ -88,8 +88,8 @@ const isCreateEnabled = computed(
 )
 watch(
   () => stampImage.value,
-  (newImageData, oldImageData) => {
-    if (newImageData && newImageData.name !== oldImageData?.name) {
+  newImageData => {
+    if (!newStampName.value && newImageData && newImageData.name) {
       newStampName.value = trimExt(newImageData.name)
     }
   }


### PR DESCRIPTION
fix: #3903