### PR TITLE
引用ブロックを折り畳めるように

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -15,20 +15,20 @@
         :id="markdownId"
         ref="contentRef"
         :class="[$style.markdownContainer, oversized && $style.oversized]"
-        :data-expanded="isExpanded"
+        :data-expanded="!isFold"
       >
         <markdown-content :content="content" />
       </div>
       <fold-button
         v-if="oversized"
-        :is-fold="!isExpanded"
-        :class="$style.expandButton"
-        :aria-expanded="isExpanded"
+        :is-fold="isFold"
+        :class="$style.foldButton"
+        :aria-expanded="!isFold"
         :aria-controls="markdownId"
         background="none"
         show-icon
         small
-        @click="toggleExpanded"
+        @click="toggleFold"
       />
     </div>
     <message-quote-list-item-footer :class="$style.footer" :message="message" />
@@ -84,7 +84,7 @@ const oversized = computed(
 )
 
 const markdownId = randomString()
-const { value: isExpanded, toggle: toggleExpanded } = useToggle(false)
+const { value: isFold, toggle: toggleFold } = useToggle(false)
 </script>
 
 <style lang="scss" module>
@@ -139,11 +139,11 @@ const { value: isExpanded, toggle: toggleExpanded } = useToggle(false)
 }
 
 $message-max-height: 200px;
-$expand-button-height: 28px;
+$fold-button-height: 28px;
 $mask-image: linear-gradient(
   black,
-  black calc(100% - $expand-button-height * 2),
-  rgba(0, 0, 0, 0.1) calc(100% - $expand-button-height),
+  black calc(100% - $fold-button-height * 2),
+  rgba(0, 0, 0, 0.1) calc(100% - $fold-button-height),
   transparent 100%
 );
 
@@ -159,12 +159,12 @@ $mask-image: linear-gradient(
 
     &[data-expanded='true'] {
       max-height: unset;
-      padding-bottom: $expand-button-height;
+      padding-bottom: $fold-button-height;
     }
   }
 }
 
-.expandButton {
+.foldButton {
   @include color-text-primary;
   cursor: pointer;
   position: absolute;

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -21,13 +21,13 @@
       </div>
       <fold-button
         v-if="oversized"
-        show-icon
-        small
         :is-fold="!isExpanded"
         :class="$style.expandButton"
         :aria-expanded="isExpanded"
         :aria-controls="markdownId"
         background="none"
+        show-icon
+        small
         @click="toggleExpanded"
       />
     </div>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -11,7 +11,25 @@
       :user-id="message.userId"
     />
     <div :class="$style.messageContents">
-      <markdown-content :content="content" />
+      <div
+        :id="markdownId"
+        ref="contentRef"
+        :class="[$style.markdownContainer, oversized && $style.oversized]"
+        :data-expanded="isExpanded"
+      >
+        <markdown-content :content="content" />
+      </div>
+      <fold-button
+        v-if="oversized"
+        show-icon
+        small
+        :is-fold="!isExpanded"
+        :class="$style.expandButton"
+        :aria-expanded="isExpanded"
+        :aria-controls="markdownId"
+        background="none"
+        @click="toggleExpanded"
+      />
     </div>
     <message-quote-list-item-footer :class="$style.footer" :message="message" />
   </div>
@@ -24,12 +42,16 @@
 import UserIcon from '/@/components/UI/UserIcon.vue'
 import MessageQuoteListItemHeader from './MessageQuoteListItemHeader.vue'
 import MessageQuoteListItemFooter from './MessageQuoteListItemFooter.vue'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { MessageId, ChannelId, DMChannelId } from '/@/types/entity-ids'
 import { useMessagesView } from '/@/store/domain/messagesView'
 import { useMessagesStore } from '/@/store/entities/messages'
 import { useChannelsStore } from '/@/store/entities/channels'
 import MarkdownContent from '/@/components/UI/MarkdownContent.vue'
+import useToggle from '/@/composables/utils/useToggle'
+import FoldButton from '/@/components/UI/FoldButton.vue'
+import { randomString } from '/@/lib/basic/randomString'
+import useBoxSize from '/@/composables/dom/useBoxSize'
 
 const props = defineProps<{
   parentMessageChannelId: ChannelId | DMChannelId
@@ -52,6 +74,17 @@ const shouldShow = computed(
 const content = computed(
   () => renderedContentMap.value.get(props.messageId) ?? ''
 )
+
+const MAX_HEIGHT = 200
+
+const contentRef = ref<HTMLDivElement | null>(null)
+const { height } = useBoxSize(contentRef)
+const oversized = computed(
+  () => height.value !== undefined && height.value >= MAX_HEIGHT
+)
+
+const markdownId = randomString()
+const { value: isExpanded, toggle: toggleExpanded } = useToggle(false)
 </script>
 
 <style lang="scss" module>
@@ -98,9 +131,50 @@ const content = computed(
   padding-top: 4px;
   padding-left: 8px;
   min-width: 0;
+  position: relative;
 
   pre {
     white-space: pre-wrap;
+  }
+}
+
+$message-max-height: 200px;
+$expand-button-height: 28px;
+$mask-image: linear-gradient(
+  black,
+  black calc(100% - $expand-button-height * 2),
+  rgba(0, 0, 0, 0.1) calc(100% - $expand-button-height),
+  transparent 100%
+);
+
+.markdownContainer {
+  &.oversized {
+    &[data-expanded='false'] {
+      max-height: $message-max-height;
+      overflow: hidden;
+      overflow: clip;
+      -webkit-mask-image: $mask-image;
+      mask-image: $mask-image;
+    }
+
+    &[data-expanded='true'] {
+      max-height: unset;
+      padding-bottom: $expand-button-height;
+    }
+  }
+}
+
+.expandButton {
+  @include color-text-primary;
+  cursor: pointer;
+  position: absolute;
+  left: 8px;
+  bottom: 0;
+  &:hover {
+    @include background-tertiary;
+  }
+  &:focus {
+    @include background-tertiary;
   }
 }
 

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -170,10 +170,13 @@ $mask-image: linear-gradient(
   position: absolute;
   left: 8px;
   bottom: 0;
-  &:hover {
-    @include background-tertiary;
+
+  @media (any-hover: hover) {
+    &:hover {
+      @include background-tertiary;
+    }
   }
-  &:focus {
+  &:focus-visible {
     @include background-tertiary;
   }
 }

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -84,7 +84,7 @@ const oversized = computed(
 )
 
 const markdownId = randomString()
-const { value: isFold, toggle: toggleFold } = useToggle(false)
+const { value: isFold, toggle: toggleFold } = useToggle(true)
 </script>
 
 <style lang="scss" module>

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -1,5 +1,8 @@
 <template>
-  <button :class="$style.button" :data-background="background">
+  <button
+    :class="[$style.button, small && $style.small]"
+    :data-background="background"
+  >
     <a-icon
       v-if="showIcon"
       :name="isFold ? 'down' : 'up'"
@@ -15,13 +18,15 @@ import AIcon from '/@/components/UI/AIcon.vue'
 
 interface Props extends /* @vue-ignore */ ButtonHTMLAttributes {
   showIcon?: boolean
-  background?: 'primary' | 'secondary' | 'tertiary'
+  background?: 'primary' | 'secondary' | 'tertiary' | 'none'
   isFold: boolean
+  small?: boolean
 }
 
 withDefaults(defineProps<Props>(), {
   showIcon: false,
-  background: 'tertiary'
+  background: 'tertiary',
+  small: false
 })
 </script>
 
@@ -38,6 +43,10 @@ withDefaults(defineProps<Props>(), {
   font-weight: bold;
   border-radius: 4px;
   padding: 0 24px;
+  &.small {
+    padding: 0 8px;
+  }
+
   min-height: 24px;
   font-size: 12px;
   line-height: 1.5;
@@ -55,6 +64,9 @@ withDefaults(defineProps<Props>(), {
 
   .icon {
     margin-left: -12px;
+  }
+  &.small .icon {
+    margin-left: -4px;
   }
 }
 </style>

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -27,6 +27,8 @@ withDefaults(defineProps<Props>(), {
 
 <style lang="scss" module>
 .button {
+  @include color-text-primary;
+
   cursor: pointer;
 
   display: flex;
@@ -41,7 +43,6 @@ withDefaults(defineProps<Props>(), {
   line-height: 1.5;
   width: fit-content;
 
-  color: $theme-text-primary-default;
   &[data-background='primary'] {
     background-color: $theme-ui-primary-default;
   }


### PR DESCRIPTION
Close #801 

高さとかは検索部分 (ref: `src/components/Main/CommandPalette/SearchResultMessageElement.vue`) 準拠です  

Figma: https://www.figma.com/file/6Wme6N24y3GN2jD0vqZWZr/traQ-S-UI?type=design&node-id=9539-23359&mode=dev

![image](https://github.com/traPtitech/traQ_S-UI/assets/62363188/5d442520-f59a-4907-9f6f-52f9e9301771)
![image](https://github.com/traPtitech/traQ_S-UI/assets/62363188/603518fa-090b-4581-82ae-2138ee18f38a)
