### PR TITLE
hotfix: スタンプパレット編集画面のスタンプ並び替えでスタンプ削除ボタンの後ろにスタンプを置けるバグを修正

### DIFF
--- a/src/components/Settings/StampPaletteTab/StampPaletteEditorSortableStampList.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteEditorSortableStampList.vue
@@ -17,6 +17,7 @@
         :key="stampId"
         :class="[
           $style.stampListItem,
+          'js-sortable-item',
           { [$style.selected]: selectedStampIds.includes(stampId) }
         ]"
         :data-id="stampId"
@@ -79,6 +80,7 @@ const setupSortable = () => {
 
   sortableInstance = Sortable.create(stampListRef.value, {
     animation: 150,
+    draggable: '.js-sortable-item',
     onUpdate: (event: SortableEvent) => {
       if (
         event.newDraggableIndex === undefined ||


### PR DESCRIPTION
draggableな要素を指定することで対応
参考: https://github.com/SortableJS/Sortable?tab=readme-ov-file#options
発見者: https://q.trap.jp/messages/0197504b-4909-7273-a157-a88dcd160de3