### PR TITLE
カスタムテーマの設定画面にカラーピッカーを設置

### DIFF
--- a/src/views/Settings/ThemeTab.vue
+++ b/src/views/Settings/ThemeTab.vue
@@ -59,6 +59,13 @@
                 :class="$style.input"
               />
               <!-- eslint-enable vue/valid-v-model --->
+              <div>
+                <input
+                  v-model="(val[name as keyof typeof val] as string)"
+                  type="color"
+                  :class="$style.colorInput"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -136,17 +143,22 @@ const resetToDark = () => {
   .color {
     display: flex;
     margin: 4px 0;
+    gap: 0.5rem;
   }
   .name {
     @include color-ui-secondary;
-    margin-right: 8px;
   }
   .input {
     margin-left: auto;
   }
 }
 .resetButtonContainer {
+  margin-top: 1rem;
   display: flex;
   gap: 1rem;
+}
+.colorInput {
+  width: 3rem;
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
chrome
![image](https://github.com/user-attachments/assets/ab78baff-71f6-4138-a037-40b599d2ba1a)
firefox
![image](https://github.com/user-attachments/assets/d74a04c2-8b0d-4fcb-9008-e955b0dc0889)
