### PR TITLE
fix: stampPickerがホバーされていない時に何も表示しない

### DIFF
--- a/src/components/Main/StampPicker/StampPickerPreview.vue
+++ b/src/components/Main/StampPicker/StampPickerPreview.vue
@@ -33,10 +33,7 @@ const previewText = computed(() => {
 
   const stampName = stampsMap.value.get(props.stampId)?.name ?? ''
 
-  return constructStampString(
-    stampName, 
-    props.sizeEffect, 
-    props.animeEffects)
+  return constructStampString(stampName, props.sizeEffect, props.animeEffects)
 })
 
 const rendered = ref('')


### PR DESCRIPTION
## 概要
スタンプピッカーで何も選択してないときに登録されてる最初のスタンプが出てしまうことの修正 #4594 

## なぜこの PR を入れたいのか
fix: #4594 

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順
stampPickerを開いて、何もホバーしないと、何も表示されない

## UI 変更部分のスクリーンショット

### before
<img width="376" alt="スクリーンショット 2025-06-26 18 04 48" src="https://github.com/user-attachments/assets/01c853f4-8964-43ba-86a6-0385bb020e45" />

### after
<img width="379" alt="スクリーンショット 2025-06-26 18 04 40" src="https://github.com/user-attachments/assets/efd4daea-faac-42d9-a156-6279345ce07c" />

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

今回の修正でstampPickerの下部にスペースができたので、ここに「スタンプを追加」のボタンを追加してみるのはいかがでしょうか