### PR TITLE
削除されたスタンプもunknown stampとして表示するように変更

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageStampList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageStampList.vue
@@ -69,12 +69,7 @@ const props = withDefaults(
 const { myId } = useMeStore()
 const { stampsMap } = useStampsStore()
 const { addStampOptimistically, removeStampOptimistically } = useStampUpdater()
-const stampList = computed(() => {
-  const stamps = props.stamps.filter(stamp =>
-    stampsMap.value.has(stamp.stampId)
-  )
-  return createStampList(stamps, myId.value)
-})
+const stampList = computed(() => createStampList(props.stamps, myId.value))
 
 const { value: isDetailShown, toggle: toggleDetail } = useToggle(false)
 

--- a/src/components/Main/MainView/MessageElement/StampDetailElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampDetailElement.vue
@@ -27,7 +27,7 @@ const props = defineProps<{
 const { stampsMap } = useStampsStore()
 
 const stampName = computed(
-  () => stampsMap.value.get(props.stamp.id)?.name ?? ''
+  () => stampsMap.value.get(props.stamp.id)?.name ?? 'unknown stamp'
 )
 
 const isLastUser = (user: StampUser) =>

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -52,7 +52,7 @@ const { isTouchDevice } = useResponsiveStore()
 const { stampsMap } = useStampsStore()
 
 const stampName = computed(
-  () => stampsMap.value.get(props.stamp.id)?.name ?? ''
+  () => stampsMap.value.get(props.stamp.id)?.name ?? 'unknown stamp'
 )
 
 const tooltip = computed(

--- a/src/components/Main/MainView/MessageElement/StampScaledElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampScaledElement.vue
@@ -48,7 +48,7 @@ const emit = defineEmits<{
 const containerEle = ref<HTMLDivElement>()
 const { stampsMap } = useStampsStore()
 const stampName = computed(
-  () => stampsMap.value.get(props.stamp.id)?.name ?? ''
+  () => stampsMap.value.get(props.stamp.id)?.name ?? 'unknown stamp'
 )
 const stylePosition = computed(() => {
   if (!props.targetRect) return { display: 'none' }

--- a/src/components/UI/AStamp.vue
+++ b/src/components/UI/AStamp.vue
@@ -33,7 +33,9 @@ const props = withDefaults(
 
 const { stampsMap } = useStampsStore()
 
-const name = computed(() => stampsMap.value.get(props.stampId)?.name ?? '')
+const name = computed(
+  () => stampsMap.value.get(props.stampId)?.name ?? 'unknown stamp'
+)
 const imageUrl = computed(() => {
   const fileId = stampsMap.value.get(props.stampId)?.fileId
   return fileId ? buildFilePath(fileId) : ''


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

close: #4575

## 動作確認の手順

開発環境のgのチャンネルのメッセージID: 0197ab8b-922a-7944-b42a-969296abf6da の投稿を見ることで確認できます

## UI 変更部分のスクリーンショット

### before

<img width="350" alt="スクリーンショット 2025-06-26 19 52 40" src="https://github.com/user-attachments/assets/20f79eac-5ade-490b-bc1a-ff4e2a0daf1b" />

### after

<img width="347" alt="スクリーンショット 2025-06-26 19 50 03" src="https://github.com/user-attachments/assets/e922eb90-eb25-47d6-8fc1-d8ff238b3239" />

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

削除されたスタンプを押すと警告が左に出るので、問題ない動作であるかどうか確認してほしいです。
