### PR TITLE
クリップフォルダの使いやすさ向上

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageTools.vue
+++ b/src/components/Main/MainView/MessageElement/MessageTools.vue
@@ -179,19 +179,19 @@ const onDotsClick = (e: MouseEvent) => {
 }
 
 const DEFAULT_CLIP_FOLDER_ID = '201fcb38-3dbe-4a53-8c0c-37b47bed9985' // FIXME: あとで直す
-const clippedFolders = ref(new Set<ClipFolderId>())
+const clippingFolderIds = ref(new Set<ClipFolderId>())
 const isClipped = computed(() =>
-  clippedFolders.value.has(DEFAULT_CLIP_FOLDER_ID)
+  clippingFolderIds.value.has(DEFAULT_CLIP_FOLDER_ID)
 )
 
 apis.getMessageClips(props.messageId).then(res => {
-  clippedFolders.value = new Set(res.data.map(c => c.folderId))
+  clippingFolderIds.value = new Set(res.data.map(c => c.folderId))
 })
 const clipIconName = computed(() => {
   return isClipped.value ? 'bookmark-check' : 'bookmark'
 })
 
-const { toggleClip } = useCreateClip(props.messageId, clippedFolders)
+const { toggleClip } = useCreateClip(props.messageId, clippingFolderIds)
 const openClipCreateModal = () => {
   toggleClip(DEFAULT_CLIP_FOLDER_ID)
 }

--- a/src/components/Modal/ClipCreateModal/ClipFolderNew.vue
+++ b/src/components/Modal/ClipCreateModal/ClipFolderNew.vue
@@ -1,0 +1,102 @@
+<template>
+  <div :class="$style.container">
+    <a-icon :class="$style.icon" mdi name="bookmark" />
+    <div :class="$style.inputContainer">
+      <input
+        v-model="clipFolderName"
+        type="text"
+        :class="$style.input"
+        placeholder="クリップフォルダを新規作成"
+      />
+      <length-count :val="clipFolderName" :max-length="30" />
+    </div>
+    <button
+      :class="$style.button"
+      :disabled="clipFolderName.length === 0 || isExceeded || adding"
+      @click="createClipFolder"
+    >
+      <a-icon name="plus" mdi :class="$style.icon" />
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, reactive } from 'vue'
+import AIcon from '/@/components/UI/AIcon.vue'
+import useMaxLength from '/@/composables/utils/useMaxLength'
+import apis from '/@/lib/apis'
+import { useToastStore } from '/@/store/ui/toast'
+import LengthCount from '/@/components/UI/LengthCount.vue'
+import type { ClipFolderId } from '/@/types/entity-ids'
+
+const emit = defineEmits<{
+  (e: 'createClipFolder', id: ClipFolderId): void
+}>()
+
+const { addErrorToast } = useToastStore()
+
+const clipFolderName = ref('')
+const adding = ref(false)
+const { isExceeded } = useMaxLength(
+  reactive({ val: clipFolderName, maxLength: 30 })
+)
+
+const createClipFolder = async () => {
+  adding.value = true
+  try {
+    const newClipFolder = (await apis.createClipFolder({
+      name: clipFolderName.value,
+      description: ''
+    })).data
+    clipFolderName.value = ''
+    emit('createClipFolder', newClipFolder.id)
+  } catch {
+    addErrorToast('クリップフォルダの作成に失敗しました')
+  }
+  adding.value = false
+}
+</script>
+
+<style lang="scss" module>
+.container {
+  @include color-ui-primary;
+  display: flex;
+  cursor: pointer;
+  gap: 8px;
+  padding: 8px 0;
+}
+.icon {
+  vertical-align: middle;
+}
+
+.inputContainer {
+  @include color-ui-secondary;
+  @include background-secondary;
+  display: flex;
+  align-items: center;
+  flex: 1 1;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.input {
+  @include color-text-primary;
+  width: 100%;
+  padding: 0 8px;
+  &::placeholder {
+    @include color-ui-secondary;
+  }
+}
+
+.button {
+  @include color-ui-secondary;
+  @include background-secondary;
+  padding: 0 12px;
+  margin-left: 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+</style>

--- a/src/composables/clips/createClip.ts
+++ b/src/composables/clips/createClip.ts
@@ -1,0 +1,44 @@
+import type { Ref } from 'vue'
+import apis from '/@/lib/apis'
+import type { MessageId, ClipFolderId } from '/@/types/entity-ids'
+import { useToastStore } from '/@/store/ui/toast'
+import type { AxiosError } from 'axios'
+
+export const useCreateClip = (
+  messageId: MessageId,
+  isSelected: Ref<Set<ClipFolderId>>
+) => {
+  const { addSuccessToast, addErrorToast } = useToastStore()
+
+  const createClip = async (clipFolderId: ClipFolderId) => {
+    try {
+      await apis.clipMessage(clipFolderId, {
+        messageId: messageId
+      })
+      isSelected.value.add(clipFolderId)
+      addSuccessToast('クリップフォルダに追加しました')
+    } catch (e) {
+      if ((e as AxiosError).response?.status === 409) {
+        isSelected.value.add(clipFolderId)
+        addErrorToast('すでに追加されています')
+        return
+      } else {
+        addErrorToast('追加に失敗しました')
+      }
+      throw e
+    }
+  }
+  const deleteClip = async (clipFolderId: ClipFolderId) => {
+    await apis.unclipMessage(clipFolderId, messageId)
+    isSelected.value.delete(clipFolderId)
+    addSuccessToast('クリップフォルダから削除しました')
+  }
+  const toggleClip = async (clipFolderId: ClipFolderId) => {
+    if (isSelected.value.has(clipFolderId)) {
+      await deleteClip(clipFolderId)
+    } else {
+      await createClip(clipFolderId)
+    }
+  }
+  return { toggleClip }
+}


### PR DESCRIPTION
close https://github.com/traPtitech/traQ_S-UI/issues/3539, close https://github.com/traPtitech/traQ_S-UI/issues/758
デフォルトフォルダの扱いがサーバー側変更する必要あるので今度ちゃんと依頼するのと、ナビゲーションバーに通知インジゲーター表示するのがまだです
メモ: クリップフォルダ内でクリップフォルダから外すボタンも用意