### PR TITLE
DM / ホームチャンネルボタン内部で、アイコンだけの表示時に偏らないように

### DIFF
--- a/src/components/Modal/UserModal/FeatureContainer/LinkButton.vue
+++ b/src/components/Modal/UserModal/FeatureContainer/LinkButton.vue
@@ -37,11 +37,11 @@ const { isMobile } = useResponsiveStore()
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+  gap: 4px;
 }
 
 .icon {
   @include color-ui-secondary;
-  margin-right: 4px;
   vertical-align: bottom;
 }
 </style>


### PR DESCRIPTION
margin -> gap で余白の取り方を変えることで、アイコンしか表示されないスマホモード時に表示が偏ることを解消しました

変更前
<img width="146" alt="image" src="https://github.com/user-attachments/assets/cae98fec-e7d8-4fe6-ad8d-314670f2c9f7">

変更後
<img width="133" alt="image" src="https://github.com/user-attachments/assets/31d1ab69-54be-44ed-81b4-e3023940bbd6">