### PR TITLE
🐛 FormButton の primary で枠線の色が変わってしまっていた

### DIFF
--- a/src/components/UI/FormButton.vue
+++ b/src/components/UI/FormButton.vue
@@ -75,7 +75,7 @@ const spinnerColor = computed(() => {
   &[data-type='primary'] {
     @include color-common-text-white-primary;
     @include background-accent-primary;
-    border-color: $theme-ui-primary-default;
+    border-color: $theme-accent-primary-default;
   }
   &[data-type='secondary'] {
     @include color-accent-primary;


### PR DESCRIPTION
ダークモードだとわかりやすい
| before (変わっちゃってる状態) | after (正常) |
| --- | --- |
|![image](https://github.com/traPtitech/traQ_S-UI/assets/62363188/b4ecb3d4-b166-4dca-ad91-a467db49a4d3)| ![image](https://github.com/traPtitech/traQ_S-UI/assets/62363188/850b12c1-0be5-48fc-8345-2abc207557c3) |

原因: #4146 
