### PR TITLE
✨ feat: プロフィールアイコン変更モーダルのアイコン変更処理に画像サイズの圧縮処理を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@traptitech/traq": "^3.20.1-1",
         "@traptitech/traq-markdown-it": "^6.3.0",
         "autosize": "^6.0.1",
+        "browser-image-compression": "^2.0.2",
         "cropperjs": "^1.6.2",
         "deepmerge": "^4.3.1",
         "dequal": "^2.0.3",
@@ -5488,6 +5489,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -11911,6 +11921,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@traptitech/traq": "^3.20.1-1",
     "@traptitech/traq-markdown-it": "^6.3.0",
     "autosize": "^6.0.1",
+    "browser-image-compression": "^2.0.2",
     "cropperjs": "^1.6.2",
     "deepmerge": "^4.3.1",
     "dequal": "^2.0.3",

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -43,8 +43,9 @@ const useIconImageEdit = (iconImage: Ref<File>) => {
     if (!iconImage.value) return
     isEditing.value = true
     try {
-      // `maxSizeMB`に2以下の値を設定し、画像を2MB以下にしても400が返ってくる
-      // `maxWidthOrHeight: 1920`を設定すると、`maxSizeMB`を設定した場合より画像容量が大きい場合でも正常にアイコンが設定できる。
+      // `PUT users/me/icon`は、swaggerでは2MBまでのpng, jpeg, gifとあるが、
+      // 実際にはそれに加えて2560*1600のピクセル数制限があるため、
+      // 2MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。
       const compressionOptions = {
         maxSizeMB: 2,
         maxWidthOrHeight: 1920,

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -43,6 +43,8 @@ const useIconImageEdit = (iconImage: Ref<File>) => {
     if (!iconImage.value) return
     isEditing.value = true
     try {
+      // `maxSizeMB`に2以下の値を設定し、画像を2MB以下にしても400が返ってくる
+      // `maxWidthOrHeight: 1920`を設定すると、`maxSizeMB`を設定した場合より画像容量が大きい場合でも正常にアイコンが設定できる。
       const compressionOptions = {
         maxWidthOrHeight: 1920,
         useWebWorker: true

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -25,6 +25,7 @@ import FormButton from '/@/components/UI/FormButton.vue'
 import ModalFrame from '../Common/ModalFrame.vue'
 import { useModalStore } from '/@/store/ui/modal'
 import ImageUpload from '/@/components/Settings/ImageUpload.vue'
+import imageCompression from 'browser-image-compression'
 
 const props = defineProps<{
   file: File
@@ -42,7 +43,15 @@ const useIconImageEdit = (iconImage: Ref<File>) => {
     if (!iconImage.value) return
     isEditing.value = true
     try {
-      await apis.changeMyIcon(iconImage.value)
+      const compressionOptions = {
+        maxWidthOrHeight: 1920,
+        useWebWorker: true
+      }
+      const compressedImage = await imageCompression(
+        iconImage.value,
+        compressionOptions
+      )
+      await apis.changeMyIcon(compressedImage)
 
       addSuccessToast('アイコン画像を変更しました')
     } catch (e) {

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -46,6 +46,7 @@ const useIconImageEdit = (iconImage: Ref<File>) => {
       // `maxSizeMB`に2以下の値を設定し、画像を2MB以下にしても400が返ってくる
       // `maxWidthOrHeight: 1920`を設定すると、`maxSizeMB`を設定した場合より画像容量が大きい場合でも正常にアイコンが設定できる。
       const compressionOptions = {
+        maxSizeMB: 2,
         maxWidthOrHeight: 1920,
         useWebWorker: true
       }


### PR DESCRIPTION
`maxSizeMB`に2以下の値を設定し、画像を2MB以下にしても400が返ってくるが、`maxWidthOrHeight: 1920`を設定すると、`maxSizeMB`を設定した場合より画像容量が大きい場合でも正常にアイコンが設定できる。

`PUT users/me/icon`は、swaggerでは2MBまでのpng, jpeg, gifとあるが、実際にはそれに加えて2560*1600のピクセル数制限があるため、2MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。