### PR TITLE
fix: スタンプピッカーでのスタンプの表示列数を10列に強制する

### DIFF
--- a/src/components/Main/StampPicker/StampPicker.vue
+++ b/src/components/Main/StampPicker/StampPicker.vue
@@ -138,8 +138,7 @@ const onFilterEnter = () => {
   margin-left: 8px;
 }
 .stampList {
-  padding: 0 4px;
-  padding-bottom: 12px;
+  padding-left: 4px;
 }
 .effectSelector {
   flex: 1 0;

--- a/src/components/Main/StampPicker/StampPickerStampList.vue
+++ b/src/components/Main/StampPicker/StampPickerStampList.vue
@@ -63,8 +63,7 @@ const onHoverStamp = (id: StampId) => {
 }
 
 .panel {
-  display: flex;
-  flex-flow: row wrap;
-  align-content: flex-start;
+  display: grid;
+  grid-template-columns: repeat(10, min-content);
 }
 </style>


### PR DESCRIPTION
close #4596 

## やったこと

- スタンプの配置を`display: grid`で行うようにしました
- グリッドの列数を`10`にしたので強制的に10列になります

## 気になること

- 画面幅が小さい ( 340px未満 ) ときにもスタンプが10列のままになります
  - 以前は溢れないように改行されていました