### PR TITLE
feat: ogp cache を message ごとに分割してブラウザにキャッシュさせるように

### DIFF
--- a/src/store/domain/messagesView.ts
+++ b/src/store/domain/messagesView.ts
@@ -66,7 +66,8 @@ const useMessagesViewPinia = defineStore('domain/messagesView', () => {
       .map(async e => {
         try {
           await messagesStore.fetchOgpData({
-            url: e.url
+            url: e.url,
+            messageId
           })
         } catch {
           // TODO: エラー処理、無効な埋め込みの扱いを考える必要あり

--- a/src/views/Settings/ThemeTab.vue
+++ b/src/views/Settings/ThemeTab.vue
@@ -61,7 +61,7 @@
               <!-- eslint-enable vue/valid-v-model --->
               <div>
                 <input
-                  v-model="(val[name as keyof typeof val] as string)"
+                  v-model="val[name as keyof typeof val] as string"
                   type="color"
                   :class="$style.colorInput"
                 />


### PR DESCRIPTION
## モチベーション

今 `DELETE /ogp/cache` したとしてもブラウザのネットワークキャッシュとして OGP のキャッシュが残っており、一度取得してしまうと通常の max-age (1週間？) が終わるまで更新されなくなる。これを直したい。

## 解決策

この問題にはいくつか解決策が考えられるが、比較的実装が容易な URL のキャッシュキーを変えるという方法を用いた。`GET /ogp?url=...` で OGP を取得しているところを `GET /ogp?url=...&message=...` とすることでメッセージごとにキャッシュキーを変えた。

この変更によってサーバー側のキャッシュが消えてから投稿されたメッセージに関しては OGP が再取得されるようになる。弊害として特にキャッシュの削除を行っていない場合でも異なるメッセージではリクエストが飛んでしまうが、サーバー側のキャッシュにはヒットする上、このようなケースは比較的稀なので問題ないと判断した。