### PR TITLE
Dependabotが死んでいるのを解決

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+engine-strict=false


### PR DESCRIPTION
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/6e9e93ba-ff5c-438f-9f32-b3ab5101614f)
Dependabotのバージョンが合っていなくて死んでいるので、一時的にengine-strictをfalseにした
https://zenn.dev/risu729/articles/dependabot-engine-strict