### PR TITLE
メッセージ入力欄でのサジェストにチャンネル名補完を追加

### DIFF
--- a/src/lib/suggestion.ts
+++ b/src/lib/suggestion.ts
@@ -11,7 +11,7 @@ export const getCurrentWord = (
   text: string
 ): Target => {
   const startIndex = elm.selectionStart
-  const nearest = lastIndexOf(text, ['@', ':', '.'], startIndex - 1)
+  const nearest = lastIndexOf(text, ['@', ':', '.', '#'], startIndex - 1)
   const prevSpaceIndex = lastIndexOf(text, [' ', '　'], startIndex - 1)
   if (prevSpaceIndex > nearest) {
     return { word: '', begin: 0, end: 0 }


### PR DESCRIPTION
## なぜやるか

- closes #4435
  - feedback: https://q.trap.jp/messages/01943eba-b2ea-7f8c-9dd8-e905d0719989

## やったこと

- 補完候補にチャンネル名を追加
  - 投稿後リンクにパースされるのは省略していない完全表記(x: #g/t/d_tteiu8383, o: #gps/times/d_etteiu8383)なので、完全表記のみを候補に追加しています
- 補完トリガーに`#`を追加
  - 全角の`＠`を自動で半角`@`に変換する処理があったため、全角`＃`も同様に半角`#`に変換するようにしています
  - スマホ等では半角`#`の入力が難しい場合もあるため、この仕様の方がUX的に良さそうと判断しました

## Preview

![20250108154935](https://github.com/user-attachments/assets/ed75529b-ac90-4d3a-8a12-6e7f57b11627)
