### PR TITLE
✨ FormButton の構造を変えて新たな状態を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "skyway-js": "^4.4.5",
         "text-field-edit": "^3.2.0",
         "throttle-debounce": "^5.0.0",
+        "ts-pattern": "^5.0.5",
         "turndown": "^7.1.1",
         "turndown-plugin-gfm": "^1.0.2",
         "vue": "^3.3.4",
@@ -10705,6 +10706,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.0.5.tgz",
+      "integrity": "sha512-tL0w8U/pgaacOmkb9fRlYzWEUDCfVjjv9dD4wHTgZ61MjhuMt46VNWTG747NqW6vRzoWIKABVhFSOJ82FvXrfA=="
     },
     "node_modules/tslib": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "skyway-js": "^4.4.5",
     "text-field-edit": "^3.2.0",
     "throttle-debounce": "^5.0.0",
+    "ts-pattern": "^5.0.5",
     "turndown": "^7.1.1",
     "turndown-plugin-gfm": "^1.0.2",
     "vue": "^3.3.4",

--- a/src/components/GroupManager/GroupListGroupEdit.vue
+++ b/src/components/GroupManager/GroupListGroupEdit.vue
@@ -31,7 +31,7 @@
     <div :class="[$style.item, $style.deleteButtonWrapper]">
       <form-button
         label="グループを削除"
-        variant="secondary"
+        type="secondary"
         is-danger
         @click="onDelete"
       />

--- a/src/components/GroupManager/GroupListGroupEdit.vue
+++ b/src/components/GroupManager/GroupListGroupEdit.vue
@@ -29,7 +29,12 @@
       :members="group.members"
     />
     <div :class="[$style.item, $style.deleteButtonWrapper]">
-      <form-button label="グループを削除" color="error" @click="onDelete" />
+      <form-button
+        label="グループを削除"
+        variant="secondary"
+        is-danger
+        @click="onDelete"
+      />
     </div>
   </div>
 </template>

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPanel.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPanel.vue
@@ -16,7 +16,7 @@
       <form-button
         v-if="showExpandButton"
         :class="$style.expandButton"
-        color="secondary"
+        variant="tertiary"
         label="全て表示"
         @click="expand"
       />

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPanel.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPanel.vue
@@ -16,7 +16,7 @@
       <form-button
         v-if="showExpandButton"
         :class="$style.expandButton"
-        variant="tertiary"
+        type="tertiary"
         label="全て表示"
         @click="expand"
       />

--- a/src/components/Main/MainView/ClipsView/ClipsSidebar/ClipsSidebarContent.vue
+++ b/src/components/Main/MainView/ClipsView/ClipsSidebar/ClipsSidebarContent.vue
@@ -23,7 +23,7 @@
       </content-editor>
     </sidebar-content-container-foldable>
     <div :class="$style.item">
-      <form-button label="削除" color="error" @click="deleteClip" />
+      <form-button label="削除" is-danger @click="deleteClip" />
     </div>
   </div>
 </template>

--- a/src/components/Main/MainView/ClipsView/ClipsSidebar/ClipsSidebarContent.vue
+++ b/src/components/Main/MainView/ClipsView/ClipsSidebar/ClipsSidebarContent.vue
@@ -23,7 +23,12 @@
       </content-editor>
     </sidebar-content-container-foldable>
     <div :class="$style.item">
-      <form-button label="削除" is-danger @click="deleteClip" />
+      <form-button
+        label="削除"
+        type="secondary"
+        is-danger
+        @click="deleteClip"
+      />
     </div>
   </div>
 </template>

--- a/src/components/Main/MainView/MessageElement/MessageEditor.vue
+++ b/src/components/Main/MainView/MessageElement/MessageEditor.vue
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div :class="$style.controls">
-      <form-button label="キャンセル" variant="tertiary" @click="cancel" />
+      <form-button label="キャンセル" type="tertiary" @click="cancel" />
       <form-button
         label="OK"
         :disabled="isPostingAttachment"

--- a/src/components/Main/MainView/MessageElement/MessageEditor.vue
+++ b/src/components/Main/MainView/MessageElement/MessageEditor.vue
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div :class="$style.controls">
-      <form-button label="キャンセル" color="secondary" @click="cancel" />
+      <form-button label="キャンセル" variant="tertiary" @click="cancel" />
       <form-button
         label="OK"
         :disabled="isPostingAttachment"

--- a/src/components/Settings/SessionTab/AccountState.vue
+++ b/src/components/Settings/SessionTab/AccountState.vue
@@ -5,9 +5,15 @@
       <form-button
         label="ログアウト"
         :class="$style.logout"
+        type="secondary"
+        is-danger
         @click="onLogoutClick"
       />
-      <form-button label="全セッション破棄" @click="onSessionDelete" />
+      <form-button
+        label="全セッション破棄"
+        is-danger
+        @click="onSessionDelete"
+      />
     </div>
   </div>
 </template>

--- a/src/components/Settings/ThemeTab/EditTheme.vue
+++ b/src/components/Settings/ThemeTab/EditTheme.vue
@@ -5,14 +5,14 @@
       label="エクスポート"
       @click="onImportClick"
       :disabled="isImporterOpen"
-      color="secondary"
+      variant="tertiary"
       :class="$style.element"
     />
     -->
     <form-button
       label="インポート/エクスポート"
       :disabled="isImporterOpen"
-      color="secondary"
+      variant="tertiary"
       :class="$style.element"
       @click="onImportClick"
     />
@@ -20,7 +20,8 @@
     <form-button
       label="選択中のテーマで上書き"
       @click="onUpdateClick"
-      color="error"
+      variant="secondary"
+      is-danger
       :class="$style.element"
     />
     -->
@@ -31,7 +32,7 @@
       <form-button
         label="保存"
         :disabled="!isChanged"
-        color="primary"
+        variant="primary"
         @click="applyTheme"
       />
     </div>

--- a/src/components/Settings/ThemeTab/EditTheme.vue
+++ b/src/components/Settings/ThemeTab/EditTheme.vue
@@ -5,14 +5,14 @@
       label="エクスポート"
       @click="onImportClick"
       :disabled="isImporterOpen"
-      variant="tertiary"
+      type="tertiary"
       :class="$style.element"
     />
     -->
     <form-button
       label="インポート/エクスポート"
       :disabled="isImporterOpen"
-      variant="tertiary"
+      type="tertiary"
       :class="$style.element"
       @click="onImportClick"
     />
@@ -20,7 +20,7 @@
     <form-button
       label="選択中のテーマで上書き"
       @click="onUpdateClick"
-      variant="secondary"
+      type="secondary"
       is-danger
       :class="$style.element"
     />
@@ -32,7 +32,7 @@
       <form-button
         label="保存"
         :disabled="!isChanged"
-        variant="primary"
+        type="primary"
         @click="applyTheme"
       />
     </div>

--- a/src/components/UI/FormButton.vue
+++ b/src/components/UI/FormButton.vue
@@ -3,7 +3,7 @@
     :class="$style.container"
     :disabled="loading || disabled"
     :data-is-loading="$boolAttr(loading)"
-    :data-variant="variant"
+    :data-type="type"
     :data-is-danger="$boolAttr(isDanger)"
   >
     <div :class="$style.label">{{ label }}</div>
@@ -20,17 +20,17 @@ import { computed } from 'vue'
 import LoadingSpinner from '/@/components/UI/LoadingSpinner.vue'
 import { match, P } from 'ts-pattern'
 
-interface Variant {
-  variant?: 'primary' | 'secondary' | 'tertiary'
+interface Type {
+  type?: 'primary' | 'secondary' | 'tertiary'
   isDanger?: boolean
 }
 
-interface NonDangerVariant extends Variant {
-  variant?: 'primary' | 'secondary' | 'tertiary'
+interface NonDangerType extends Type {
+  type?: 'primary' | 'secondary' | 'tertiary'
   isDanger?: false
 }
-interface DangerVariant extends Variant {
-  variant?: 'primary' | 'secondary'
+interface DangerType extends Type {
+  type?: 'primary' | 'secondary'
   isDanger: true
 }
 
@@ -38,18 +38,18 @@ type Props = {
   label?: string
   loading?: boolean
   disabled?: boolean
-} & (NonDangerVariant | DangerVariant)
+} & (NonDangerType | DangerType)
 
 const props = withDefaults(defineProps<Props>(), {
   label: '',
   loading: false,
   disabled: false,
-  variant: 'primary',
+  type: 'primary',
   isDanger: false
 })
 
 const spinnerColor = computed(() => {
-  return match([props.variant, props.isDanger] as const)
+  return match([props.type, props.isDanger] as const)
     .with(['primary', P._], () => 'white' as const)
     .with(['secondary', true], () => 'accent-error' as const)
     .with(['secondary', false], () => 'accent-primary' as const)
@@ -72,26 +72,26 @@ const spinnerColor = computed(() => {
   &[data-is-loading] {
     cursor: wait;
   }
-  &[data-variant='primary'] {
+  &[data-type='primary'] {
     @include color-common-text-white-primary;
     @include background-accent-primary;
     border-color: $theme-ui-primary-default;
   }
-  &[data-variant='secondary'] {
+  &[data-type='secondary'] {
     @include color-accent-primary;
     border-color: $theme-accent-primary-default;
   }
-  &[data-variant='tertiary'] {
+  &[data-type='tertiary'] {
     @include color-ui-secondary;
     border-color: $theme-ui-secondary-default;
   }
 
-  &[data-variant='primary'][data-is-danger] {
+  &[data-type='primary'][data-is-danger] {
     @include color-common-text-white-primary;
     @include background-accent-error;
     border-color: $theme-accent-error-default;
   }
-  &[data-variant='secondary'][data-is-danger] {
+  &[data-type='secondary'][data-is-danger] {
     color: $theme-accent-error-default;
     border-color: $theme-accent-error-default;
   }

--- a/src/components/UI/LoadingSpinner.vue
+++ b/src/components/UI/LoadingSpinner.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts" setup>
-type SpinnerColor = 'white' | 'ui-secondary' | 'accent-primary'
+type SpinnerColor = 'white' | 'ui-secondary' | 'accent-primary' | 'accent-error'
 
 withDefaults(
   defineProps<{
@@ -35,6 +35,10 @@ $spinner-width: 0.35em;
   }
   &[data-color='accent-primary'] {
     --spinner-color: #{$theme-accent-primary-default};
+    --spinner-gap-color: transparent;
+  }
+  &[data-color='accent-error'] {
+    --spinner-color: #{$theme-accent-error-default};
     --spinner-gap-color: transparent;
   }
 }


### PR DESCRIPTION
設定画面の改修にあたって、中が塗られた赤いボタンを追加
それに伴って、FormButton の variant を変える手段を `color: 'primary' | 'secondary' | 'tertiary' | 'danger'` で指定していたのを、添付画像のように `type: 'primary' | 'secondary' | 'tertiary'` と `isDanger: boolean` で指定するように
(以前の `color: 'secondary'` , `color: 'tertiary'` がそれぞれ `type: 'tertiary'`, `type: 'secondary'` に対応しているので注意)

![image](https://github.com/traPtitech/traQ_S-UI/assets/62363188/bc2ca1ac-f07a-47cc-816c-8393fa87738c)

経緯とかは https://q.trap.jp/messages/84c7491d-6470-4a37-834a-cff4feea3ec4 以下にあります