### PR TITLE
サムネイル画像の表示を修正

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageFileList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileList.vue
@@ -58,12 +58,7 @@ const showLargeImage = computed(() => fileMetaDataState.images.length === 1)
 .imageContainer {
   display: flex;
   flex-flow: row wrap;
-}
-.imageItem {
-  margin-bottom: 16px;
-  &:not(:last-child) {
-    margin-right: 16px;
-  }
+  gap: 16px;
 }
 .item {
   flex-shrink: 0;

--- a/src/components/Main/MainView/MessageElement/MessageFileList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileList.vue
@@ -7,7 +7,6 @@
         :channel-id="channelId"
         :file-id="meta.id"
         :is-large="showLargeImage"
-        :class="$style.imageItem"
       />
     </div>
     <message-file-list-video
@@ -61,7 +60,6 @@ const showLargeImage = computed(() => fileMetaDataState.images.length === 1)
   flex-flow: row wrap;
 }
 .imageItem {
-  flex-shrink: 0;
   margin-bottom: 16px;
   &:not(:last-child) {
     margin-right: 16px;

--- a/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/MessageFileListImage.vue
@@ -1,30 +1,28 @@
 <template>
-  <div>
-    <template v-if="canShow">
-      <router-link v-if="isLarge" :to="fileLink" :class="$style.largeContainer">
-        <!--
+  <template v-if="canShow">
+    <router-link v-if="isLarge" :to="fileLink" :class="$style.largeContainer">
+      <!--
         height, widthはlayout shift対策
         https://www.mizdra.net/entry/2020/05/31/192613
       -->
-        <img
-          draggable="false"
-          :alt="name"
-          :src="fileThumbnailPath"
-          :height="fileThumbnailSize.height"
-          :width="fileThumbnailSize.width"
-        />
-        <play-icon v-if="isAnimatedImage" :class="$style.playIcon" />
-      </router-link>
-      <router-link v-else :to="fileLink" :class="$style.container">
-        <!--
+      <img
+        draggable="false"
+        :alt="name"
+        :src="fileThumbnailPath"
+        :height="fileThumbnailSize.height"
+        :width="fileThumbnailSize.width"
+      />
+      <play-icon v-if="isAnimatedImage" :class="$style.playIcon" />
+    </router-link>
+    <router-link v-else :to="fileLink" :class="$style.container">
+      <!--
         CSSで固定値指定なのでheight, widthはつけない
       -->
-        <img draggable="false" :alt="name" :src="fileThumbnailPath" />
-        <play-icon v-if="isAnimatedImage" :class="$style.playIcon" />
-      </router-link>
-    </template>
-    <div v-else :class="$style.container">表示できない画像です</div>
-  </div>
+      <img draggable="false" :alt="name" :src="fileThumbnailPath" />
+      <play-icon v-if="isAnimatedImage" :class="$style.playIcon" />
+    </router-link>
+  </template>
+  <div v-else :class="$style.container">表示できない画像です</div>
 </template>
 
 <script lang="ts" setup>
@@ -56,6 +54,7 @@ const {
 
 <style lang="scss" module>
 .container {
+  flex-shrink: 0;
   position: relative;
   width: 240px;
   max-width: 100%;
@@ -75,6 +74,7 @@ const {
   }
 }
 .largeContainer {
+  flex-shrink: 0;
   position: relative;
   display: flex;
   border-radius: 6px;


### PR DESCRIPTION
fix #4502

# やったこと

- #4391 の変更により埋め込まれていたバグの修正
    - `width` の指定されていない flex 扱いの `div` タブ内部で `flex-shrink: 0;` が適用されていたのが今回の原因だと考えました
    - そのため、 `div` を使わなくても実装できるように CSS の書く位置を変更しました
    - `flex-shrink: 0;` 自体あまり書かなくてもいいのかな〜とは思ったので、ここはご意見を伺いたいです
- `:not(:last-child)` を使って適用されていた margin を、 gap に置き換えることもしました