### PR TITLE
🐛 #general などでめっちゃずれてたのを治す

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -148,11 +148,14 @@ $mask-image: linear-gradient(
 );
 
 .markdownContainer {
+  &[data-expanded='false'] {
+    max-height: $message-max-height;
+    overflow: hidden;
+    overflow: clip;
+  }
+
   &.oversized {
     &[data-expanded='false'] {
-      max-height: $message-max-height;
-      overflow: hidden;
-      overflow: clip;
       -webkit-mask-image: $mask-image;
       mask-image: $mask-image;
     }


### PR DESCRIPTION
おそらく #4051 が原因

直接の原因はわからなかったのですが、おそらくレイアウトシフト関連だろうということでシフトしないようにしました

- https://q.trap.jp/channels/general
- https://q.trap.jp/channels/random

で再現します