### PR TITLE
メッセージの再取得時に時系列がソートされていないバグの修正

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelViewContent/composables/useChannelMessageFetcher.ts
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent/composables/useChannelMessageFetcher.ts
@@ -159,7 +159,7 @@ const useChannelMessageFetcher = (
     const { messages, hasMore } = await fetchMessagesByChannelId({
       channelId: props.channelId,
       limit: fetchLimit.value,
-      order: 'desc',
+      order: 'asc',
       since: loadedMessageLatestDate.value
     })
 

--- a/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
+++ b/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
@@ -75,6 +75,19 @@ const useMessageFetcher = (
     lastLoadingDirection.value = 'latest'
   }
 
+  const sortMessages = async (messageIdsParam: ref<MessageId[]>) => {
+    Promise.all(messageIdsParam.value.map((id) => fetchMessage(id))).then(
+      (messages) => messages.map((m: Message) => {return { id:m.id, createdAt: new Date(m.createdAt)} })
+    ).then((messages) => {
+      messages.sort((a, b) => {
+        if (a.createdAt < b.createdAt) { return -1; }
+        if (a.createdAt > b.createdAt) { return 1; }
+        return 0;
+      })
+      return messages.map((m) => m.id)
+    })
+  }
+
   const onLoadFormerMessagesRequest = async () => {
     if (isReachedEnd.value) {
       return
@@ -185,6 +198,7 @@ const useMessageFetcher = (
     // https://github.com/traPtitech/traQ_S-UI/issues/1748
     if (messageIds.value.includes(messageId)) return
     messageIds.value.push(messageId)
+    messageIds.value = await sortMessages(messageIds.value)
   }
 
   const init = () => {

--- a/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
+++ b/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
@@ -75,19 +75,6 @@ const useMessageFetcher = (
     lastLoadingDirection.value = 'latest'
   }
 
-  const sortMessages = async (messageIdsParam: ref<MessageId[]>) => {
-    Promise.all(messageIdsParam.value.map((id) => fetchMessage(id))).then(
-      (messages) => messages.map((m: Message) => {return { id:m.id, createdAt: new Date(m.createdAt)} })
-    ).then((messages) => {
-      messages.sort((a, b) => {
-        if (a.createdAt < b.createdAt) { return -1; }
-        if (a.createdAt > b.createdAt) { return 1; }
-        return 0;
-      })
-      return messages.map((m) => m.id)
-    })
-  }
-
   const onLoadFormerMessagesRequest = async () => {
     if (isReachedEnd.value) {
       return
@@ -198,7 +185,6 @@ const useMessageFetcher = (
     // https://github.com/traPtitech/traQ_S-UI/issues/1748
     if (messageIds.value.includes(messageId)) return
     messageIds.value.push(messageId)
-    messageIds.value = await sortMessages(messageIds.value)
   }
 
   const init = () => {


### PR DESCRIPTION
メッセージの再取得時に時系列がソートされていないバグの修正

fetchLatterMessages とほぼ同じ処理なのでascのはず。