### PR TITLE
自分はChannelViewStateに関わらず閲覧中とする

### DIFF
--- a/src/composables/useCurrentViewers.ts
+++ b/src/composables/useCurrentViewers.ts
@@ -21,14 +21,19 @@ const useCurrentViewers = (channelId: Ref<ChannelId>) => {
       .filter(
         v =>
           v.state === ChannelViewState.Monitoring ||
-          v.state === ChannelViewState.Editing
+          v.state === ChannelViewState.Editing ||
+          v.userId === meStore.myId.value
       )
       .map(v => v.userId)
   )
 
   const inactiveViewingUsers = computed(() =>
     currentViewers.value
-      .filter(v => v.state === ChannelViewState.None)
+      .filter(
+        v => 
+          v.state === ChannelViewState.None &&
+          v.userId !== meStore.myId.value
+      )
       .map(v => v.userId)
   )
 

--- a/src/composables/useCurrentViewers.ts
+++ b/src/composables/useCurrentViewers.ts
@@ -30,9 +30,8 @@ const useCurrentViewers = (channelId: Ref<ChannelId>) => {
   const inactiveViewingUsers = computed(() =>
     currentViewers.value
       .filter(
-        v => 
-          v.state === ChannelViewState.None &&
-          v.userId !== meStore.myId.value
+        v =>
+          v.state === ChannelViewState.None && v.userId !== meStore.myId.value
       )
       .map(v => v.userId)
   )

--- a/src/views/composables/useViewStateSender.ts
+++ b/src/views/composables/useViewStateSender.ts
@@ -30,12 +30,13 @@ const useViewStateSender = () => {
   })
 
   const state = computed(() => {
-    if (!shouldReceiveLatestMessages.value) return ChannelViewState.None
     // 最新メッセージ閲覧中でない場合はタイピング中でもEditingにしてはいけない
     // (Editingにすると未読に追加されなくなるため)
-    return isTyping.value
-      ? ChannelViewState.Editing
-      : ChannelViewState.Monitoring
+    if (isTyping.value && shouldReceiveLatestMessages.value) {
+      return ChannelViewState.Editing
+    } else {
+      return ChannelViewState.Monitoring
+    }
   })
 
   watchEffect(() => {

--- a/src/views/composables/useViewStateSender.ts
+++ b/src/views/composables/useViewStateSender.ts
@@ -57,7 +57,7 @@ const useViewStateSender = () => {
     }
     changeViewState(currentChannelId.value, ChannelViewState.None)
   }
-  const focusListeiner = () => {
+  const focusListener = () => {
     if (!currentChannelId.value) {
       changeViewState(null)
       return
@@ -65,7 +65,7 @@ const useViewStateSender = () => {
     changeViewState(currentChannelId.value, state.value)
   }
 
-  const blurListeiner = () => {
+  const blurListener = () => {
     if (!currentChannelId.value) {
       changeViewState(null)
       return
@@ -75,13 +75,13 @@ const useViewStateSender = () => {
 
   onMounted(() => {
     document.addEventListener('visibilitychange', visibilitychangeListener)
-    window.addEventListener('focus', focusListeiner)
-    window.addEventListener('blur', blurListeiner)
+    window.addEventListener('focus', focusListener)
+    window.addEventListener('blur', blurListener)
   })
   onUnmounted(() => {
     document.removeEventListener('visibilitychange', visibilitychangeListener)
-    window.removeEventListener('focus', focusListeiner)
-    window.removeEventListener('blur', blurListeiner)
+    window.removeEventListener('focus', focusListener)
+    window.removeEventListener('blur', blurListener)
   })
 }
 

--- a/src/views/composables/useViewStateSender.ts
+++ b/src/views/composables/useViewStateSender.ts
@@ -30,13 +30,12 @@ const useViewStateSender = () => {
   })
 
   const state = computed(() => {
+    if (!shouldReceiveLatestMessages.value) return ChannelViewState.None
     // 最新メッセージ閲覧中でない場合はタイピング中でもEditingにしてはいけない
     // (Editingにすると未読に追加されなくなるため)
-    if (isTyping.value && shouldReceiveLatestMessages.value) {
-      return ChannelViewState.Editing
-    } else {
-      return ChannelViewState.Monitoring
-    }
+    return isTyping.value
+      ? ChannelViewState.Editing
+      : ChannelViewState.Monitoring
   })
 
   watchEffect(() => {


### PR DESCRIPTION
## 概要
チャンネルを開いていても最新のメッセージを読み込んでいない場合にアイコンが暗転していた。最新のメッセージを読み込んでいない場合でもアイコンが暗転しないようにした。

## なぜこの PR を入れたいのか

#4610

## 動作確認の手順
スクロールしないと最新のメッセージが読み込まれないような古いメッセージを読み込む。引用から、または検索から飛ぶのが楽。

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [ ] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
おそらく #1808 の実装を #4395 で使っているのですが、ChannelViewStateを当時の設計から変更しているので確認してほしいです。