### PR TITLE
feat: スタンプピッカー内のスタンプをTabキーでナビゲーションできるように変更

### DIFF
--- a/src/components/Main/StampPicker/StampPickerStampListItem.vue
+++ b/src/components/Main/StampPicker/StampPickerStampListItem.vue
@@ -1,13 +1,13 @@
 <template>
   <transition name="stamp-pressed" mode="out-in">
     <button
+      :key="pressedAnimationKey"
       :class="$style.container"
       @click="onClickStamp"
       @mouseenter="onStampHover"
     >
       <!-- keyにしてアニメーションが動くようにしている -->
       <a-stamp
-        :key="pressedAnimationKey"
         :stamp-id="stamp.id"
         :size="32"
         :class="$style.item"


### PR DESCRIPTION
## やったこと

- スタンプピッカーを開いた状態でTabキーを押すとスタンプを順番にフォーカスできるようにしました
- フォーカス時のアウトラインを付けました

![screenshot](https://github.com/user-attachments/assets/e119d3e2-c810-4f56-a2c1-341237b95de6)
