### PR TITLE
ダークモード時のフラッシュを防ぐ

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,17 @@
     />
     <title>traQ</title>
 
+    <style>
+      /*
+        ダークモード時のフラッシュを防ぐために、
+        テーマ読み込み前はcolor-schemeごとのbackground primaryを表示する
+      */
+      body {
+        color-scheme: light dark;
+        background-color: Canvas;
+      }
+    </style>
+
     <link href="/fonts/fonts.css" rel="stylesheet" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"


### PR DESCRIPTION
ダークモードで白が表示される方が、ライトモードで黒が表示されるより辛いのでデフォルトの背景色をcolor-schemeによって出しわけるようにしました。

外部CSSを読み込む前に背景色を表示しておきたいのでindex.htmlに直接書いたんですが他に良い方法があれば教えてほしいです。

>【サービス】traQ
【何をしたか】テーマをOS準拠にして端末がダークモードのときにtraQを開いた
【期待する動作】暗いまま使用できる
【実際の動作】デフォルトの白背景が一瞬表示されてまぶしい
https://q.trap.jp/messages/019696cc-6430-7051-9a18-9f284d75a483
