### PR TITLE
OAuth2の新しいスコープに対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mdi/js": "^7.2.96",
         "@sapphi-red/web-noise-suppressor": "^0.3.3",
-        "@traptitech/traq": "^3.15.1-8",
+        "@traptitech/traq": "^3.17.0-3",
         "@traptitech/traq-markdown-it": "^6.3.0",
         "autosize": "^6.0.1",
         "cropperjs": "^1.5.13",
@@ -3399,11 +3399,14 @@
       "integrity": "sha512-tH/Fk1WMsnSuLpuRsXw8iHtdivoCEI5V08hQ7doVm6WmzAnBf/cUzyH9+GbOldPq9Hwv9v9tuy5t/MxmdNAGXg=="
     },
     "node_modules/@traptitech/traq": {
-      "version": "3.15.1-8",
-      "resolved": "https://registry.npmjs.org/@traptitech/traq/-/traq-3.15.1-8.tgz",
-      "integrity": "sha512-dKmqqxdp6VWg+qqrtiPMYOv3OVL1BV8TBdpint/QC1CASIUQPd5eBEfgXvglcr3OBUF4mMqWOByCgNNrnPZotQ==",
+      "version": "3.17.0-3",
+      "resolved": "https://registry.npmjs.org/@traptitech/traq/-/traq-3.17.0-3.tgz",
+      "integrity": "sha512-PsZltFNiguEfRoAmtOJ7R3wuiLQLh0m6RXfpuFdIaUvP+Z43GI4M1fX7AOOBHXoUIRgHEhLxNNFAo3/IzL/ELQ==",
       "dependencies": {
-        "axios": "^1.6.1"
+        "axios": "^1.6.8"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@traptitech/traq-markdown-it": {
@@ -4723,11 +4726,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -7041,9 +7044,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@mdi/js": "^7.2.96",
     "@sapphi-red/web-noise-suppressor": "^0.3.3",
-    "@traptitech/traq": "^3.15.1-8",
+    "@traptitech/traq": "^3.17.0-3",
     "@traptitech/traq-markdown-it": "^6.3.0",
     "autosize": "^6.0.1",
     "cropperjs": "^1.5.13",

--- a/src/lib/clientScope.ts
+++ b/src/lib/clientScope.ts
@@ -4,6 +4,14 @@ export const scopeInfoMap: Record<
   OAuth2Scope,
   { name: string; permissions: string[] }
 > = {
+  [OAuth2Scope.Openid]: {
+    name: 'ユーザーID取得',
+    permissions: ['traQ IDの取得']
+  },
+  [OAuth2Scope.Profile]: {
+    name: 'プロフィール取得',
+    permissions: ['自ユーザー情報の取得']
+  },
   [OAuth2Scope.Read]: {
     name: 'データの読み取り',
     permissions: [


### PR DESCRIPTION
確認URL:
https://4275-dev.traq-preview.trapti.tech/api/v3/oauth2/authorize?client_id=XzEAPVFhfy9egf5FTJBw6iZr83HGzcMtvPYR&response_type=code

こんな感じになります
![image](https://github.com/traPtitech/traQ_S-UI/assets/18257693/4264f25a-923d-4b42-a909-e06c1009c63a)

ref: traPtitech/traQ#1887