### PR TITLE
dependabot での npm パッケージのグルーピングを変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
           - '*prettier*'
       patches:
         update-types:
-          - "patch"
+          - 'patch'
   - package-ecosystem: docker
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,16 @@ updates:
       interval: monthly
     open-pull-requests-limit: 10
     groups:
-      non-majors:
+      types:
+        patterns:
+          - '@types/*'
+      linters-and-formatters:
+        patterns:
+          - '*eslint*'
+          - '*prettier*'
+      patches:
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
   - package-ecosystem: docker
     directory: '/'
     schedule:


### PR DESCRIPTION
## 概要
dependabot での grouping を変更

## なぜこの PR を入れたいのか
dependabot での PR において non-majors が大きすぎること、また formatter や linter だけの影響により CI が通らないことだけがあるのでこれらを分離したかったから

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
特にないです