### PR TITLE
fetchNewMessagesが最古のN件を取得している問題の修正

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelViewContent/composables/useChannelMessageFetcher.ts
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent/composables/useChannelMessageFetcher.ts
@@ -154,12 +154,13 @@ const useChannelMessageFetcher = (
     ]
   }
 
+  // 最新メッセージを作成日時昇順で取得
   const fetchNewMessages = async (isReachedLatest: Ref<boolean>) => {
     await waitHeightResolved
     const { messages, hasMore } = await fetchMessagesByChannelId({
       channelId: props.channelId,
       limit: fetchLimit.value,
-      order: 'asc',
+      order: 'desc',
       since: loadedMessageLatestDate.value
     })
 
@@ -167,9 +168,10 @@ const useChannelMessageFetcher = (
       isReachedLatest.value = true
     }
 
-    updateDates(messages)
+    const messagesAsc = messages.reverse()
+    updateDates(messagesAsc)
 
-    return messages.map(message => message.id)
+    return messagesAsc.map(message => message.id)
   }
 
   const onReachedLatest = async () => {

--- a/src/components/Main/MainView/ChannelView/ChannelViewContent/composables/useChannelMessageFetcher.ts
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent/composables/useChannelMessageFetcher.ts
@@ -154,7 +154,7 @@ const useChannelMessageFetcher = (
     ]
   }
 
-  // 最新メッセージを作成日時昇順で取得
+  // 直近のメッセージを取得し作成日時昇順で並べ替えて返す
   const fetchNewMessages = async (isReachedLatest: Ref<boolean>) => {
     await waitHeightResolved
     const { messages, hasMore } = await fetchMessagesByChannelId({


### PR DESCRIPTION
close https://github.com/traPtitech/traQ_S-UI/issues/3968
ref https://github.com/traPtitech/traQ_S-UI/pull/4026
最新のfetchLimit件を作成日時昇順で取得するようにしました