### PR TITLE
サービス一覧でghostの表示名を変更

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -33,7 +33,7 @@
         appLink: 'https://wiki.trap.jp/'
       },
       {
-        label: 'Blog',
+        label: 'Blog Admin',
         iconPath: 'ghost.svg',
         appLink: 'https://blog-admin.trap.jp/'
       },


### PR DESCRIPTION
ブログ閲覧用のサイトと思われてしまうことがあるので: https://q.trap.jp/messages/75fd8b9e-e720-4346-84f9-1736c6b89802
![image](https://github.com/traPtitech/traQ_S-UI/assets/83744975/e4d8b652-fbdf-40ac-8f95-6c75b39d4c6b)
