### PR TITLE
チャンネル検索でワイルドカードを使えるようにする

### DIFF
--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -54,6 +54,7 @@ const checkMatchChannel = (
   channel: ChannelLike,
   query: string
 ): CheckResult => {
+  if (query === '*') return 'perfect'
   if (channel.name.toLowerCase() === query.toLowerCase()) return 'perfect'
   if (channel.name.toLowerCase().includes(query.toLowerCase())) return 'match'
   return 'none'


### PR DESCRIPTION
close #4171

`/*` みたいなやつがほぼ全てのチャンネルを表示しようとして重いという問題点があるので，#4630 も一緒に入れて解決したい
