### PR TITLE
特定のバージョン以上のipadでもモーダルがクリックで閉じられるように

### DIFF
--- a/src/lib/dom/browser.ts
+++ b/src/lib/dom/browser.ts
@@ -6,6 +6,11 @@ export const isSafari = () => {
   return ua.includes('safari') && !ua.includes('chrome') && !ua.includes('edge')
 }
 
+/** 特定の条件のiPadだとuaに'ipad'の文字列を含まない
+ *  https://qiita.com/ShingoFukuyama/items/ef573a8e3e23ef12542e
+ *  'macinstosh'だとmacOSも含まれてしまうため、含まないように`'ontouchend' in document`の条件も追加
+ *  https://jsnotice.com/posts/2019-09-08/index.html
+ */
 export const isIOS = () => {
   return (
     ua.includes('iphone') ||

--- a/src/lib/dom/browser.ts
+++ b/src/lib/dom/browser.ts
@@ -11,7 +11,7 @@ export const isIOS = () => {
     ua.includes('iphone') ||
     ua.includes('ipod') ||
     ua.includes('ipad') ||
-    ua.includes('macintosh')
+    (ua.includes('macintosh') && 'ontouchend' in document)
   )
 }
 

--- a/src/lib/dom/browser.ts
+++ b/src/lib/dom/browser.ts
@@ -7,7 +7,12 @@ export const isSafari = () => {
 }
 
 export const isIOS = () => {
-  return ua.includes('iphone') || ua.includes('ipod') || ua.includes('ipad')
+  return (
+    ua.includes('iphone') ||
+    ua.includes('ipod') ||
+    ua.includes('ipad') ||
+    ua.includes('macintosh')
+  )
 }
 
 export const isFirefox = () => {


### PR DESCRIPTION
close https://github.com/traPtitech/traQ_S-UI/issues/4003

参考: https://qiita.com/ShingoFukuyama/items/ef573a8e3e23ef12542e, https://iwb.jp/ipad-safari-javascript-useragent-is-not-ipad/, https://jsnotice.com/posts/2019-09-08/index.html

以下2点が確認できたらマージします
- iPadで動作確認
- macOSでも今と変わらず閉じられることの確認