### PR TITLE
emitの追加によるclosePopupMenuの発火

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderTools.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderTools.vue
@@ -14,6 +14,7 @@
           :channel-id="channelId"
           :show-notification-setting-btn="!channelState.forced"
           :is-archived="channelState.archived"
+          @click-item="closePopupMenu"
         />
       </click-outside>
     </channel-header-tools-list>

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderToolsMenu.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderToolsMenu.vue
@@ -9,18 +9,21 @@
       :disabled="!canToggleQall"
       :data-is-active="$boolAttr(isQallSessionOpened)"
       @click="toggleQall"
+      @click-item="emit('clickItem')"
     />
     <header-tools-menu-item
       v-if="isChildChannelCreatable"
       icon-name="hash"
       label="子チャンネルを作成"
       @click="openChannelCreateModal"
+      @click-item="emit('clickItem')"
     />
     <header-tools-menu-item
       v-if="showNotificationSettingBtn"
       icon-name="notified-or-subscribed"
       label="通知設定"
       @click="openNotificationModal"
+      @click-item="emit('clickItem')"
     />
     <header-tools-menu-item
       v-if="isSearchEnabled"
@@ -28,12 +31,14 @@
       icon-mdi
       label="チャンネル内検索"
       @click="openCommandPalette('search', 'in:here ')"
+      @click-item="emit('clickItem')"
     />
     <header-tools-menu-item
       icon-name="link"
       icon-mdi
       label="チャンネルリンクをコピー"
       @click="copyLink"
+      @click-item="emit('clickItem')"
     />
     <header-tools-menu-item
       v-if="hasChannelEditPermission"
@@ -41,6 +46,7 @@
       :class="$style.manageChannel"
       label="チャンネル管理"
       @click="openChannelManageModal"
+      @click-item="emit('clickItem')"
     />
   </primary-view-header-popup-frame>
 </template>
@@ -59,6 +65,10 @@ import useNotificationModal from './composables/useNotificationModal'
 import { useCommandPalette } from '/@/store/app/commandPalette'
 import useChannelManageModal from './composables/useChannelManageModal'
 import useCopyChannelLink from './composables/useCopyChannelLink'
+
+const emit = defineEmits<{
+  (e: 'clickItem'): void
+}>()
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/Main/MainView/PrimaryViewHeader/PrimaryViewHeaderPopupMenuItem.vue
+++ b/src/components/Main/MainView/PrimaryViewHeader/PrimaryViewHeaderPopupMenuItem.vue
@@ -28,11 +28,13 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'click'): void
+  (f: 'clickItem'): void
 }>()
 
 const onClick = () => {
   if (props.disabled) return
   emit('click')
+  emit('clickItem')
 }
 </script>
 


### PR DESCRIPTION
close #3904 

上部ツールバー部分において、3点ドットを押すとポップアップメニューが開くが同メニュー内のアイテムがクリックされた際にポップアップが閉じられるようにしました。

ポップアップを親コンポーネントとしたとき、メニュー内アイテムが孫コンポーネントに位置していることからemitを多く用いた実装となっています

