### PR TITLE
fix: border-color じゃなくて box-shadow を使って選択中を表示するように

### DIFF
--- a/src/components/Main/StampPicker/StampPickerStampListItem.vue
+++ b/src/components/Main/StampPicker/StampPickerStampListItem.vue
@@ -43,9 +43,8 @@ const onStampHover = () => {
 <style lang="scss" module>
 .container {
   border-radius: 4px;
-  border: solid 2px transparent;
   &:focus-within {
-    border-color: $theme-accent-focus-default;
+    box-shadow: inset 0 0 0 2px $theme-accent-focus-default;
   }
   &:hover {
     @include background-secondary;


### PR DESCRIPTION
## 概要

border-color じゃなくて box-shadow を使って選択中を表示するように

## なぜこの PR を入れたいのか

border を使うとスタンプピッカーから溢れてしまうので

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
