### PR TITLE
音声ファイルの音量をデバイス内で同期するように

### DIFF
--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageFileListAudio.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageFileListAudio.vue
@@ -18,6 +18,7 @@
         />
         <AudioPlayerVolumeSlider
           v-model:volume="volume"
+          v-model:is-mute="isMute"
           :class="$style.volumeSlider"
           :disabled="cantPlay"
           keep-expanded
@@ -90,7 +91,7 @@ const {
   isPlaying,
   currentTime,
   duration,
-  volume,
+  volume: { volume, isMute },
   loop,
   isPinPShown,
   startPinP

--- a/src/components/Main/NavigationBar/EphemeralNavigationContent/AudioController/AudioControllerDetailPanel.vue
+++ b/src/components/Main/NavigationBar/EphemeralNavigationContent/AudioController/AudioControllerDetailPanel.vue
@@ -30,6 +30,7 @@
       />
       <AudioPlayerVolumeSlider
         v-model:volume="volume"
+        v-model:is-mute="isMute"
         :class="$style.volumeSlider"
         :disabled="duration === 0"
       />
@@ -55,11 +56,13 @@ const { fileMeta, fileRawPath } = useFileMeta(
   reactive({ fileId: computed(() => fileId.value ?? '') })
 )
 const name = computed(() => fileMeta.value?.name ?? '')
-const { isPlaying, currentTime, duration, volume, loop } = useAudio(
-  fileMeta,
-  fileRawPath,
-  audio
-)
+const {
+  isPlaying,
+  currentTime,
+  duration,
+  volume: { volume, isMute },
+  loop
+} = useAudio(fileMeta, fileRawPath, audio)
 </script>
 
 <style lang="scss" module>

--- a/src/components/UI/AudioPlayer/AudioPlayerVolumeSlider.vue
+++ b/src/components/UI/AudioPlayer/AudioPlayerVolumeSlider.vue
@@ -16,8 +16,8 @@
       :class="$style.icon"
       mdi
       :size="20"
-      :name="volume > 0 ? 'volume-high' : 'volume-off'"
-      @click.prevent="toggleVolume"
+      :name="isMute ? 'volume-off' : 'volume-high'"
+      @click.prevent="isMute = !isMute"
     />
   </div>
 </template>
@@ -29,6 +29,7 @@ import AIcon from '/@/components/UI/AIcon.vue'
 import ASlider from '/@/components/UI/ASlider.vue'
 
 const volume = defineModel<number>('volume', { required: true })
+const isMute = defineModel<boolean>('isMute', { required: true })
 
 withDefaults(
   defineProps<{
@@ -49,9 +50,6 @@ const roundedVolume = computed({
     volume.value = v
   }
 })
-const toggleVolume = () => {
-  roundedVolume.value = volume.value > 0 ? 0 : 100
-}
 </script>
 
 <style lang="scss" module>

--- a/src/components/UI/ChromeAudio.vue
+++ b/src/components/UI/ChromeAudio.vue
@@ -17,6 +17,7 @@
       />
       <AudioPlayerVolumeSlider
         v-model:volume="volume"
+        v-model:is-mute="isMute"
         :class="$style.volumeSlider"
         :disabled="duration === 0"
       />
@@ -62,7 +63,7 @@ const {
   isPlaying,
   currentTime,
   duration,
-  volume,
+  volume: { volume, isMute },
   isPinPShown,
   startPinP
 } = useAudio(fileMeta, fileRawPath)

--- a/src/composables/media/useAudio.ts
+++ b/src/composables/media/useAudio.ts
@@ -1,8 +1,17 @@
 import type { FileInfo } from '@traptitech/traq'
 
 import type { Ref } from 'vue'
-import { computed, onUnmounted, readonly, ref, shallowRef, watch } from 'vue'
+import {
+  computed,
+  onMounted,
+  onUnmounted,
+  readonly,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
 
+import { useMediaSettingsStore } from '/@/store/app/mediaSettings'
 import { useAudioController } from '/@/store/ui/audioController'
 
 import usePictureInPicture from './usePictureInPicture'
@@ -138,11 +147,21 @@ export const useDuration = (audio: Ref<HTMLAudioElement | undefined>) => {
 }
 
 const useVolume = (audio: Ref<HTMLAudioElement | undefined>) => {
-  const nativeVolume = ref(toFinite(audio.value?.volume, 1))
+  const { audioVolume, restoringPromise } = useMediaSettingsStore()
+
+  onMounted(async () => {
+    await restoringPromise
+    setVolume(toFinite(audioVolume.value, 1))
+  })
+
+  const setVolume = (v: number) => {
+    if (audio.value) audio.value.volume = v
+    audioVolume.value = v
+  }
 
   const onVolumeChange = () => {
     if (!audio.value) return
-    nativeVolume.value = toFinite(audio.value.volume, 1)
+    setVolume(toFinite(audio.value.volume, audioVolume.value ?? 1))
   }
 
   watch(
@@ -152,7 +171,7 @@ const useVolume = (audio: Ref<HTMLAudioElement | undefined>) => {
         oldAudio.removeEventListener('volumechange', onVolumeChange)
       }
       if (newAudio) {
-        nativeVolume.value = toFinite(newAudio.volume, 1)
+        setVolume(toFinite(audioVolume.value, 1))
         newAudio.addEventListener('volumechange', onVolumeChange)
       }
     },
@@ -161,7 +180,7 @@ const useVolume = (audio: Ref<HTMLAudioElement | undefined>) => {
 
   const volume = computed<number>({
     get() {
-      return nativeVolume.value
+      return audioVolume.value ?? 1
     },
     set(v) {
       if (!audio.value) return

--- a/src/composables/media/useAudio.ts
+++ b/src/composables/media/useAudio.ts
@@ -3,12 +3,12 @@ import type { FileInfo } from '@traptitech/traq'
 import type { Ref } from 'vue'
 import {
   computed,
-  onMounted,
   onUnmounted,
   readonly,
   ref,
   shallowRef,
-  watch
+  watch,
+  watchEffect
 } from 'vue'
 
 import { useMediaSettingsStore } from '/@/store/app/mediaSettings'
@@ -147,33 +147,29 @@ export const useDuration = (audio: Ref<HTMLAudioElement | undefined>) => {
 }
 
 const useVolume = (audio: Ref<HTMLAudioElement | undefined>) => {
-  const { audioVolume, restoringPromise } = useMediaSettingsStore()
+  const { audioVolume } = useMediaSettingsStore()
+  const isMute = ref(audio.value?.muted ?? false)
 
-  onMounted(async () => {
-    await restoringPromise
-    setVolume(toFinite(audioVolume.value, 1))
+  // ストア音量とミュートをaudio要素へ常に反映する
+  // 要素の差し替え・他プレイヤーによるストア変更・restore完了のいずれにも自動で追従する
+  watchEffect(() => {
+    if (!audio.value) return
+    audio.value.volume = audioVolume.value ?? 1
+    audio.value.muted = isMute.value
   })
 
-  const setVolume = (v: number) => {
-    if (audio.value) audio.value.volume = v
-    audioVolume.value = v
-  }
-
+  // ネイティブコントロール(<audio controls>)側の変更を取り込む
   const onVolumeChange = () => {
     if (!audio.value) return
-    setVolume(toFinite(audio.value.volume, audioVolume.value ?? 1))
+    audioVolume.value = toFinite(audio.value.volume, audioVolume.value ?? 1)
+    isMute.value = audio.value.muted
   }
 
   watch(
     audio,
     (newAudio, oldAudio) => {
-      if (oldAudio) {
-        oldAudio.removeEventListener('volumechange', onVolumeChange)
-      }
-      if (newAudio) {
-        setVolume(toFinite(audioVolume.value, 1))
-        newAudio.addEventListener('volumechange', onVolumeChange)
-      }
+      oldAudio?.removeEventListener('volumechange', onVolumeChange)
+      newAudio?.addEventListener('volumechange', onVolumeChange)
     },
     { immediate: true }
   )
@@ -183,11 +179,10 @@ const useVolume = (audio: Ref<HTMLAudioElement | undefined>) => {
       return audioVolume.value ?? 1
     },
     set(v) {
-      if (!audio.value) return
-      audio.value.volume = v / 100
+      audioVolume.value = v / 100
     }
   })
-  return volume
+  return { volume, isMute }
 }
 
 const useLoop = (audio: Ref<HTMLAudioElement | undefined>) => {

--- a/src/store/app/mediaSettings.ts
+++ b/src/store/app/mediaSettings.ts
@@ -1,0 +1,41 @@
+import { toRefs } from 'vue'
+
+import { acceptHMRUpdate, defineStore } from 'pinia'
+
+import useIndexedDbValue from '/@/composables/storage/useIndexedDbValue'
+import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
+
+export type IDBState = {
+  audioVolume: Readonly<number> | undefined
+  videoVolume: Readonly<number> | undefined
+}
+
+const useMediaSettingsStorePinia = defineStore('app/mediaSettings', () => {
+  const initialValue: IDBState = {
+    audioVolume: 1,
+    videoVolume: 1
+  }
+
+  const [state, restoring, restoringPromise] = useIndexedDbValue(
+    'store/app/mediaSettings',
+    1,
+    {},
+    initialValue
+  )
+
+  return {
+    ...toRefs(state),
+    restoring,
+    restoringPromise
+  }
+})
+
+export const useMediaSettingsStore = convertToRefsStore(
+  useMediaSettingsStorePinia
+)
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useMediaSettingsStorePinia, import.meta.hot)
+  )
+}

--- a/src/store/app/mediaSettings.ts
+++ b/src/store/app/mediaSettings.ts
@@ -7,13 +7,11 @@ import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 
 export type IDBState = {
   audioVolume: Readonly<number> | undefined
-  videoVolume: Readonly<number> | undefined
 }
 
 const useMediaSettingsStorePinia = defineStore('app/mediaSettings', () => {
   const initialValue: IDBState = {
-    audioVolume: 1,
-    videoVolume: 1
+    audioVolume: 1
   }
 
   const [state, restoring, restoringPromise] = useIndexedDbValue(

--- a/src/store/app/mediaSettings.ts
+++ b/src/store/app/mediaSettings.ts
@@ -5,12 +5,12 @@ import { acceptHMRUpdate, defineStore } from 'pinia'
 import useIndexedDbValue from '/@/composables/storage/useIndexedDbValue'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 
-export type IDBState = {
+export type State = {
   audioVolume: Readonly<number> | undefined
 }
 
 const useMediaSettingsStorePinia = defineStore('app/mediaSettings', () => {
-  const initialValue: IDBState = {
+  const initialValue: State = {
     audioVolume: 1
   }
 

--- a/src/store/domain/me.ts
+++ b/src/store/domain/me.ts
@@ -13,12 +13,12 @@ import { wsListener } from '/@/lib/websocket'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import type { UserId } from '/@/types/entity-ids'
 
-export type IDBState = {
+export type State = {
   detail: Readonly<MyUserDetail> | undefined
 }
 
 const useMeStorePinia = defineStore('domain/me', () => {
-  const initialValue: IDBState = {
+  const initialValue: State = {
     detail: undefined
   }
   const router = useRouter()

--- a/src/sw/store.ts
+++ b/src/sw/store.ts
@@ -1,7 +1,7 @@
 import { promisifyRequest } from 'idb-keyval'
 
 import { key, storeName } from '/@/composables/storage/useIndexedDbValue'
-import type { IDBState } from '/@/store/domain/me'
+import type { State } from '/@/store/domain/me'
 
 import { dbPrefix } from '../lib/storage/indexedDb'
 
@@ -9,7 +9,7 @@ export const getMeStore = async () => {
   try {
     const openReq = indexedDB.open(`${dbPrefix}store/domain/me`)
     const db = await promisifyRequest(openReq)
-    const getReq: IDBRequest<IDBState> = db
+    const getReq: IDBRequest<State> = db
       .transaction(storeName)
       .objectStore(storeName)
       .get(key)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 音量スライダーのミュート切り替えを追加し、ミュート状態をUIへ反映しました。
  * 音量設定とミュート状態を保存し、次回以降も維持されます。
* **改善**
  * ミュート表示と音量操作の連動を整理し、オーディオ再生コントロール全体で操作の一貫性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->