### PR TITLE
ブラウザの文字サイズ変えてもスタンプの表示が微妙な感じにならないように

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationListItem.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationListItem.vue
@@ -61,8 +61,7 @@ defineExpose({ focus })
 }
 .topic {
   @include color-ui-secondary;
-
-  font-size: 0.75rem;
+  @include size-caption;
 
   &.empty {
     opacity: 0.5;

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPanel.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPanel.vue
@@ -88,11 +88,11 @@ const showExpandButton = computed(
 
 .empty {
   @include color-ui-secondary;
+  @include size-caption;
 
   padding: 16px;
   place-items: center;
   text-align: center;
-  font-size: 0.75rem;
 }
 
 .list {

--- a/src/components/Main/MainView/MessageElement/MessageStampList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageStampList.vue
@@ -140,8 +140,8 @@ const { toggleStampPicker } = useStampPickerInvoker(
 }
 .stamp {
   margin: {
-    right: 4px;
-    bottom: 4px;
+    right: 0.25rem;
+    bottom: 0.25rem;
   }
 
   display: flex;

--- a/src/components/Main/MainView/MessageElement/MessageTools.vue
+++ b/src/components/Main/MainView/MessageElement/MessageTools.vue
@@ -181,7 +181,6 @@ const { value: showQuickReaction, toggle: toggleQuickReaction } = useToggle(
   @include color-ui-tertiary;
   @include background-primary;
   display: flex;
-  align-items: center;
   border-radius: 4px;
   contain: content;
   &:not([data-is-mobile]) {

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -95,10 +95,10 @@ watch(
   }
   display: inline-flex;
   flex-shrink: 0;
-  height: 24px;
+  height: 1.5rem;
   align-items: center;
-  padding: 2px 4px;
-  border-radius: 4px;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
   cursor: pointer;
   user-select: none;
   overflow: hidden;

--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -226,6 +226,8 @@ $radius: 4px;
 }
 
 .toNewMessageButton {
+  @include size-body2;
+
   color: $theme-ui-secondary-default;
   background-color: $theme-background-secondary-default;
   width: 160px;
@@ -238,7 +240,6 @@ $radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
   font-weight: bold;
   gap: 10px;
   cursor: pointer;

--- a/src/components/UI/AStamp.vue
+++ b/src/components/UI/AStamp.vue
@@ -38,8 +38,8 @@ const imageUrl = computed(() => {
 })
 
 const containerStyle = computed(() => ({
-  width: `${props.size}px`,
-  height: `${props.size}px`
+  width: `${props.size / 16}rem`,
+  height: `${props.size / 16}rem`
 }))
 </script>
 

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -33,6 +33,7 @@ withDefaults(defineProps<Props>(), {
 <style lang="scss" module>
 .button {
   @include color-text-primary;
+  @include size-caption;
 
   cursor: pointer;
 
@@ -48,7 +49,6 @@ withDefaults(defineProps<Props>(), {
   }
 
   min-height: 24px;
-  font-size: 12px;
   line-height: 1.5;
   width: fit-content;
 


### PR DESCRIPTION
`px`を`rem`にすることによってベースのフォントサイズが変わったときにいい感じになるようにしました
また、https://github.com/traPtitech/traQ_S-UI/blob/24d955b6ac3b917a950fd357634787c4fb77cc17/docs/architecture.md#font-size%E3%81%AB%E9%96%A2%E3%81%97%E3%81%A6 に気付いたのでmixinを使わずにfont-size指定しているところを直しました

before:
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/ecce5ed0-9da5-452f-bb51-b5df0b5d4ada)
after:
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/414f1c9c-71ba-4595-88c5-b279067ea4d7)
