### PR TITLE
share-target でデフォルトテキストが表示されないバグの修正

### DIFF
--- a/src/components/ShareTarget/ShareTargetForm.vue
+++ b/src/components/ShareTarget/ShareTargetForm.vue
@@ -8,7 +8,7 @@
     />
     <share-target-message-input
       :class="[$style.item, $style.input]"
-      :default-text="defaultTextRef"
+      :default-text="defaultText"
     />
     <form-button
       :class="[$style.item, $style.button]"
@@ -37,7 +37,6 @@ import { useUsersStore } from '/@/store/entities/users'
 const props = defineProps<{
   defaultText: string
 }>()
-const defaultTextRef = computed(() => props.defaultText)
 
 const emit = defineEmits<{
   (e: 'post'): void

--- a/src/components/ShareTarget/ShareTargetForm.vue
+++ b/src/components/ShareTarget/ShareTargetForm.vue
@@ -6,10 +6,7 @@
       label="投稿先チャンネル"
       :options="channelOptions"
     />
-    <share-target-message-input
-      :class="[$style.item, $style.input]"
-      :default-text="defaultText"
-    />
+    <share-target-message-input :class="[$style.item, $style.input]" />
     <form-button
       :class="[$style.item, $style.button]"
       label="送信"

--- a/src/components/ShareTarget/ShareTargetForm.vue
+++ b/src/components/ShareTarget/ShareTargetForm.vue
@@ -6,7 +6,10 @@
       label="投稿先チャンネル"
       :options="channelOptions"
     />
-    <share-target-message-input :class="[$style.item, $style.input]" />
+    <share-target-message-input
+      :class="[$style.item, $style.input]"
+      :default-text="defaultTextRef"
+    />
     <form-button
       :class="[$style.item, $style.button]"
       label="送信"
@@ -34,6 +37,7 @@ import { useUsersStore } from '/@/store/entities/users'
 const props = defineProps<{
   defaultText: string
 }>()
+const defaultTextRef = computed(() => props.defaultText)
 
 const emit = defineEmits<{
   (e: 'post'): void

--- a/src/components/ShareTarget/ShareTargetMessageInput.vue
+++ b/src/components/ShareTarget/ShareTargetMessageInput.vue
@@ -7,8 +7,9 @@
           <textarea
             :id="id"
             ref="textareaRef"
-            v-model="state.text"
             :class="$style.input"
+            :value="defaultTextRef"
+            @input="event => state.text = (event.target as HTMLTextAreaElement)?.value"
           />
         </div>
         <div :class="$style.controls">
@@ -34,7 +35,7 @@
 import MessageInputFileList from '/@/components/Main/MainView/MessageInput/MessageInputFileList.vue'
 import MessageInputUploadButton from '/@/components/Main/MainView/MessageInput/MessageInputUploadButton.vue'
 import MessageInputInsertStampButton from '/@/components/Main/MainView/MessageInput/MessageInputInsertStampButton.vue'
-import { onMounted, shallowRef, ref, toRef } from 'vue'
+import { onMounted, shallowRef, computed, ref, toRef } from 'vue'
 import { randomString } from '/@/lib/basic/randomString'
 import useTextStampPickerInvoker from '../Main/MainView/composables/useTextStampPickerInvoker'
 import useAttachments from '../Main/MainView/MessageInput/composables/useAttachments'
@@ -44,6 +45,11 @@ import { useToastStore } from '/@/store/ui/toast'
 import { useStampsStore } from '/@/store/entities/stamps'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
 import { useStampHistory } from '/@/store/domain/stampHistory'
+
+const props = defineProps<{
+  defaultText: string
+}>()
+const defaultTextRef = computed(() => props.defaultText)
 
 const { fetchStampHistory } = useStampHistory()
 const { fetchStamps } = useStampsStore()

--- a/src/components/ShareTarget/ShareTargetMessageInput.vue
+++ b/src/components/ShareTarget/ShareTargetMessageInput.vue
@@ -8,7 +8,7 @@
             :id="id"
             ref="textareaRef"
             :class="$style.input"
-            :value="defaultText"
+            :value="state.text"
             @input="event => state.text = (event.target as HTMLTextAreaElement).value"
           />
         </div>
@@ -45,10 +45,6 @@ import { useToastStore } from '/@/store/ui/toast'
 import { useStampsStore } from '/@/store/entities/stamps'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
 import { useStampHistory } from '/@/store/domain/stampHistory'
-
-const props = defineProps<{
-  defaultText: string
-}>()
 
 const { fetchStampHistory } = useStampHistory()
 const { fetchStamps } = useStampsStore()

--- a/src/components/ShareTarget/ShareTargetMessageInput.vue
+++ b/src/components/ShareTarget/ShareTargetMessageInput.vue
@@ -9,7 +9,7 @@
             ref="textareaRef"
             :class="$style.input"
             :value="defaultTextRef"
-            @input="event => state.text = (event.target as HTMLTextAreaElement)?.value"
+            @input="event => state.text = (event.target as HTMLTextAreaElement).value"
           />
         </div>
         <div :class="$style.controls">

--- a/src/components/ShareTarget/ShareTargetMessageInput.vue
+++ b/src/components/ShareTarget/ShareTargetMessageInput.vue
@@ -8,7 +8,7 @@
             :id="id"
             ref="textareaRef"
             :class="$style.input"
-            :value="defaultTextRef"
+            :value="defaultText"
             @input="event => state.text = (event.target as HTMLTextAreaElement).value"
           />
         </div>
@@ -35,7 +35,7 @@
 import MessageInputFileList from '/@/components/Main/MainView/MessageInput/MessageInputFileList.vue'
 import MessageInputUploadButton from '/@/components/Main/MainView/MessageInput/MessageInputUploadButton.vue'
 import MessageInputInsertStampButton from '/@/components/Main/MainView/MessageInput/MessageInputInsertStampButton.vue'
-import { onMounted, shallowRef, computed, ref, toRef } from 'vue'
+import { onMounted, shallowRef, ref, toRef } from 'vue'
 import { randomString } from '/@/lib/basic/randomString'
 import useTextStampPickerInvoker from '../Main/MainView/composables/useTextStampPickerInvoker'
 import useAttachments from '../Main/MainView/MessageInput/composables/useAttachments'
@@ -49,7 +49,6 @@ import { useStampHistory } from '/@/store/domain/stampHistory'
 const props = defineProps<{
   defaultText: string
 }>()
-const defaultTextRef = computed(() => props.defaultText)
 
 const { fetchStampHistory } = useStampHistory()
 const { fetchStamps } = useStampsStore()


### PR DESCRIPTION
share-target API が今まではデフォルトテキストが空文字になっていたので修正。
元々の状態でもテキストエリアに表示されないだけで編集せずに投稿すれば元々の文字列が投稿できていたが、一度でも編集するとテキストエリアの文字が投稿されていた。

Vue何も分からずに適当に編集しているので作法とか間違ってるかも

share-target APIの使用例: https://q.trap.jp/share-target?title=foo&text=aaaaaaaa&url=www.google.co.jp