### PR TITLE
リリースノートを自動生成するように

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          generate_release_notes: true
           files: dist.tar.gz
   image1:
     name: Build Docker Image (amd64 only)


### PR DESCRIPTION
close https://github.com/traPtitech/traQ_S-UI/issues/3995
元からaction-gh-release使ってたのでオプションつけるだけしました