### PR TITLE
ボタン内部の要素が中央揃えになるように戻した

### DIFF
--- a/src/components/UI/FormButton.vue
+++ b/src/components/UI/FormButton.vue
@@ -106,6 +106,7 @@ const spinnerColor = computed(() => {
 .label {
   display: flex;
   align-items: center;
+  justify-items: center;
   gap: 8px;
   margin: 8px 32px;
   .container[data-is-loading] & {


### PR DESCRIPTION
v3.22.0 以前
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/d86cf0fe-9e83-4690-b8d1-98f0e1db2b07" />

 v3.22.0 での変更後
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/2e41a1ff-f363-4c39-920e-0f7eddead5b1" />

となっていたが、これは `display: flex;` の追加とボタン幅指定が重なった結果だった
そのため、ここに `justify-items: center;` を追加してもとの表示と同じようにした