### PR TITLE
fix: NewRelic の内容が変わってもキャッシュが更新されないバグを修正

### DIFF
--- a/build/docker/startup.sh
+++ b/build/docker/startup.sh
@@ -41,7 +41,9 @@ if [ -n "$NEW_RELIC_LICENSE_KEY" ] && [ -n "$NEW_RELIC_ACCOUNT_ID" ] && [ -n "$N
   sed -i -e "s/TRUST_KEY_PLACEHOLDER/$NEW_RELIC_TRUST_KEY/g" /usr/share/caddy/new-relic.js
   sed -i -e "s/AGENT_ID_PLACEHOLDER/$NEW_RELIC_AGENT_ID/g" /usr/share/caddy/new-relic.js
   sed -i -e "s/APPLICATION_ID_PLACEHOLDER/$NEW_RELIC_APPLICATION_ID/g" /usr/share/caddy/new-relic.js
-  sed -i -e "s/<!-- <script src=\"\/new-relic.js\"><\/script> -->/<script src=\"\/new-relic.js\"><\/script>/" /usr/share/caddy/index.html
+  CACHE_KEY=$(cat /usr/share/caddy/new-relic.js | md5sum | cut -d ' ' -f 1)
+  mv /usr/share/caddy/new-relic.js /usr/share/caddy/new-relic-$CACHE_KEY.js
+  sed -i -e "s/<!-- <script src=\"\/new-relic.js\"><\/script> -->/<script src=\"\/new-relic-$CACHE_KEY.js\"><\/script>/" /usr/share/caddy/index.html
 else
   echo "Startup: New Relic is not configured"
 fi

--- a/build/docker/startup.sh
+++ b/build/docker/startup.sh
@@ -41,7 +41,7 @@ if [ -n "$NEW_RELIC_LICENSE_KEY" ] && [ -n "$NEW_RELIC_ACCOUNT_ID" ] && [ -n "$N
   sed -i -e "s/TRUST_KEY_PLACEHOLDER/$NEW_RELIC_TRUST_KEY/g" /usr/share/caddy/new-relic.js
   sed -i -e "s/AGENT_ID_PLACEHOLDER/$NEW_RELIC_AGENT_ID/g" /usr/share/caddy/new-relic.js
   sed -i -e "s/APPLICATION_ID_PLACEHOLDER/$NEW_RELIC_APPLICATION_ID/g" /usr/share/caddy/new-relic.js
-  CACHE_KEY=$(cat /usr/share/caddy/new-relic.js | md5sum | cut -d ' ' -f 1)
+  CACHE_KEY=$(md5sum /usr/share/caddy/new-relic.js | cut -d ' ' -f 1)
   mv /usr/share/caddy/new-relic.js /usr/share/caddy/new-relic-$CACHE_KEY.js
   sed -i -e "s/<!-- <script src=\"\/new-relic.js\"><\/script> -->/<script src=\"\/new-relic-$CACHE_KEY.js\"><\/script>/" /usr/share/caddy/index.html
 else


### PR DESCRIPTION
## 概要

Workboxのキャッシュキー (revision) 計算はビルド時に行われるため、ビルド後に環境変数の値で書き換えてもキャッシュキーは変化せず、アプリをアップデートしても以前のキャッシュが利用されてしまう

ファイルの内容をもとに自前でキャッシュキー (md5ハッシュ) を計算してファイル名に含めることで環境変数の更新時にもキャッシュを飛ばせるようにした

## なぜこの PR を入れたいのか

NewRelic周りの環境変数を変えてもキャッシュが飛ばず、実質的にクライアントを更新できないため

## 動作確認の手順

イメージをビルドして異なるのNewRelicの環境変数で走らせたときに、`/usr/share/caddy/new-relic.js` が適切にリネームされて、それが index.html から参照できる (すなわちちゃんとアプリとして動作する) ことを確かめる

## やっていないこと

APP_NAME や THEME_COLOR も同様の現象が起こるが、これらを変えることはほとんどないであろうから、このPRのスコープ外とする

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
