### PR TITLE
feat: スタンプパレット編集画面で、設定ページから離れたりタブを閉じるときに確認するように変更

### DIFF
--- a/src/composables/dom/useBeforeUnload.ts
+++ b/src/composables/dom/useBeforeUnload.ts
@@ -1,0 +1,19 @@
+import { onMounted, onUnmounted, type ComputedRef, type Ref } from 'vue'
+
+export const useBeforeUnload = (
+  enabled: Ref<boolean> | ComputedRef<boolean>,
+  message: string
+) => {
+  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    if (!enabled.value) return
+    event.preventDefault()
+    event.returnValue = message
+    return message
+  }
+  onMounted(() => {
+    window.addEventListener('beforeunload', handleBeforeUnload)
+  })
+  onUnmounted(() => {
+    window.removeEventListener('beforeunload', handleBeforeUnload)
+  })
+}

--- a/src/composables/dom/useBeforeUnload.ts
+++ b/src/composables/dom/useBeforeUnload.ts
@@ -7,9 +7,7 @@ export const useBeforeUnload = (
 ) => {
   const handleBeforeUnload = (event: BeforeUnloadEvent) => {
     if (!isEnabled.value) return
-    if (onBeforeUnload) {
-      onBeforeUnload(event)
-    }
+    onBeforeUnload?.(event)
     event.preventDefault()
     event.returnValue = message
     return message

--- a/src/composables/dom/useBeforeUnload.ts
+++ b/src/composables/dom/useBeforeUnload.ts
@@ -1,11 +1,15 @@
 import { onMounted, onUnmounted, type ComputedRef, type Ref } from 'vue'
 
 export const useBeforeUnload = (
-  enabled: Ref<boolean> | ComputedRef<boolean>,
-  message: string
+  isEnabled: Ref<boolean> | ComputedRef<boolean>,
+  message: string,
+  onBeforeUnload?: (event: BeforeUnloadEvent) => void
 ) => {
   const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-    if (!enabled.value) return
+    if (!isEnabled.value) return
+    if (onBeforeUnload) {
+      onBeforeUnload(event)
+    }
     event.preventDefault()
     event.returnValue = message
     return message

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -60,6 +60,13 @@ const discardWithConfirm = () => {
   }
 }
 
+const addSuccessToast = () => {
+  addInfoToast('スタンプパレットを保存しました')
+}
+const addFailureToast = () => {
+  addErrorToast('スタンプパレットの保存に失敗しました')
+}
+
 const finalizeWithToast = async () => {
   if (!hasPaletteUnsavedChanges.value) {
     goToSettingsStampPalette()
@@ -67,10 +74,10 @@ const finalizeWithToast = async () => {
   }
   try {
     await createStampPaletteWrapper(newStampPalette.value)
-    addInfoToast('スタンプパレットを保存しました')
+    addSuccessToast()
     goToSettingsStampPalette()
   } catch (e) {
-    addErrorToast('スタンプパレットの保存に失敗しました')
+    addFailureToast()
   }
 }
 
@@ -78,9 +85,9 @@ onUnmounted(async () => {
   if (!hasPaletteUnsavedChanges.value) return
   try {
     await createStampPaletteWrapper(newStampPalette.value)
-    addInfoToast('スタンプパレットを保存しました')
+    addSuccessToast()
   } catch (e) {
-    addErrorToast('スタンプパレットの保存に失敗しました')
+    addFailureToast()
   }
 })
 </script>

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
-import { computed, onBeforeUnmount, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -24,6 +24,7 @@ import {
   createStampPaletteWrapper,
   goToSettingsStampPalette
 } from '/@/components/Settings/StampPaletteTab/utils'
+import { useBeforeUnload } from '/@/composables/dom/useBeforeUnload'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
 import { useToastStore } from '/@/store/ui/toast'
 import type { StampId, StampPaletteId } from '/@/types/entity-ids'
@@ -92,20 +93,10 @@ onBeforeUnmount(async () => {
   }
 })
 
-const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-  if (!hasPaletteUnsavedChanges.value) return
-  event.preventDefault()
-  event.returnValue = '未保存の編集内容があります。ページを離れますか？'
-  return '未保存の編集内容があります。ページを離れますか？'
-}
-
-onMounted(() => {
-  window.addEventListener('beforeunload', handleBeforeUnload)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('beforeunload', handleBeforeUnload)
-})
+useBeforeUnload(
+  hasPaletteUnsavedChanges,
+  '未保存の編集内容があります。ページを離れますか？'
+)
 </script>
 
 <style lang="scss" module>

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
-import { computed, ref } from 'vue'
+import { computed, onUnmounted, ref } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -73,6 +73,16 @@ const finalizeWithToast = async () => {
     addErrorToast('スタンプパレットの保存に失敗しました')
   }
 }
+
+onUnmounted(async () => {
+  if (!hasPaletteUnsavedChanges.value) return
+  try {
+    await createStampPaletteWrapper(newStampPalette.value)
+    addInfoToast('スタンプパレットを保存しました')
+  } catch (e) {
+    addErrorToast('スタンプパレットの保存に失敗しました')
+  }
+})
 </script>
 
 <style lang="scss" module>

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -83,6 +83,7 @@ const finalizeWithToast = async () => {
 
 onUnmounted(async () => {
   if (!hasPaletteUnsavedChanges.value) return
+  if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {
     await createStampPaletteWrapper(newStampPalette.value)
     addSuccessToast()

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
-import { computed, onUnmounted, ref } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -81,7 +81,7 @@ const finalizeWithToast = async () => {
   }
 }
 
-onUnmounted(async () => {
+onBeforeUnmount(async () => {
   if (!hasPaletteUnsavedChanges.value) return
   if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
-import { computed, onBeforeUnmount, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, onUnmounted, ref } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -90,6 +90,21 @@ onBeforeUnmount(async () => {
   } catch (e) {
     addFailureToast()
   }
+})
+
+const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+  if (!hasPaletteUnsavedChanges.value) return
+  event.preventDefault()
+  event.returnValue = '未保存の編集内容があります。ページを離れますか？'
+  return '未保存の編集内容があります。ページを離れますか？'
+}
+
+onMounted(() => {
+  window.addEventListener('beforeunload', handleBeforeUnload)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('beforeunload', handleBeforeUnload)
 })
 </script>
 

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -82,8 +82,11 @@ const finalizeWithToast = async () => {
   }
 }
 
+const isConfirmed = ref(false)
+
 onBeforeUnmount(async () => {
-  if (!hasPaletteUnsavedChanges.value) return
+  if (!hasPaletteUnsavedChanges.value || isConfirmed.value) return
+  isConfirmed.value = true
   if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {
     await createStampPaletteWrapper(newStampPalette.value)
@@ -94,8 +97,11 @@ onBeforeUnmount(async () => {
 })
 
 useBeforeUnload(
-  hasPaletteUnsavedChanges,
-  '未保存の編集内容があります。ページを離れますか？'
+  computed(() => hasPaletteUnsavedChanges.value && !isConfirmed.value),
+  '未保存の編集内容があります。ページを離れますか？',
+  event => {
+    isConfirmed.value = true
+  }
 )
 </script>
 

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -27,7 +27,7 @@
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
 import { isAxiosError } from 'axios'
-import { computed, onBeforeMount, ref, toRaw } from 'vue'
+import { computed, onBeforeMount, onUnmounted, ref, toRaw } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -122,6 +122,16 @@ const finalizeWithToast = async () => {
     addErrorToast('スタンプパレットの保存に失敗しました')
   }
 }
+
+onUnmounted(async () => {
+  if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
+  try {
+    await editStampPaletteWrapper(stampPaletteToEdit.value)
+    addInfoToast('スタンプパレットを保存しました')
+  } catch (e) {
+    addErrorToast('スタンプパレットの保存に失敗しました')
+  }
+})
 </script>
 
 <style lang="scss" module>

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -27,7 +27,7 @@
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
 import { isAxiosError } from 'axios'
-import { computed, onBeforeMount, onUnmounted, ref, toRaw } from 'vue'
+import { computed, onBeforeMount, onBeforeUnmount, ref, toRaw } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -130,7 +130,7 @@ const finalizeWithToast = async () => {
   }
 }
 
-onUnmounted(async () => {
+onBeforeUnmount(async () => {
   if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
   if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -27,15 +27,7 @@
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
 import { isAxiosError } from 'axios'
-import {
-  computed,
-  onBeforeMount,
-  onBeforeUnmount,
-  onMounted,
-  onUnmounted,
-  ref,
-  toRaw
-} from 'vue'
+import { computed, onBeforeMount, onBeforeUnmount, ref, toRaw } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -44,6 +36,7 @@ import {
   editStampPaletteWrapper,
   goToSettingsStampPalette
 } from '/@/components/Settings/StampPaletteTab/utils'
+import { useBeforeUnload } from '/@/composables/dom/useBeforeUnload'
 import { useMeStore } from '/@/store/domain/me'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
 import { useToastStore } from '/@/store/ui/toast'
@@ -149,20 +142,10 @@ onBeforeUnmount(async () => {
   }
 })
 
-const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-  if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
-  event.preventDefault()
-  event.returnValue = '未保存の編集内容があります。ページを離れますか？'
-  return '未保存の編集内容があります。ページを離れますか？'
-}
-
-onMounted(() => {
-  window.addEventListener('beforeunload', handleBeforeUnload)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('beforeunload', handleBeforeUnload)
-})
+useBeforeUnload(
+  hasPaletteUnsavedChanges,
+  '未保存の編集内容があります。ページを離れますか？'
+)
 </script>
 
 <style lang="scss" module>

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -131,6 +131,8 @@ const finalizeWithToast = async () => {
   }
 }
 
+const isConfirmed = ref(false)
+
 onBeforeUnmount(async () => {
   if (
     !hasPaletteUnsavedChanges.value ||

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -132,7 +132,13 @@ const finalizeWithToast = async () => {
 }
 
 onBeforeUnmount(async () => {
-  if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
+  if (
+    !hasPaletteUnsavedChanges.value ||
+    !stampPaletteToEdit.value ||
+    isConfirmed.value
+  )
+    return
+  isConfirmed.value = true
   if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {
     await editStampPaletteWrapper(stampPaletteToEdit.value)
@@ -144,7 +150,10 @@ onBeforeUnmount(async () => {
 
 useBeforeUnload(
   hasPaletteUnsavedChanges,
-  '未保存の編集内容があります。ページを離れますか？'
+  '未保存の編集内容があります。ページを離れますか？',
+  event => {
+    isConfirmed.value = true
+  }
 )
 </script>
 

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -27,7 +27,15 @@
 <script lang="ts" setup>
 import type { StampPalette } from '@traptitech/traq'
 import { isAxiosError } from 'axios'
-import { computed, onBeforeMount, onBeforeUnmount, ref, toRaw } from 'vue'
+import {
+  computed,
+  onBeforeMount,
+  onBeforeUnmount,
+  onMounted,
+  onUnmounted,
+  ref,
+  toRaw
+} from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'
 import StampPaletteEditor from '/@/components/Settings/StampPaletteTab/StampPaletteEditor.vue'
@@ -139,6 +147,21 @@ onBeforeUnmount(async () => {
   } catch (e) {
     addFailureToast()
   }
+})
+
+const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+  if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
+  event.preventDefault()
+  event.returnValue = '未保存の編集内容があります。ページを離れますか？'
+  return '未保存の編集内容があります。ページを離れますか？'
+}
+
+onMounted(() => {
+  window.addEventListener('beforeunload', handleBeforeUnload)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('beforeunload', handleBeforeUnload)
 })
 </script>
 

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -132,6 +132,7 @@ const finalizeWithToast = async () => {
 
 onUnmounted(async () => {
   if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
+  if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {
     await editStampPaletteWrapper(stampPaletteToEdit.value)
     addSuccessToast()

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -108,6 +108,13 @@ const discardWithConfirm = () => {
   }
 }
 
+const addSuccessToast = () => {
+  addInfoToast('スタンプパレットを保存しました')
+}
+const addFailureToast = () => {
+  addErrorToast('スタンプパレットの保存に失敗しました')
+}
+
 const finalizeWithToast = async () => {
   if (!hasPaletteUnsavedChanges.value) {
     goToSettingsStampPalette()
@@ -116,10 +123,10 @@ const finalizeWithToast = async () => {
   try {
     if (!stampPaletteToEdit.value) throw new Error('stampPaletteToEdit is null')
     await editStampPaletteWrapper(stampPaletteToEdit.value)
-    addInfoToast('スタンプパレットを保存しました')
+    addSuccessToast()
     goToSettingsStampPalette()
   } catch (e) {
-    addErrorToast('スタンプパレットの保存に失敗しました')
+    addFailureToast()
   }
 }
 
@@ -127,9 +134,9 @@ onUnmounted(async () => {
   if (!hasPaletteUnsavedChanges.value || !stampPaletteToEdit.value) return
   try {
     await editStampPaletteWrapper(stampPaletteToEdit.value)
-    addInfoToast('スタンプパレットを保存しました')
+    addSuccessToast()
   } catch (e) {
-    addErrorToast('スタンプパレットの保存に失敗しました')
+    addFailureToast()
   }
 })
 </script>


### PR DESCRIPTION
## 概要

- 設定ページから離れるときに、未保存の内容があれば保存するか確認するように変更
- タブを閉じるときに、未保存の内容があれば確認ダイアログを出すように変更

## なぜこの PR を入れたいのか

close https://github.com/traPtitech/traQ_S-UI/issues/4599

## 動作確認の手順

- スタンプパレット新規作成 or 編集ページを開く
- 編集し、右上の閉じるを押す or タブを閉じる
- 確認ダイアログが出れば成功

## UI 変更部分のスクリーンショット

なし

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
