### PR TITLE
設定画面プロフィールタブの改修

### DIFF
--- a/src/components/Modal/Common/ModalFrame.vue
+++ b/src/components/Modal/Common/ModalFrame.vue
@@ -64,7 +64,7 @@ const { clearModal } = useModalStore()
 }
 .body {
   width: 100%;
-  padding: 16px 24px;
+  padding: 16px;
   overflow: {
     x: hidden;
     y: auto;

--- a/src/components/Modal/ModalContainer.vue
+++ b/src/components/Modal/ModalContainer.vue
@@ -45,7 +45,8 @@
         "
         :file="
           currentState.type === 'settings-stamp-create' ||
-          currentState.type === 'settings-stamp-image-edit'
+          currentState.type === 'settings-stamp-image-edit' ||
+          currentState.type === 'settings-profile-icon-edit'
             ? currentState.file
             : undefined
         "
@@ -74,6 +75,7 @@ import GroupMemberAddModal from './GroupMemberAddModal/GroupMemberAddModal.vue'
 import StampCreateModal from './StampCreateModal/StampCreateModal.vue'
 import StampEditModal from './StampEditModal/StampEditModal.vue'
 import StampImageEditModal from './StampImageEditModal/StampImageEditModal.vue'
+import ProfileIconEditModal from './ProfileIconEditModal/ProfileIconEditModal.vue'
 
 const { shouldShowModal, currentState } = useModalStore()
 
@@ -113,6 +115,8 @@ const component = computed(() => {
       return StampEditModal
     case 'settings-stamp-image-edit':
       return StampImageEditModal
+    case 'settings-profile-icon-edit':
+      return ProfileIconEditModal
   }
   // eslint-disable-next-line no-console
   console.error('Unexpected modal type:', currentState.value)

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -1,0 +1,79 @@
+<template>
+  <modal-frame
+    title="アイコンの編集"
+    subtitle="画像の位置・サイズを編集できます"
+  >
+    <div :class="$style.container">
+      <image-upload v-model="iconImage" />
+    </div>
+    <div :class="$style.buttonContainer">
+      <form-button label="キャンセル" type="tertiary" @click="cancel" />
+      <form-button
+        label="更新する"
+        :loading="isEditing"
+        @click="editIconImage"
+      />
+    </div>
+  </modal-frame>
+</template>
+
+<script lang="ts" setup>
+import { ref, type Ref } from 'vue'
+import apis, { formatResizeError } from '/@/lib/apis'
+import { useToastStore } from '/@/store/ui/toast'
+import FormButton from '/@/components/UI/FormButton.vue'
+import ModalFrame from '../Common/ModalFrame.vue'
+import { useModalStore } from '/@/store/ui/modal'
+import ImageUpload from '/@/components/Settings/ImageUpload.vue'
+
+const props = defineProps<{
+  file: File
+}>()
+
+const { clearModal } = useModalStore()
+
+const iconImage = ref<File>(props.file)
+
+const useIconImageEdit = (iconImage: Ref<File>) => {
+  const { addSuccessToast, addErrorToast } = useToastStore()
+  const isEditing = ref(false)
+
+  const editIconImage = async () => {
+    if (!iconImage.value) return
+    isEditing.value = true
+    try {
+      await apis.changeMyIcon(iconImage.value)
+
+      addSuccessToast('アイコン画像を変更しました')
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('アイコン画像の変更に失敗しました', e)
+      addErrorToast(formatResizeError(e, 'アイコン画像の変更に失敗しました'))
+    }
+    clearModal()
+    isEditing.value = false
+  }
+
+  return { isEditing, editIconImage }
+}
+
+const { isEditing, editIconImage } = useIconImageEdit(iconImage)
+const cancel = () => {
+  clearModal()
+}
+</script>
+
+<style lang="scss" module>
+.container {
+  display: flex;
+  justify-content: center;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  margin-top: 16px;
+}
+</style>

--- a/src/components/Settings/ImageUpload.vue
+++ b/src/components/Settings/ImageUpload.vue
@@ -117,7 +117,6 @@ onUnmounted(() => {
 .cropper {
   width: 280px;
   height: 280px;
-  margin: 12px;
   &[data-is-rounded] {
     :global(.cropper-view-box),
     :global(.cropper-face) {

--- a/src/components/UI/UserIcon.vue
+++ b/src/components/UI/UserIcon.vue
@@ -20,7 +20,19 @@ import { useMeStore } from '/@/store/domain/me'
 import { useUsersStore } from '/@/store/entities/users'
 import NotificationIndicator from '/@/components/UI/NotificationIndicator.vue'
 
-export type IconSize = 160 | 100 | 64 | 48 | 44 | 40 | 36 | 32 | 28 | 24 | 20
+export type IconSize =
+  | 200
+  | 160
+  | 100
+  | 64
+  | 48
+  | 44
+  | 40
+  | 36
+  | 32
+  | 28
+  | 24
+  | 20
 
 const props = withDefaults(
   defineProps<{

--- a/src/store/ui/modal/states.ts
+++ b/src/store/ui/modal/states.ts
@@ -28,6 +28,7 @@ type ModalStateType =
   | 'settings-stamp-create'
   | 'settings-stamp-edit'
   | 'settings-stamp-image-edit'
+  | 'settings-profile-icon-edit'
 
 export type ModalState =
   | UserModalState
@@ -47,6 +48,7 @@ export type ModalState =
   | SettingsStampCreateModalState
   | SettingsStampEditModalState
   | SettingsStampImageEditModalState
+  | SettingsProfileIconEdit
 
 interface BaseModalState {
   /** モーダル種別 */
@@ -144,5 +146,10 @@ interface SettingsStampEditModalState extends BaseModalState {
 interface SettingsStampImageEditModalState extends BaseModalState {
   type: 'settings-stamp-image-edit'
   id: StampId
+  file: File
+}
+
+interface SettingsProfileIconEdit extends BaseModalState {
+  type: 'settings-profile-icon-edit'
   file: File
 }

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -12,10 +12,10 @@
         />
       </div>
     </section>
-    <div :class="$style.section">
+    <section :class="$style.section">
       <h3 :class="$style.heading">表示名</h3>
       <form-input v-model="state.displayName" :max-length="32" />
-    </div>
+    </section>
     <section :class="$style.section">
       <h3 :class="$style.heading">ひとこと</h3>
       <div :class="$style.bioContainer">
@@ -201,7 +201,7 @@ onBeforeRouteLeave(() => {
 }
 .iconContainer {
   display: flex;
-  align-items: end;
+  align-items: flex-end;
   justify-content: space-between;
 }
 .iconEditButton {
@@ -214,7 +214,7 @@ onBeforeRouteLeave(() => {
 }
 .buttonContainer {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   gap: 16px;
 }
 </style>

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -26,7 +26,7 @@
       <form-selector v-model="state.homeChannel" :options="channelOptions" />
     </section>
     <section :class="$style.section">
-      <h3 :class="$style.heading">X (旧:Twitter)</h3>
+      <h3 :class="$style.heading">X (旧Twitter)</h3>
       <form-input v-model="state.twitterId" prefix="@" :max-length="15" />
     </section>
     <div :class="$style.buttonContainer">

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -2,13 +2,15 @@
   <div>
     <section :class="$style.section">
       <h3 :class="$style.heading">アイコン</h3>
-      <user-icon :user-id="detail.id" :size="200" prevent-modal />
-      <form-button
-        label="アイコンを変更する"
-        type="secondary"
-        :class="$style.iconEditButton"
-        @click="handleOpenModal"
-      />
+      <div :class="$style.iconContainer">
+        <user-icon :user-id="detail.id" :size="200" prevent-modal />
+        <form-button
+          label="アイコンを変更する"
+          type="secondary"
+          :class="$style.iconEditButton"
+          @click="handleOpenModal"
+        />
+      </div>
     </section>
     <div :class="$style.section">
       <h3 :class="$style.heading">表示名</h3>
@@ -196,6 +198,11 @@ onBeforeRouteLeave(() => {
 }
 .heading {
   margin-bottom: 4px;
+}
+.iconContainer{
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
 }
 .iconEditButton {
   margin-top: 8px;

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -1,64 +1,49 @@
 <template>
-  <section>
-    <div :class="$style.element">
-      <h3 :class="$style.header">アイコン</h3>
-      <user-icon
-        :user-id="detail.id"
-        :size="100"
-        prevent-modal
-        :class="$style.icon"
-      />
-      <image-upload v-model="newIcon" rounded :class="$style.uploder" />
-    </div>
-    <div :class="$style.element">
-      <h3 :class="$style.header">表示名</h3>
-      <form-input
-        v-model="state.displayName"
-        :class="$style.form"
-        :max-length="32"
-      />
-    </div>
-    <div :class="$style.element">
-      <h3 :class="$style.header">ひとこと</h3>
-      <div :class="$style.bioContainer">
-        <form-text-area
-          v-model="state.bio"
-          :class="$style.form"
-          rows="1"
-          :max-length="1000"
-        />
-        <div :class="$style.form">
-          <h4>プレビュー</h4>
-          <inline-markdown :content="state.bio" accept-action />
-        </div>
-      </div>
-    </div>
-    <div :class="$style.element">
-      <h3 :class="$style.header">ホームチャンネル</h3>
-      <form-selector
-        v-model="state.homeChannel"
-        :options="channelOptions"
-        :class="$style.form"
-      />
-    </div>
-    <div :class="$style.element">
-      <h3 :class="$style.header">𝕏</h3>
-      <form-input
-        v-model="state.twitterId"
-        prefix="@"
-        :class="$style.form"
-        :max-length="15"
-      />
-    </div>
-    <div :class="$style.updater">
+  <div>
+    <section :class="$style.section">
+      <h3 :class="$style.heading">アイコン</h3>
+      <user-icon :user-id="detail.id" :size="200" prevent-modal />
       <form-button
-        label="更新"
+        label="アイコンを変更する"
+        type="secondary"
+        :class="$style.iconEditButton"
+        @click="handleOpenModal"
+      />
+    </section>
+    <div :class="$style.section">
+      <h3 :class="$style.heading">表示名</h3>
+      <form-input v-model="state.displayName" :max-length="32" />
+    </div>
+    <section :class="$style.section">
+      <h3 :class="$style.heading">ひとこと</h3>
+      <div :class="$style.bioContainer">
+        <inline-markdown :content="state.bio" accept-action />
+        <form-text-area v-model="state.bio" rows="2" :max-length="1000" />
+      </div>
+    </section>
+    <section :class="$style.section">
+      <h3 :class="$style.heading">ホームチャンネル</h3>
+      <form-selector v-model="state.homeChannel" :options="channelOptions" />
+    </section>
+    <section :class="$style.section">
+      <h3 :class="$style.heading">X (旧:Twitter)</h3>
+      <form-input v-model="state.twitterId" prefix="@" :max-length="15" />
+    </section>
+    <div :class="$style.buttonContainer">
+      <form-button
+        label="リセット"
+        :disabled="!isChanged"
+        type="tertiary"
+        @click="handleReset"
+      />
+      <form-button
+        label="プロフィールを更新"
         :disabled="!canUpdate"
         :loading="isUpdating"
-        @click="onUpdateClick"
+        @click="handleUpdate"
       />
     </div>
-  </section>
+  </div>
 </template>
 
 <script lang="ts">
@@ -77,6 +62,10 @@ import { useChannelsStore } from '/@/store/entities/channels'
 import { useUsersStore } from '/@/store/entities/users'
 import { useStampsStore } from '/@/store/entities/stamps'
 import { useGroupsStore } from '/@/store/entities/groups'
+import FormButton from '/@/components/UI/FormButton.vue'
+import { useFileSelect } from '/@/composables/dom/useFileSelect'
+import { useModalStore } from '/@/store/ui/modal'
+import { onBeforeRouteLeave } from 'vue-router'
 
 const useState = (detail: Ref<UserDetail>) => {
   const profile = computed(() => ({
@@ -90,7 +79,12 @@ const useState = (detail: Ref<UserDetail>) => {
   const { hasDiff } = useStateDiff<UserDetail>()
   const isStateChanged = computed(() => hasDiff(state, detail))
 
-  return { state, isStateChanged }
+  const handleReset = () => {
+    if (!confirm('変更をリセットしますか？')) return
+    Object.assign(state, profile.value)
+  }
+
+  return { state, isStateChanged, handleReset }
 }
 
 type Profile = Pick<
@@ -98,26 +92,14 @@ type Profile = Pick<
   'displayName' | 'bio' | 'twitterId' | 'homeChannel'
 > & { homeChannel: string }
 
-const useProfileUpdate = (
-  state: Profile,
-  newIcon: Ref<File | undefined>,
-  isStateChanged: Ref<boolean>
-) => {
+const useProfileUpdate = (state: Profile) => {
   const { addSuccessToast, addErrorToast } = useToastStore()
   const isUpdating = ref(false)
 
-  const onUpdateClick = async () => {
-    const promises = []
-    if (newIcon.value !== undefined) {
-      promises.push(apis.changeMyIcon(newIcon.value))
-    }
-    if (isStateChanged.value) {
-      promises.push(apis.editMe(state))
-    }
+  const handleUpdate = async () => {
     try {
       isUpdating.value = true
-      await Promise.all(promises)
-      newIcon.value = undefined
+      await apis.editMe(state)
 
       addSuccessToast('プロフィールを更新しました')
     } catch (e) {
@@ -128,7 +110,7 @@ const useProfileUpdate = (
     }
     isUpdating.value = false
   }
-  return { isUpdating, onUpdateClick }
+  return { isUpdating, handleUpdate }
 }
 
 const useIsLengthValid = (state: Profile) => {
@@ -147,10 +129,8 @@ const useIsLengthValid = (state: Profile) => {
 
 <script lang="ts" setup>
 import UserIcon from '/@/components/UI/UserIcon.vue'
-import ImageUpload from '/@/components/Settings/ImageUpload.vue'
 import FormInput from '/@/components/UI/FormInput.vue'
 import FormSelector from '/@/components/UI/FormSelector.vue'
-import FormButton from '/@/components/UI/FormButton.vue'
 import FormTextArea from '/@/components/UI/FormTextArea.vue'
 import InlineMarkdown from '/@/components/UI/InlineMarkdown.vue'
 
@@ -171,18 +151,11 @@ fetchStamps()
 
 const { channelOptions } = useChannelOptions('--未設定--')
 
-const { state, isStateChanged } = useState(detail)
+const { state, isStateChanged, handleReset } = useState(detail)
 
-const newIcon = ref<File | undefined>()
-const isChanged = computed(
-  () => isStateChanged.value || newIcon.value !== undefined
-)
+const isChanged = computed(() => isStateChanged.value)
 
-const { isUpdating, onUpdateClick } = useProfileUpdate(
-  state,
-  newIcon,
-  isChanged
-)
+const { isUpdating, handleUpdate } = useProfileUpdate(state)
 const isLengthValid = useIsLengthValid(state)
 const isTwitterIdValid = computed(
   () => state.twitterId === '' || isValidTwitter(state.twitterId)
@@ -191,38 +164,50 @@ const isTwitterIdValid = computed(
 const canUpdate = computed(
   () => isChanged.value && isLengthValid.value && isTwitterIdValid.value
 )
+
+const { pushModal } = useModalStore()
+
+const acceptImageType = ['image/jpeg', 'image/png', 'image/gif'].join(',')
+const { selectImage } = useFileSelect({ accept: acceptImageType }, files => {
+  if (!files[0]) return
+  pushModal({
+    type: 'settings-profile-icon-edit',
+    file: files[0]
+  })
+})
+const handleOpenModal = () => {
+  selectImage()
+}
+
+onBeforeRouteLeave(() => {
+  if (!isChanged.value) return
+  const result = window.confirm(
+    'このページを離れると変更が破棄されます。本当に離れますか？'
+  )
+  if (!result) {
+    return false
+  }
+})
 </script>
 
 <style lang="scss" module>
-.element {
+.section {
   margin: 24px 0;
 }
-.header {
-  margin-bottom: 8px;
+.heading {
+  margin-bottom: 4px;
 }
-.form {
-  margin-left: 12px;
-}
-.icon {
-  margin: {
-    bottom: 8px;
-    left: 36px;
-  }
-}
-.uploder {
-  margin-left: 12px;
+.iconEditButton {
+  margin-top: 8px;
 }
 .bioContainer {
   display: flex;
-  flex-wrap: wrap;
-  > * {
-    width: 50%;
-    flex: 1 1 15rem;
-  }
+  flex-direction: column;
+  gap: 4px;
 }
-.updater {
+.buttonContainer {
   display: flex;
-  justify-content: center;
-  margin-top: 24px;
+  justify-content: end;
+  gap: 16px;
 }
 </style>

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -199,7 +199,7 @@ onBeforeRouteLeave(() => {
 .heading {
   margin-bottom: 4px;
 }
-.iconContainer{
+.iconContainer {
   display: flex;
   align-items: end;
   justify-content: space-between;


### PR DESCRIPTION
https://github.com/traPtitech/traQ_S-UI/issues/2203
スタンプタブの改修で使ってるものを使ってるのでスタンプタブのPRから生やしてます

動作確認事項
- 各項目を編集して更新できる
- アイコンの変更で画像編集ができる
- 編集して更新していない状態で別ページに移動しようとするとconfirmが出て、各選択肢に応じて正しい動作をする
- リセットボタンを押すと変更前の状態に戻る
- 変更がない状態、バリデーションエラーが出ている状態などでボタンがdisabledになっている