### PR TITLE
feat: スタンプの作成に画像のサイズダウン処理を追加

### DIFF
--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -18,14 +18,14 @@
 </template>
 
 <script lang="ts" setup>
+import imageCompression, { type Options } from 'browser-image-compression'
 import { ref, type Ref } from 'vue'
-import apis, { formatResizeError } from '/@/lib/apis'
-import { useToastStore } from '/@/store/ui/toast'
-import FormButton from '/@/components/UI/FormButton.vue'
 import ModalFrame from '../Common/ModalFrame.vue'
-import { useModalStore } from '/@/store/ui/modal'
 import ImageUpload from '/@/components/Settings/ImageUpload.vue'
-import imageCompression from 'browser-image-compression'
+import FormButton from '/@/components/UI/FormButton.vue'
+import apis, { formatResizeError } from '/@/lib/apis'
+import { useModalStore } from '/@/store/ui/modal'
+import { useToastStore } from '/@/store/ui/toast'
 
 const props = defineProps<{
   file: File
@@ -46,7 +46,7 @@ const useIconImageEdit = (iconImage: Ref<File>) => {
       // `PUT users/me/icon`は、swaggerでは2MBまでのpng, jpeg, gifとあるが、
       // 実際にはそれに加えて2560*1600のピクセル数制限があるため、
       // 2MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。
-      const compressionOptions = {
+      const compressionOptions: Options = {
         maxSizeMB: 2,
         maxWidthOrHeight: 1920,
         useWebWorker: true

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import imageCompression from 'browser-image-compression'
+import imageCompression, { type Options } from 'browser-image-compression'
 import { ref, type Ref } from 'vue'
 import ModalFrame from '../Common/ModalFrame.vue'
 import ImageUpload from '/@/components/Settings/ImageUpload.vue'
@@ -44,7 +44,7 @@ const compressIconImage = async () => {
   // `PUT users/me/icon`は、swaggerでは2MBまでのpng, jpeg, gifとあるが、
   // 実際にはそれに加えて2560*1600のピクセル数制限があるため、
   // 2MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。
-  const compressionOptions = {
+  const compressionOptions: Options = {
     maxSizeMB: 2,
     maxWidthOrHeight: 1920,
     useWebWorker: true

--- a/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
+++ b/src/components/Modal/ProfileIconEditModal/ProfileIconEditModal.vue
@@ -46,7 +46,7 @@ const compressIconImage = async () => {
   // 2MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。
   const compressionOptions: Options = {
     maxSizeMB: 2,
-    maxWidthOrHeight: 1920,
+    maxWidthOrHeight: 2000,
     useWebWorker: true
   }
   iconImage.value = await imageCompression(iconImage.value, compressionOptions)

--- a/src/components/Modal/StampCreateModal/StampImageEdit.vue
+++ b/src/components/Modal/StampCreateModal/StampImageEdit.vue
@@ -15,13 +15,14 @@
 </template>
 
 <script lang="ts" setup>
+import imageCompression, { type Options } from 'browser-image-compression'
 import { ref, type Ref } from 'vue'
-import { formatResizeError } from '/@/lib/apis'
-import { useToastStore } from '/@/store/ui/toast'
+import ImageUpload from '/@/components/Settings/ImageUpload.vue'
 import { imageSize } from '/@/components/Settings/StampTab/imageSize'
 import FormButton from '/@/components/UI/FormButton.vue'
+import { formatResizeError } from '/@/lib/apis'
 import { useModalStore } from '/@/store/ui/modal'
-import ImageUpload from '/@/components/Settings/ImageUpload.vue'
+import { useToastStore } from '/@/store/ui/toast'
 
 const props = defineProps<{
   file: File
@@ -33,6 +34,17 @@ const emit = defineEmits<{
 const { popModal } = useModalStore()
 
 const stampImage = ref<File>(props.file)
+
+const compressStampImage = async () => {
+  const compressionOptions: Options = {
+    maxSizeMB: 1,
+    useWebWorker: true
+  }
+  stampImage.value = await imageCompression(
+    stampImage.value,
+    compressionOptions
+  )
+}
 
 const useCheckStamp = (stampImage: Ref<File>) => {
   const { addErrorToast } = useToastStore()
@@ -47,6 +59,7 @@ const useCheckStamp = (stampImage: Ref<File>) => {
         addErrorToast('画像が正方形ではありません。編集してください')
         return
       }
+      await compressStampImage()
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error('画像の整形に失敗しました', e)

--- a/src/components/Modal/StampCreateModal/StampImageEdit.vue
+++ b/src/components/Modal/StampCreateModal/StampImageEdit.vue
@@ -36,8 +36,17 @@ const { popModal } = useModalStore()
 const stampImage = ref<File>(props.file)
 
 const compressStampImage = async () => {
+  // jpeg, png, webp, bmp のみが`imageCompression`で圧縮できる
+  const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/bmp']
+  if (!allowedTypes.includes(stampImage.value.type)) {
+    return
+  }
+  // `POST /stamps`は、swaggerでは1MBまでのpng, jpeg, gifとあるが、
+  // 実際にはそれに加えて2560*1600のピクセル数制限があるため、
+  // 1MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。
   const compressionOptions: Options = {
     maxSizeMB: 1,
+    maxWidthOrHeight: 2000,
     useWebWorker: true
   }
   stampImage.value = await imageCompression(


### PR DESCRIPTION
`POST /stamps`は、swaggerでは1MBまでのpng, jpeg, gifとあるが、実際にはそれに加えて2560*1600のピクセル数制限があるため、2MBの制限に加えて`maxWidthOrHeight`の制約が必要になる。