### PR TITLE
fix: 設定画面を開いて閉じた後、スタンプピッカーを開いてピッカー内の任意の場所をクリックすると、スタンプピッカーが閉じられるバグの修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
     </router-view>
     <modal-container />
     <toast-container />
+    <stamp-picker-container />
   </div>
 </template>
 
@@ -86,6 +87,7 @@ ${Object.entries(style.value)
 <script lang="ts" setup>
 import ToastContainer from '/@/components/Toast/ToastContainer.vue'
 import ModalContainer from '/@/components/Modal/ModalContainer.vue'
+import StampPickerContainer from '/@/components/Main/StampPicker/StampPickerContainer.vue'
 
 useTts()
 

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -36,7 +36,6 @@
         <div id="sidebar-mobile" :class="$style.sidebarPortal" />
       </div>
     </div>
-    <stamp-picker-container />
     <command-palette-container />
   </div>
 </template>
@@ -119,7 +118,6 @@ const NotFoundPage = defineAsyncComponent(
 import MainView from '/@/components/Main/MainView/MainView.vue'
 import MainViewFrame from '/@/components/Main/MainView/MainViewFrame.vue'
 import NavigationBar from '/@/components/Main/NavigationBar/NavigationBar.vue'
-import StampPickerContainer from '/@/components/Main/StampPicker/StampPickerContainer.vue'
 import CommandPaletteContainer from '/@/components/Main/CommandPalette/CommandPaletteContainer.vue'
 import useViewStateSender from './composables/useViewStateSender'
 

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -6,7 +6,6 @@
     <desktop-setting-modal v-else>
       <router-view />
     </desktop-setting-modal>
-    <StampPickerContainer />
   </div>
   <div v-else></div>
 </template>
@@ -19,7 +18,6 @@ import { RouteName } from '/@/router'
 import { defaultSettingsName } from '/@/router/settings'
 import { useResponsiveStore } from '/@/store/ui/responsive'
 import useLoginCheck from './composables/useLoginCheck'
-import StampPickerContainer from '../components/Main/StampPicker/StampPickerContainer.vue'
 
 const useSettingsRootPathWatcher = (
   isMobile: Ref<boolean>,

--- a/src/views/ShareTargetPage.vue
+++ b/src/views/ShareTargetPage.vue
@@ -1,13 +1,11 @@
 <template>
   <div :class="$style.container">
     <share-target-component :title="title" :text="text" :url="url" />
-    <stamp-picker-container />
   </div>
 </template>
 
 <script lang="ts" setup>
 import ShareTargetComponent from '/@/components/ShareTarget/ShareTarget.vue'
-import StampPickerContainer from '/@/components/Main/StampPicker/StampPickerContainer.vue'
 import { computed } from 'vue'
 import { getFirstQuery } from '/@/lib/basic/url'
 import { useRoute } from 'vue-router'


### PR DESCRIPTION
`<stamp-picker-container />`を呼び出すコンポーネントを`App.vue`のみに変更