### PR TITLE
change label Git to Gitea

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -43,7 +43,7 @@
         appLink: 'https://drive.trap.jp/'
       },
       {
-        label: 'Git',
+        label: 'Gitea',
         iconPath: 'gitea.svg',
         appLink: 'https://git.trap.jp/'
       },


### PR DESCRIPTION
issue #4278
サービス一覧表示のアイコン上で、GiteaがGitと表示されていたのをGiteaと正しく表示されるようにした。