### PR TITLE
Revert "最新メッセージを読み込んだときにスクロールが上に吹き飛ぶ問題を修正"

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelViewContent/ChannelViewContentMain.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent/ChannelViewContentMain.vue
@@ -86,9 +86,6 @@ const {
   onLoadAroundMessagesRequest
 } = useChannelMessageFetcher(scrollerEle, props)
 
-const { unreadChannelsMap, deleteUnreadChannelWithSend } =
-  useSubscriptionStore()
-
 const { messagesMap } = useMessagesStore()
 const firstUnreadMessageId = computed(() => {
   if (!unreadSince.value) return ''
@@ -117,18 +114,9 @@ const messagePinnedUserMap = computed(
   () => new Map(props.pinnedMessages.map(pin => [pin.message.id, pin.userId]))
 )
 
+const { unreadChannelsMap } = useSubscriptionStore()
 const resetIsReachedLatest = () => {
-  const unread = unreadChannelsMap.value.get(props.channelId)
-  if (unread === undefined) return
-  //最後まで読み込まれている時は「ここから未読」の位置を修正し、未読を消す。
-  //TODO: 関数名とやってることが違いすぎるので、どうにかする。今日はもう眠いので寝る。
-  if (
-    unread.updatedAt ===
-    messagesMap.value.get(messageIds.value.at(-1) ?? '')?.createdAt
-  ) {
-    unreadSince.value = unread.since
-    deleteUnreadChannelWithSend(props.channelId)
-  }
+  if (!unreadChannelsMap.value.get(props.channelId)) return
   isReachedLatest.value = false
 }
 

--- a/src/components/Main/MainView/ChannelView/ChannelViewContent/ChannelViewContentMain.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent/ChannelViewContentMain.vue
@@ -12,7 +12,7 @@
       @request-load-former="onLoadFormerMessagesRequest"
       @request-load-latter="onLoadLatterMessagesRequest"
       @scroll-passive="handleScroll"
-      @window-viewed="onWindowViewed"
+      @reset-is-reached-latest="resetIsReachedLatest"
     >
       <template #default="{ messageId, onChangeHeight, onEntryMessageLoaded }">
         <messages-scroller-separator
@@ -117,10 +117,11 @@ const messagePinnedUserMap = computed(
   () => new Map(props.pinnedMessages.map(pin => [pin.message.id, pin.userId]))
 )
 
-const onWindowViewed = () => {
+const resetIsReachedLatest = () => {
   const unread = unreadChannelsMap.value.get(props.channelId)
   if (unread === undefined) return
   //最後まで読み込まれている時は「ここから未読」の位置を修正し、未読を消す。
+  //TODO: 関数名とやってることが違いすぎるので、どうにかする。今日はもう眠いので寝る。
   if (
     unread.updatedAt ===
     messagesMap.value.get(messageIds.value.at(-1) ?? '')?.createdAt

--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -191,6 +191,7 @@ watch(
   (ids, prevIds) => {
     if (!rootRef.value) return
     /* state.height の更新を忘れないようにすること */
+
     const newHeight = rootRef.value.scrollHeight
     if (
       props.lastLoadingDirection === 'latest' ||
@@ -205,6 +206,7 @@ watch(
       if (ids.length - prevIds.length === 0) {
         const scrollBottom =
           rootRef.value.scrollTop + rootRef.value.clientHeight
+
         // 一番下のメッセージあたりを見ているときに、
         // 新規に一つ追加された場合は一番下までスクロール
         if (state.height - 50 <= scrollBottom) {
@@ -244,27 +246,16 @@ const requestLoadMessages = () => {
 const handleScroll = throttle(17, requestLoadMessages)
 
 const visibilitychangeListener = () => {
-  emit('resetIsReachedLatest')
   if (document.visibilityState === 'visible') {
-    nextTick(requestLoadMessages)
+    requestLoadMessages()
   }
-}
-const focusListener = () => {
-  emit('resetIsReachedLatest')
-  nextTick(requestLoadMessages)
-}
-const blurListener = () => {
   emit('resetIsReachedLatest')
 }
 onMounted(() => {
   document.addEventListener('visibilitychange', visibilitychangeListener)
-  window.addEventListener('focus', focusListener)
-  window.addEventListener('blur', blurListener)
 })
 onUnmounted(() => {
   document.removeEventListener('visibilitychange', visibilitychangeListener)
-  window.removeEventListener('focus', focusListener)
-  window.removeEventListener('blur', blurListener)
 })
 
 const { onClick } = useMarkdownInternalHandler()

--- a/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
+++ b/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
@@ -112,6 +112,10 @@ const useMessageFetcher = (
         isLoading.value = false
         isInitialLoad.value = false
         lastLoadingDirection.value = 'latter'
+        // 一番新しいメッセージに達した時は`latest`にする
+        if (isReachedLatest.value) {
+          lastLoadingDirection.value = 'latest'
+        }
         messageIds.value = [...new Set([...messageIds.value, ...newMessageIds])]
       }
     )

--- a/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
+++ b/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
@@ -112,10 +112,6 @@ const useMessageFetcher = (
         isLoading.value = false
         isInitialLoad.value = false
         lastLoadingDirection.value = 'latter'
-        // 一番新しいメッセージに達した時は`latest`にする
-        if (isReachedLatest.value) {
-          lastLoadingDirection.value = 'latest'
-        }
         messageIds.value = [...new Set([...messageIds.value, ...newMessageIds])]
       }
     )

--- a/src/components/Main/MainView/QallView/QallMessageView.vue
+++ b/src/components/Main/MainView/QallView/QallMessageView.vue
@@ -38,18 +38,9 @@ const isArchived = computed(
 
 const { unreadChannelsMap, deleteUnreadChannelWithSend } =
   useSubscriptionStore()
-const onWindowViewed = () => {
-  const unread = unreadChannelsMap.value.get(props.channelId)
-  if (unread === undefined) return
-  //最後まで読み込まれている時は「ここから未読」の位置を修正し、未読を消す。
-  if (
-    unread.updatedAt ===
-    messagesMap.value.get(messageIds.value.at(-1) ?? '')?.createdAt
-  ) {
-    unreadSince.value = unread.since
-    deleteUnreadChannelWithSend(props.channelId)
-  }
-  isReachedLatest.value = false
+
+const resetIsReachedLatest = () => {
+  if (!unreadChannelsMap.value.get(props.channelId)) return
 }
 
 const showToNewMessageButton = ref(false)
@@ -104,7 +95,7 @@ const handleScroll = () => {
               @request-load-former="onLoadFormerMessagesRequest"
               @request-load-latter="onLoadLatterMessagesRequest"
               @scroll-passive="handleScroll"
-              @window-viewed="onWindowViewed"
+              @reset-is-reached-latest="resetIsReachedLatest"
             >
               <template
                 #default="{ messageId, onChangeHeight, onEntryMessageLoaded }"

--- a/src/composables/useCurrentViewers.ts
+++ b/src/composables/useCurrentViewers.ts
@@ -18,11 +18,7 @@ const useCurrentViewers = (channelId: Ref<ChannelId>) => {
    */
   const activeViewingUsers = computed(() =>
     currentViewers.value
-      .filter(
-        v =>
-          v.state === ChannelViewState.Monitoring ||
-          v.state === ChannelViewState.Editing
-      )
+      .filter(v => v.state === ChannelViewState.Monitoring)
       .map(v => v.userId)
   )
 


### PR DESCRIPTION
This reverts commit 68d238f3e8c5616d6328a183c10e387f796ebbd2.

* チャンネルを開いたときのスクロール位置がブラウザ依存でおかしくなってしまっていたので修正