### PR TITLE
traQ上のメッセージの投稿・編集日時に年月日を適宜省略しつつ付け足す

### DIFF
--- a/src/lib/basic/date.ts
+++ b/src/lib/basic/date.ts
@@ -42,12 +42,25 @@ export const getDateRepresentationWithoutSameDate = (
 }
 
 export const getDisplayDate = (createdAt: string, updatedAt: string) => {
-  const createdDate = new Date(createdAt)
+  let displayDate = new Date(createdAt)
   if (createdAt === updatedAt) {
-    return getTimeString(createdDate)
+    displayDate = new Date(updatedAt)
+  }
+  const today = new Date()
+  const timeString = getTimeString(displayDate)
+  const yesterday = new Date(today)
+  yesterday.setDate(today.getDate() - 1)
+
+  if (getFullDayString(displayDate) === getFullDayString(today)) {
+    return '今日' + ' ' + timeString
+  }
+  if (getFullDayString(displayDate) === getFullDayString(yesterday)) {
+    return '昨日' + ' ' + timeString
+  }
+  if (displayDate.getFullYear() === today.getFullYear()) {
+    return getDayString(displayDate) + ' ' + timeString
   } else {
-    const updatedDate = new Date(updatedAt)
-    return getDateRepresentationWithoutSameDate(updatedDate, createdDate)
+    return getFullDayString(displayDate) + ' ' + timeString
   }
 }
 

--- a/src/lib/basic/date.ts
+++ b/src/lib/basic/date.ts
@@ -42,14 +42,10 @@ export const getDateRepresentationWithoutSameDate = (
 }
 
 export const getDisplayDate = (createdAt: string, updatedAt: string) => {
-  let displayDate = new Date(createdAt)
-  if (createdAt !== updatedAt) {
-    displayDate = new Date(updatedAt)
-  }
+  const displayDate = new Date(updatedAt)
   const today = new Date()
   const timeString = getTimeString(displayDate)
-  const yesterday = new Date(today)
-  yesterday.setDate(today.getDate() - 1)
+  const yesterday = new Date(today.getTime() - 1000 * 60 * 60 * 24)
 
   if (getFullDayString(displayDate) === getFullDayString(today)) {
     return '今日' + ' ' + timeString

--- a/src/lib/basic/date.ts
+++ b/src/lib/basic/date.ts
@@ -47,10 +47,18 @@ export const getDisplayDate = (createdAt: string, updatedAt: string) => {
   const timeString = getTimeString(displayDate)
   const yesterday = new Date(today.getTime() - 1000 * 60 * 60 * 24)
 
-  if (getFullDayString(displayDate) === getFullDayString(today)) {
+  if (
+    displayDate.getFullYear() === today.getFullYear() &&
+    displayDate.getMonth() === today.getMonth() &&
+    displayDate.getDate() === today.getDate()
+  ) {
     return '今日' + ' ' + timeString
   }
-  if (getFullDayString(displayDate) === getFullDayString(yesterday)) {
+  if (
+    displayDate.getFullYear() === yesterday.getFullYear() &&
+    displayDate.getMonth() === yesterday.getMonth() &&
+    displayDate.getDate() === yesterday.getDate()
+  ) {
     return '昨日' + ' ' + timeString
   }
   if (displayDate.getFullYear() === today.getFullYear()) {

--- a/src/lib/basic/date.ts
+++ b/src/lib/basic/date.ts
@@ -43,7 +43,7 @@ export const getDateRepresentationWithoutSameDate = (
 
 export const getDisplayDate = (createdAt: string, updatedAt: string) => {
   let displayDate = new Date(createdAt)
-  if (createdAt === updatedAt) {
+  if (createdAt !== updatedAt) {
     displayDate = new Date(updatedAt)
   }
   const today = new Date()

--- a/tests/unit/lib/basic/date.spec.ts
+++ b/tests/unit/lib/basic/date.spec.ts
@@ -94,8 +94,12 @@ describe('getDateRepresentationWithoutSameDate', () => {
 })
 
 describe('getDisplayDate', () => {
-  beforeEach(() => {vi.useFakeTimers()})
-  afterEach(() => {vi.useRealTimers()})
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
 
   const createdDateISO = '2010-04-01T12:34:56'
   const updatedDateISO = '2010-05-02T14:28:57'
@@ -114,7 +118,9 @@ describe('getDisplayDate', () => {
   })
   it('should get YYYY/MM/DD when updated before last year', () => {
     vi.setSystemTime('2015-10-10T15:00:00')
-    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('2010/05/02 14:28')
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe(
+      '2010/05/02 14:28'
+    )
   })
 })
 

--- a/tests/unit/lib/basic/date.spec.ts
+++ b/tests/unit/lib/basic/date.spec.ts
@@ -95,9 +95,6 @@ describe('getDateRepresentationWithoutSameDate', () => {
 
 describe('getDisplayDate', () => {
   const today = new Date()
-  const year = today.getFullYear().toString()
-  const month = (today.getMonth() + 1).toString().padStart(2, '0')
-  const day = today.getDate().toString().padStart(2, '0')
 
   const createdDateISO = '2014-04-01T10:20:30'
   const updatedDate = today
@@ -116,6 +113,8 @@ describe('getDisplayDate', () => {
   it('should get date string when updated in the same year', () => {
     updatedDate.setDate(today.getDate() - 2)
     updatedDate.setFullYear(today.getFullYear())
+    const month = (updatedDate.getMonth() + 1).toString().padStart(2, '0')
+    const day = updatedDate.getDate().toString().padStart(2, '0')
     const updatedDateISO = updatedDate.toISOString()
     expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe(
       month + '/' + day + ' 12:34'

--- a/tests/unit/lib/basic/date.spec.ts
+++ b/tests/unit/lib/basic/date.spec.ts
@@ -94,18 +94,38 @@ describe('getDateRepresentationWithoutSameDate', () => {
 })
 
 describe('getDisplayDate', () => {
-  const dateISO = '2001-04-04T05:20:34'
+  const today = new Date()
+  const year = today.getFullYear().toString()
+  const month = (today.getMonth() + 1).toString().padStart(2, '0')
+  const day = today.getDate().toString().padStart(2, '0')
 
-  it('should get time string when not modified', () => {
-    expect(getDisplayDate(dateISO, dateISO)).toBe('05:20')
+  const createdDateISO = '2014-04-01T10:20:30'
+  const updatedDate = today
+  updatedDate.setHours(12)
+  updatedDate.setMinutes(34)
+
+  it('should say 今日 when updated today', () => {
+    const updatedDateISO = updatedDate.toISOString()
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('今日 12:34')
   })
-  it('should get time string when same date', () => {
-    const dateISO2 = '2001-04-04T08:25:34'
-    expect(getDisplayDate(dateISO, dateISO2)).toBe('08:25')
+  it('should say 昨日 when updated yesterday', () => {
+    updatedDate.setDate(today.getDate() - 1)
+    const updatedDateISO = updatedDate.toISOString()
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('昨日 12:34')
   })
-  it('should get date string when not same date', () => {
-    const dateISO2 = '2001-06-04T08:25:34'
-    expect(getDisplayDate(dateISO, dateISO2)).toBe('06/04 08:25')
+  it('should get date string when updated in the same year', () => {
+    updatedDate.setDate(today.getDate() - 2)
+    updatedDate.setFullYear(today.getFullYear())
+    const updatedDateISO = updatedDate.toISOString()
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe(
+      month + '/' + day + ' 12:34'
+    )
+  })
+  it('should get FULL date string when updated before last year', () => {
+    const updatedDateISO = '2014-05-01T10:20:30'
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe(
+      '2014/05/01 10:20'
+    )
   })
 })
 

--- a/tests/unit/lib/basic/date.spec.ts
+++ b/tests/unit/lib/basic/date.spec.ts
@@ -94,37 +94,27 @@ describe('getDateRepresentationWithoutSameDate', () => {
 })
 
 describe('getDisplayDate', () => {
-  const today = new Date()
+  beforeEach(() => {vi.useFakeTimers()})
+  afterEach(() => {vi.useRealTimers()})
 
-  const createdDateISO = '2014-04-01T10:20:30'
-  const updatedDate = today
-  updatedDate.setHours(12)
-  updatedDate.setMinutes(34)
+  const createdDateISO = '2010-04-01T12:34:56'
+  const updatedDateISO = '2010-05-02T14:28:57'
 
   it('should say 今日 when updated today', () => {
-    const updatedDateISO = updatedDate.toISOString()
-    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('今日 12:34')
+    vi.setSystemTime('2010-05-02T15:00:00')
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('今日 14:28')
   })
   it('should say 昨日 when updated yesterday', () => {
-    updatedDate.setDate(today.getDate() - 1)
-    const updatedDateISO = updatedDate.toISOString()
-    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('昨日 12:34')
+    vi.setSystemTime('2010-05-03T15:00:00')
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('昨日 14:28')
   })
-  it('should get date string when updated in the same year', () => {
-    updatedDate.setDate(today.getDate() - 2)
-    updatedDate.setFullYear(today.getFullYear())
-    const month = (updatedDate.getMonth() + 1).toString().padStart(2, '0')
-    const day = updatedDate.getDate().toString().padStart(2, '0')
-    const updatedDateISO = updatedDate.toISOString()
-    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe(
-      month + '/' + day + ' 12:34'
-    )
+  it('should get MM/DD when updated in the same year', () => {
+    vi.setSystemTime('2010-07-07T15:00:00')
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('05/02 14:28')
   })
-  it('should get FULL date string when updated before last year', () => {
-    const updatedDateISO = '2014-05-01T10:20:30'
-    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe(
-      '2014/05/01 10:20'
-    )
+  it('should get YYYY/MM/DD when updated before last year', () => {
+    vi.setSystemTime('2015-10-10T15:00:00')
+    expect(getDisplayDate(createdDateISO, updatedDateISO)).toBe('2010/05/02 14:28')
   })
 })
 


### PR DESCRIPTION
https://github.com/traPtitech/traQ_S-UI/issues/3746

↑に関連していますが、当初のIssueが求める通りの実装ではありません。
- 去年以前のメッセージには年月日を
- 今年のメッセージには月日のみを
- 昨日と今日のメッセージには『昨日』『今日』と

表示するよう `date.ts`内の関数`getDisplayDate` を書き換えました。
開発環境ではうまくいっているように見えましたが、この変更がtraQに表示されるメッセージの日付以外に影響を与える可能性について把握し切れていないのでレビューをお願いしたいです。

<img width="519" alt="スクリーンショット 2024-07-01 15 56 59" src="https://github.com/traPtitech/traQ_S-UI/assets/169665926/588348f9-e9b6-467a-8719-945c95500f59">