### PR TITLE
画像モーダルの挙動の変更

### DIFF
--- a/src/components/UI/ImageViewer.vue
+++ b/src/components/UI/ImageViewer.vue
@@ -32,9 +32,6 @@ const { styles } = useImageViewer(containerEle)
   overflow: hidden;
 }
 .imgContainer {
-  position: absolute;
-  top: 50%;
-  left: 50%;
   height: 100%;
   width: 100%;
   user-select: none;

--- a/src/components/UI/ImageViewer.vue
+++ b/src/components/UI/ImageViewer.vue
@@ -2,6 +2,7 @@
   <div ref="containerEle" :class="$style.container">
     <div :class="$style.imgContainer" :style="styles.imgContainer">
       <img
+        ref="imgEle"
         :src="src"
         :alt="alt"
         :class="$style.img"
@@ -22,8 +23,9 @@ defineProps<{
 }>()
 
 const containerEle = ref<HTMLDivElement>()
+const imgEle = ref<HTMLImageElement>()
 
-const { styles } = useImageViewer(containerEle)
+const { styles } = useImageViewer(containerEle, imgEle)
 </script>
 
 <style lang="scss" module>

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -248,12 +248,7 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
   const styles = reactive({
     imgContainer: computed(() => ({
       /*
-       * - translate(-50%, -50%)は中心にもってくるために必要
-       *   (`position: relative; top: 50%; left: 50%`)
-       * - translate(x, y)をscale(ratio)の前に持ってくると画像の位置のずれも拡大されてしまうので、
-       *   scale(ratio)のあとにおく
-       * - translate(x,y)のx,yがzoomRatioで割られているのはscale(ratio)のあとに持ってきているので、
-       *   座標軸が拡大されているため
+       * scale(ratio)による拡縮後にtranslate(x, y)による移動
        */
       transform: `translate(${state.centerDiff.x}px, ${state.centerDiff.y}px) scale(${state.zoomRatio})`
     })),

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -299,9 +299,10 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       )
 
       if (containerEle.value) {
+        const containerRect = containerEle.value.getBoundingClientRect()
         const cursorCenterDiff = {
-          x: e.clientX - containerEle.value.clientWidth / 2,
-          y: e.clientY - containerEle.value.clientHeight / 2
+          x: e.clientX - containerRect.x - containerRect.width / 2,
+          y: e.clientY - containerRect.y - containerRect.height / 2
         }
 
         state.centerDiff.x =
@@ -336,13 +337,14 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
         )
         const scaleDiff = afterScale / beforeScale
 
+        const containerRect = containerEle.value.getBoundingClientRect()
         const newMidPointCenterDiff = {
-          x: newMidPoint.x - containerEle.value.clientWidth / 2,
-          y: newMidPoint.y - containerEle.value.clientHeight / 2
+          x: newMidPoint.x - containerRect.x - containerRect.width / 2,
+          y: newMidPoint.y - containerRect.y - containerRect.height / 2
         }
         const firstMidPointCenterDiff = {
-          x: firstMidPoint.x - containerEle.value.clientWidth / 2,
-          y: firstMidPoint.y - containerEle.value.clientHeight / 2
+          x: firstMidPoint.x - containerRect.x - containerRect.width / 2,
+          y: firstMidPoint.y - containerRect.y - containerRect.height / 2
         }
 
         state.centerDiff.x =

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -302,11 +302,11 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       state.centerDiff.y = firstState!.centerDiff.y + newPoint.y - firstPoint.y
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       state.centerDiff.x =
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         firstState!.centerDiff.x + newMidPoint.x - firstMidPoint.x
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       state.centerDiff.y =
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         firstState!.centerDiff.y + newMidPoint.y - firstMidPoint.y
     },
     () => {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -241,7 +241,10 @@ const useTouch = (
   })
 }
 
-const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
+const useImageViewer = (
+  containerEle: Ref<HTMLElement | undefined>,
+  imgEle: Ref<HTMLElement | undefined>
+) => {
   const state: State = reactive({
     centerDiff: {
       x: 0,
@@ -283,19 +286,19 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
     state.rotate = newRotate
   }
 
-  const clampCenterDiff = (
-    centerDiff: Point,
-    scale: number,
-    containerRect: DOMRect
-  ) => {
+  const clampCenterDiff = (centerDiff: Point, scale: number) => {
+    if (!imgEle.value) return centerDiff
+
+    const imgRect = imgEle.value.getBoundingClientRect()
+
     const newCenterDiff: Point = {
       x: Math.max(
-        (-containerRect.width * scale) / 2,
-        Math.min((containerRect.width * scale) / 2, centerDiff.x)
+        -imgRect.width / 2,
+        Math.min(imgRect.width / 2, centerDiff.x)
       ),
       y: Math.max(
-        (-containerRect.height * scale) / 2,
-        Math.min((containerRect.height * scale) / 2, centerDiff.y)
+        -imgRect.height / 2,
+        Math.min(imgRect.height / 2, centerDiff.y)
       )
     }
     return newCenterDiff
@@ -355,19 +358,15 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
   useTouch(
     containerEle,
     (newPoint, firstPoint) => {
-      if (containerEle.value) {
-        const containerRect = containerEle.value.getBoundingClientRect()
-        state.centerDiff = clampCenterDiff(
-          {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            x: firstState!.centerDiff.x + newPoint.x - firstPoint.x,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            y: firstState!.centerDiff.y + newPoint.y - firstPoint.y
-          },
-          state.zoomRatio,
-          containerRect
-        )
-      }
+      state.centerDiff = clampCenterDiff(
+        {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          x: firstState!.centerDiff.x + newPoint.x - firstPoint.x,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          y: firstState!.centerDiff.y + newPoint.y - firstPoint.y
+        },
+        state.zoomRatio
+      )
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
       if (containerEle.value) {
@@ -401,8 +400,7 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               (firstState!.centerDiff.y - firstMidPointCenterDiff.y) * scaleDiff
           },
-          afterScale,
-          containerRect
+          afterScale
         )
 
         state.zoomRatio = afterScale

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -10,7 +10,7 @@ import {
 
 const WHEEL_SCROLL_SCALE_X = 0.5
 const WHEEL_SCROLL_SCALE_Y = 0.5
-const WHEEL_ZOOM_SCALE = 0.1
+const WHEEL_ZOOM_SCALE = 0.05
 const ZOOM_RATIO_MIN = 0.1
 const ROTATE_STEP = 5
 

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -8,6 +8,8 @@ import {
   getAngleBetweenLines
 } from '/@/lib/basic/point'
 
+const WHEEL_SCROLL_SCALE_X = 0.5
+const WHEEL_SCROLL_SCALE_Y = 0.5
 const ROTATE_STEP = 5
 
 export interface State {
@@ -291,7 +293,8 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       // TODO
     } else {
       // トラックパッドでスクロールジェスチャをする場合は e.ctrlKey == false になる
-      // TODO
+      state.centerDiff.x -= e.deltaX * WHEEL_SCROLL_SCALE_X
+      state.centerDiff.y -= e.deltaY * WHEEL_SCROLL_SCALE_Y
     }
   })
 

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -304,10 +304,13 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
       state.centerDiff.x =
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        firstState!.centerDiff.x + newMidPoint.x - firstMidPoint.x
+        firstState!.centerDiff.x + (newMidPoint.x - firstMidPoint.x)
       state.centerDiff.y =
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        firstState!.centerDiff.y + newMidPoint.y - firstMidPoint.y
+        firstState!.centerDiff.y + (newMidPoint.y - firstMidPoint.y)
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      state.zoomRatio = (firstState!.zoomRatio * newDistance) / firstDistance
     },
     () => {
       firstState = {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -10,7 +10,7 @@ import {
 
 const WHEEL_SCROLL_SCALE_X = 0.5
 const WHEEL_SCROLL_SCALE_Y = 0.5
-const WHEEL_ZOOM_SCALE = 0.05
+const WHEEL_ZOOM_SCALE = 0.01
 const ZOOM_RATIO_MIN = 0.1
 const ROTATE_STEP = 5
 
@@ -290,7 +290,8 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       const beforeScale = state.zoomRatio
       const afterScale = Math.max(
         ZOOM_RATIO_MIN,
-        state.zoomRatio - e.deltaY * WHEEL_ZOOM_SCALE
+        // ratio * exp(a) * exp(b) == ratio * exp(a+b) より deltaYの総和に対応して一定の拡縮
+        state.zoomRatio * Math.exp(-e.deltaY * WHEEL_ZOOM_SCALE)
       )
 
       if (containerEle.value) {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -300,17 +300,30 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       state.centerDiff.y = firstState!.centerDiff.y + newPoint.y - firstPoint.y
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
-      const scaleDiff = newDistance / firstDistance
+      if (containerEle.value) {
+        const scaleDiff = newDistance / firstDistance
 
-      state.centerDiff.x =
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        newMidPoint.x + (firstState!.centerDiff.x - firstMidPoint.x) * scaleDiff
-      state.centerDiff.y =
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        newMidPoint.y + (firstState!.centerDiff.y - firstMidPoint.y) * scaleDiff
+        const newMidPointCenterDiff = {
+          x: newMidPoint.x - containerEle.value.clientWidth / 2,
+          y: newMidPoint.y - containerEle.value.clientHeight / 2
+        }
+        const firstMidPointCenterDiff = {
+          x: firstMidPoint.x - containerEle.value.clientWidth / 2,
+          y: firstMidPoint.y - containerEle.value.clientHeight / 2
+        }
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      state.zoomRatio = firstState!.zoomRatio * scaleDiff
+        state.centerDiff.x =
+          newMidPointCenterDiff.x +
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          (firstState!.centerDiff.x - firstMidPointCenterDiff.x) * scaleDiff
+        state.centerDiff.y =
+          newMidPointCenterDiff.y +
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          (firstState!.centerDiff.y - firstMidPointCenterDiff.y) * scaleDiff
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        state.zoomRatio = firstState!.zoomRatio * scaleDiff
+      }
     },
     () => {
       firstState = {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -286,7 +286,7 @@ const useImageViewer = (
     state.rotate = newRotate
   }
 
-  const clampCenterDiff = (centerDiff: Point, scale: number) => {
+  const clampCenterDiff = (centerDiff: Point) => {
     if (!imgEle.value) return centerDiff
 
     const imgRect = imgEle.value.getBoundingClientRect()
@@ -308,8 +308,8 @@ const useImageViewer = (
    * centerDiffを移動範囲制限を適用して変更
    * @return 移動範囲制限が適用されたかどうか
    */
-  const rewriteCenterDiffWithClamp = (newCenterDiff: Point, scale: number) => {
-    state.centerDiff = clampCenterDiff(newCenterDiff, scale)
+  const rewriteCenterDiffWithClamp = (newCenterDiff: Point) => {
+    state.centerDiff = clampCenterDiff(newCenterDiff)
     return (
       state.centerDiff.x !== newCenterDiff.x ||
       state.centerDiff.y !== newCenterDiff.y
@@ -384,7 +384,7 @@ const useImageViewer = (
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         y: firstState!.centerDiff.y + newPoint.y - firstPoint.y
       }
-      rewriteCenterDiffWithClamp(newCenterDiff, state.zoomRatio)
+      rewriteCenterDiffWithClamp(newCenterDiff)
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
       if (containerEle.value) {
@@ -415,7 +415,7 @@ const useImageViewer = (
             (firstState!.centerDiff.y - firstMidPointCenterDiff.y) * scaleDiff
         }
 
-        rewriteCenterDiffWithClamp(newCenterDiff, afterScale)
+        rewriteCenterDiffWithClamp(newCenterDiff)
       }
     },
     () => {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -134,7 +134,7 @@ const useMouseWheel = (
       x: e.clientX - left,
       y: e.clientY - top
     })
-    e.preventDefault();
+    e.preventDefault()
   }
 
   onMounted(() => {
@@ -215,10 +215,12 @@ const useTouch = (
     containerEle.value!.addEventListener(
       'touchend',
       _endEvent => {
-        handlingTouch = false
+        if (_endEvent.touches.length === 0) {
+          handlingTouch = false
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        containerEle.value!.removeEventListener('touchmove', onMove)
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          containerEle.value!.removeEventListener('touchmove', onMove)
+        }
       },
       { once: true }
     )

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -253,7 +253,7 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
   /**
    * 基準となるタッチ開始時の状態情報
    */
-  let firstState: State = structuredClone(state)
+  let firstState: State | null = null
 
   /**
    * 拡大率 (1.0で等倍)
@@ -348,7 +348,14 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       // TODO
     },
     () => {
-      firstState = structuredClone(state)
+      firstState = {
+        centerDiff: {
+          x: state.centerDiff.x,
+          y: state.centerDiff.y
+        },
+        zoomLevel: state.zoomLevel,
+        rotate: state.rotate
+      }
     }
   )
 

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -251,9 +251,7 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
        * - translate(x,y)のx,yがzoomRatioで割られているのはscale(ratio)のあとに持ってきているので、
        *   座標軸が拡大されているため
        */
-      transform: `scale(${state.zoomRatio}) translate(${
-        state.centerDiff.x / state.zoomRatio
-      }px, ${state.centerDiff.y / state.zoomRatio}px)`
+      transform: `translate(${state.centerDiff.x}px, ${state.centerDiff.y}px) scale(${state.zoomRatio})`
     })),
     img: computed(() => ({
       /*

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -300,15 +300,17 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
       state.centerDiff.y = firstState!.centerDiff.y + newPoint.y - firstPoint.y
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
+      const scaleDiff = newDistance / firstDistance
+
       state.centerDiff.x =
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        firstState!.centerDiff.x + (newMidPoint.x - firstMidPoint.x)
+        newMidPoint.x + (firstState!.centerDiff.x - firstMidPoint.x) * scaleDiff
       state.centerDiff.y =
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        firstState!.centerDiff.y + (newMidPoint.y - firstMidPoint.y)
+        newMidPoint.y + (firstState!.centerDiff.y - firstMidPoint.y) * scaleDiff
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      state.zoomRatio = (firstState!.zoomRatio * newDistance) / firstDistance
+      state.zoomRatio = firstState!.zoomRatio * scaleDiff
     },
     () => {
       firstState = {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -342,10 +342,16 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
   useTouch(
     containerEle,
     (newPoint, firstPoint) => {
-      // TODO
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      state.centerDiff.x = firstState!.centerDiff.x + newPoint.x - firstPoint.x
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      state.centerDiff.y = firstState!.centerDiff.y + newPoint.y - firstPoint.y
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
-      // TODO
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      state.centerDiff.x = firstState!.centerDiff.x + newMidPoint.x - firstMidPoint.x
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      state.centerDiff.y = firstState!.centerDiff.y + newMidPoint.y - firstMidPoint.y
     },
     () => {
       firstState = {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -251,7 +251,7 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
        * - translate(x,y)のx,yがzoomRatioで割られているのはscale(ratio)のあとに持ってきているので、
        *   座標軸が拡大されているため
        */
-      transform: `translate(-50%, -50%) scale(${state.zoomRatio}) translate(${
+      transform: `scale(${state.zoomRatio}) translate(${
         state.centerDiff.x / state.zoomRatio
       }px, ${state.centerDiff.y / state.zoomRatio}px)`
     })),

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -344,10 +344,11 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
       if (containerEle.value) {
-        const beforeScale = state.zoomRatio
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const beforeScale = firstState!.zoomRatio
         const afterScale = Math.max(
           ZOOM_RATIO_MIN,
-          (state.zoomRatio * newDistance) / firstDistance
+          (beforeScale * newDistance) / firstDistance
         )
         const scaleDiff = afterScale / beforeScale
 
@@ -370,8 +371,7 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           (firstState!.centerDiff.y - firstMidPointCenterDiff.y) * scaleDiff
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        state.zoomRatio = firstState!.zoomRatio * scaleDiff
+        state.zoomRatio = afterScale
       }
     },
     () => {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -22,7 +22,7 @@ const WHEEL_SCALE_DELTAY = new Map<number, number>([
 const WHEEL_SCROLL_SCALE_X = 0.5
 const WHEEL_SCROLL_SCALE_Y = 0.5
 const WHEEL_ZOOM_SCALE = 0.01
-const ZOOM_RATIO_MIN = 0.1
+const ZOOM_RATIO_MIN = 1.0
 const ROTATE_STEP = 5
 
 export interface State {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -134,6 +134,7 @@ const useMouseWheel = (
       x: e.clientX - left,
       y: e.clientY - top
     })
+    e.preventDefault();
   }
 
   onMounted(() => {

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -160,7 +160,7 @@ const useTouch = (
     // タッチによるスクロールの無効化
     moveEvent.preventDefault()
 
-    const touches = moveEvent.targetTouches
+    const touches = moveEvent.touches
 
     if (firstPinchTouches && touches.length >= 2) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -176,7 +176,7 @@ const useTouch = (
   }
 
   const changeTouchMode = (e: TouchEvent) => {
-    const touches = e.targetTouches
+    const touches = e.touches
 
     if (touches.length >= 2) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -11,6 +11,7 @@ import {
 const WHEEL_SCROLL_SCALE_X = 0.5
 const WHEEL_SCROLL_SCALE_Y = 0.5
 const WHEEL_ZOOM_SCALE = 0.1
+const ZOOM_RATIO_MIN = 0.1
 const ROTATE_STEP = 5
 
 export interface State {
@@ -292,7 +293,10 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
     } else if (e.ctrlKey) {
       // トラックパッドでズームジェスチャをする場合は e.ctrlKey == true になる
       const beforeScale = state.zoomRatio
-      const afterScale = state.zoomRatio - e.deltaY * WHEEL_ZOOM_SCALE
+      const afterScale = Math.max(
+        ZOOM_RATIO_MIN,
+        state.zoomRatio - e.deltaY * WHEEL_ZOOM_SCALE
+      )
 
       if (containerEle.value) {
         const cursorCenterDiff = {
@@ -325,7 +329,12 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
     },
     (newDistance, firstDistance, newMidPoint, firstMidPoint, rotateAngle) => {
       if (containerEle.value) {
-        const scaleDiff = newDistance / firstDistance
+        const beforeScale = state.zoomRatio
+        const afterScale = Math.max(
+          ZOOM_RATIO_MIN,
+          (state.zoomRatio * newDistance) / firstDistance
+        )
+        const scaleDiff = afterScale / beforeScale
 
         const newMidPointCenterDiff = {
           x: newMidPoint.x - containerEle.value.clientWidth / 2,

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -243,7 +243,7 @@ const useTouch = (
 
 const useImageViewer = (
   containerEle: Ref<HTMLElement | undefined>,
-  imgEle: Ref<HTMLElement | undefined>
+  imgEle: Ref<HTMLImageElement | undefined>
 ) => {
   const state: State = reactive({
     centerDiff: {
@@ -291,15 +291,12 @@ const useImageViewer = (
 
     const imgRect = imgEle.value.getBoundingClientRect()
 
+    const width = imgEle.value.width * state.zoomRatio
+    const height = imgEle.value.height * state.zoomRatio
+
     const newCenterDiff: Point = {
-      x: Math.max(
-        -imgRect.width / 2,
-        Math.min(imgRect.width / 2, centerDiff.x)
-      ),
-      y: Math.max(
-        -imgRect.height / 2,
-        Math.min(imgRect.height / 2, centerDiff.y)
-      )
+      x: Math.max(-width / 2, Math.min(width / 2, centerDiff.x)),
+      y: Math.max(-height / 2, Math.min(height / 2, centerDiff.y))
     }
     return newCenterDiff
   }

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -208,7 +208,7 @@ const useTouch = (
       firstDistance,
       getTouchesMidpoint(...newPinchTouches),
       getTouchesMidpoint(...firstPinchTouches),
-      getAngleBetweenLinesFromTouches(newPinchTouches, firstPinchTouches)
+      getAngleBetweenLinesFromTouches(firstPinchTouches, newPinchTouches)
     )
 
     return newPinchTouches
@@ -286,7 +286,11 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
         r -= ROTATE_STEP
       }
       rewriteRotate(r)
+    } else if(e.ctrlKey) {
+      // トラックパッドでズームジェスチャをする場合は e.ctrlKey == true になる
+      // TODO
     } else {
+      // トラックパッドでスクロールジェスチャをする場合は e.ctrlKey == false になる
       // TODO
     }
   })

--- a/src/components/UI/composables/useImageViewer.ts
+++ b/src/components/UI/composables/useImageViewer.ts
@@ -10,6 +10,7 @@ import {
 
 const WHEEL_SCROLL_SCALE_X = 0.5
 const WHEEL_SCROLL_SCALE_Y = 0.5
+const WHEEL_ZOOM_SCALE = 0.1
 const ROTATE_STEP = 5
 
 export interface State {
@@ -288,9 +289,25 @@ const useImageViewer = (containerEle: Ref<HTMLElement | undefined>) => {
         r -= ROTATE_STEP
       }
       rewriteRotate(r)
-    } else if(e.ctrlKey) {
+    } else if (e.ctrlKey) {
       // トラックパッドでズームジェスチャをする場合は e.ctrlKey == true になる
-      // TODO
+      const beforeScale = state.zoomRatio
+      const afterScale = state.zoomRatio - e.deltaY * WHEEL_ZOOM_SCALE
+
+      if (containerEle.value) {
+        const cursorCenterDiff = {
+          x: e.clientX - containerEle.value.clientWidth / 2,
+          y: e.clientY - containerEle.value.clientHeight / 2
+        }
+
+        state.centerDiff.x =
+          cursorCenterDiff.x +
+          ((state.centerDiff.x - cursorCenterDiff.x) * afterScale) / beforeScale
+        state.centerDiff.y =
+          cursorCenterDiff.y +
+          ((state.centerDiff.y - cursorCenterDiff.y) * afterScale) / beforeScale
+        state.zoomRatio = afterScale
+      }
     } else {
       // トラックパッドでスクロールジェスチャをする場合は e.ctrlKey == false になる
       state.centerDiff.x -= e.deltaX * WHEEL_SCROLL_SCALE_X


### PR DESCRIPTION
https://github.com/traPtitech/traQ_S-UI/issues/4063

- ピンチ時に連続的に拡縮するよう変更
- ピンチ時にタッチ2点間の中点が維持される形でスクロールされるよう変更
- ピンチ時回転不可(alt+onwheel時の回転はそのまま)
- 2本指でのピンチ状態から1本指を離したときにもう片方も離すまでスクロールしなくなる問題を解消
- モーダル中, 画像の中と画像の外を同時にタッチしてピンチ動作をすると挙動がおかしくなる問題を解消
- onwheel時, トラックパッドの挙動を考慮してスクロールと拡縮両方に対応 ([参考資料](https://scrapbox.io/nishio/Macbook%E3%81%AE%E3%83%88%E3%83%A9%E3%83%83%E3%82%AF%E3%83%91%E3%83%83%E3%83%89%E3%81%A7%E6%8B%A1%E5%A4%A7%E7%B8%AE%E5%B0%8F%E5%B9%B3%E8%A1%8C%E7%A7%BB%E5%8B%95))
- onwheel時, deltaX/deltaYの値を考慮した挙動に変更
- onwheelによる拡大時, モーダルの画像だけでなくページ全体も拡大される問題を解消