### PR TITLE
test: changed timezone for tests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -129,6 +129,9 @@ export default defineConfig(({ command, mode }) => ({
     brotli()
   ],
   test: {
+    env: {
+      TZ: 'UTC'
+    },
     include: ['tests/unit/**/*.spec.ts'],
     globals: true,
     setupFiles: ['tests/unit/setup.ts', 'tests/unit/expectExtends.ts'],


### PR DESCRIPTION
fix #4416

https://vitest.dev/config/#env を見て、それに合うように `vite.config.ts` に追記しました