### PR TITLE
🐛  fix: スマホでメッセージのスタンプ一覧から開くスタンプピッカーの右側が画面外に出るバグを修正

### DIFF
--- a/src/components/Main/StampPicker/StampPickerContainer.vue
+++ b/src/components/Main/StampPicker/StampPickerContainer.vue
@@ -20,7 +20,7 @@ const style = computed(() => {
   if (alignment.value === 'top-left') {
     return {
       top: `min(calc(100% - ${height + margin}px), ${position.value.y}px)`,
-      left: `${position.value.x}px`
+      left: `min(calc(100% - ${width}px), ${position.value.x}px)`
     }
   }
 


### PR DESCRIPTION
StampPickerContainer.vue で alignment に 'top-left' が指定された場合、スタンプピッカーの右端が画面外に出ないように、 スタンプピッカーの左端の位置を示す left プロパティが画面幅 - スタンプピッカーの幅より大きくならないように修正しました。