### PR TITLE
チャンネルの省略案

### DIFF
--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -89,7 +89,6 @@ const useChannelPath = () => {
       let count = 0;
       let comfusable = false
       for (const element of parent_similar_brother) {
-        let array = channelsMap.value.get(element)?.children
         if (channelsMap.value.get(element)?.children!.length !== 0){
           for (const element_child of channelsMap.value.get(element)?.children!){
             if (channelsMap.value.get(element_child)!.name === channelsMap.value.get(child)!.name) {

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -5,10 +5,13 @@ import { channelIdToSimpleChannelPath as libChannelIdToSimpleChannelPath } from 
 import { channelPathToId } from '/@/lib/channelTree'
 import { useChannelsStore } from '/@/store/entities/channels'
 import { useUsersStore } from '../store/entities/users'
+import { useChannelTree } from '/@/store/domain/channelTree'
 
 const useChannelPath = () => {
   const { channelsMap, dmChannelsMap } = useChannelsStore()
   const { usersMap } = useUsersStore()
+  const { topLevelChannels } = useChannelTree()
+
 
   const getUserNameByDMChannelId = (dmChannelId: DMChannelId) => {
     const dmChannel = dmChannelsMap.value.get(dmChannelId)
@@ -46,6 +49,24 @@ const useChannelPath = () => {
     return (hashed ? '#' : '') + channelIdToPath(id).join('/')
   }
 
+  const stringMinimaze = (  //引数を直接変更してるのなんとかしろや
+    data : string[],
+    text : string
+  ): string => {
+    const index: number = data.indexOf(text);
+    if (index !== -1) {
+      data.splice(index, 1);
+    }
+    for (var i=0;i < text.length;i++){
+      data = data.filter((word) => word[i] === text[i])
+      if (data.length === 0){
+        return text.slice(0,i+1)
+      }
+    }
+    return text;
+  }
+
+
   const channelIdToShortPathString = (
     id: ChannelId | DMChannelId,
     hashed = false
@@ -53,10 +74,93 @@ const useChannelPath = () => {
     if (dmChannelsMap.value.has(id)) {
       return dmChannelIdToPathString(id, hashed)
     }
+    const maxPathLength = 20
     const channels = channelIdToPath(id)
-    const formattedChannels = channels.slice(0, -1).map(c => c[0])
-    formattedChannels.push(channels.pop() ?? '')
-    return (hashed ? '#' : '') + formattedChannels.join('/')
+    const channelsSimple = channelIdToSimpleChannelPath(id)
+    const channelsId = channelsSimple.map((simpchan) =>  simpchan.id)
+    const channelsName = channelsId.map((c) => channelsMap.value.get(c)!.name)
+    const formattedChannels = channelsName.map((c) => c[0])
+    if (channels.length >= 3){
+      const child = channelsId.pop() ?? ''
+      const parent = channelsId.pop() ?? ''
+      const grandparent = channelsId.pop() ?? ''
+      const parent_brother = channelsMap.value.get(grandparent)?.children!
+      const parent_similar_brother = parent_brother.filter((x) => channelsMap.value.get(x)!.name[0]! === channelsMap.value.get(parent)!.name[0])
+      let count = 0;
+      let comfusable = false
+      for (const element of parent_similar_brother) {
+        let array = channelsMap.value.get(element)?.children
+        if (channelsMap.value.get(element)?.children!.length !== 0){
+          for (const element_child of channelsMap.value.get(element)?.children!){
+            if (channelsMap.value.get(element_child)!.name === channelsMap.value.get(child)!.name) {
+              count++;
+            }
+            if (count >= 2) {
+              comfusable = true
+              break
+            }
+          }
+        }
+      }
+      if (comfusable){
+        const parent_name = channelsMap.value.get(parent)!.name
+        formattedChannels.pop()
+        formattedChannels.pop()
+        formattedChannels.push(parent_name ?? '')
+        const child_name = channelsMap.value.get(child)!.name
+        formattedChannels.push(child_name ?? '')
+        const path = formattedChannels.join("/")
+        if (path.length <= maxPathLength){
+          return (hashed ? '#' : '') + path
+        } else {
+          console.log(path)
+          formattedChannels[formattedChannels.length-2] = ""
+          const nonParentPath = formattedChannels.join("/")
+          const nonParentPathsLength = nonParentPath.length
+          console.log(nonParentPath)
+          const N = Math.min(Math.max(maxPathLength - nonParentPathsLength,1),parent_name.length)
+          console.log(N)
+          formattedChannels[formattedChannels.length-2] = parent_name.slice(0,N)
+          const boundedPath = formattedChannels.join("/")
+          console.log(boundedPath)
+          const parent_similar_brother_name = parent_similar_brother.map((x) => channelsMap.value.get(x)!.name)
+          const shorted_parent_name = stringMinimaze(parent_similar_brother_name,parent_name)
+          formattedChannels[formattedChannels.length-2] = shorted_parent_name
+          const ShortedPath = formattedChannels.join("/")
+          console.log(ShortedPath)
+          console.log("xcvvvfgtewsgbi dnbp iugjipdsbzmgu svnmn uidgkjlsrevadar")
+          if (N > shorted_parent_name.length){
+            console.log("bounded")
+            return (hashed ? '#' : '') + boundedPath
+          } else {
+            console.log("shorted")
+            return (hashed ? '#' : '') + ShortedPath
+          }
+        }
+      } else {
+        formattedChannels.pop()
+        const child_name = channelsMap.value.get(child)!.name
+        formattedChannels.push(child_name ?? '')
+        return (hashed ? '#' : '') + formattedChannels.join("/")
+      }
+    } else if (channels.length == 2){
+      const child_name = channels.pop() ?? ''
+      const parent_name = channels.pop() ?? ''
+      const confusable_parents : string[] = []
+      for (let i = 0;i<topLevelChannels.value.length;i++){
+        const topLevelChannelId = topLevelChannels.value[i]?.id!
+        if (channelsMap.value.get(topLevelChannelId)?.children.map((x) => channelsMap.value.get(x)!.name).includes(child_name)){
+          confusable_parents.push(channelsMap.value.get(topLevelChannelId!)?.name!)
+        }
+      }
+      const shorted_parent = stringMinimaze(confusable_parents,parent_name)
+      return (hashed ? '#' : '') + shorted_parent + "/" + child_name
+    } else if (channels.length == 1){
+      const path = channels[0]
+      return (hashed ? '#' : '') + path
+    } else {
+      return hashed ? '#' : ''
+    }
   }
 
   const channelIdToLink = (id: ChannelId | DMChannelId) => {

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -88,7 +88,7 @@ const useChannelPath = () => {
       const parent_similar_brother = parent_brother.filter((x) => channelsMap.value.get(x)!.name[0]! === channelsMap.value.get(parent)!.name[0])
       let count = 0;
       let comfusable = false
-      for (const element of parent_similar_brother) {
+      for (const element of parent_brother) {
         if (channelsMap.value.get(element)?.children!.length !== 0){
           for (const element_child of channelsMap.value.get(element)?.children!){
             if (channelsMap.value.get(element_child)!.name === channelsMap.value.get(child)!.name) {
@@ -112,27 +112,19 @@ const useChannelPath = () => {
         if (path.length <= maxPathLength){
           return (hashed ? '#' : '') + path
         } else {
-          console.log(path)
           formattedChannels[formattedChannels.length-2] = ""
           const nonParentPath = formattedChannels.join("/")
           const nonParentPathsLength = nonParentPath.length
-          console.log(nonParentPath)
           const N = Math.min(Math.max(maxPathLength - nonParentPathsLength,1),parent_name.length)
-          console.log(N)
           formattedChannels[formattedChannels.length-2] = parent_name.slice(0,N)
           const boundedPath = formattedChannels.join("/")
-          console.log(boundedPath)
           const parent_similar_brother_name = parent_similar_brother.map((x) => channelsMap.value.get(x)!.name)
           const shorted_parent_name = stringMinimaze(parent_similar_brother_name,parent_name)
           formattedChannels[formattedChannels.length-2] = shorted_parent_name
           const ShortedPath = formattedChannels.join("/")
-          console.log(ShortedPath)
-          console.log("xcvvvfgtewsgbi dnbp iugjipdsbzmgu svnmn uidgkjlsrevadar")
           if (N > shorted_parent_name.length){
-            console.log("bounded")
             return (hashed ? '#' : '') + boundedPath
           } else {
-            console.log("shorted")
             return (hashed ? '#' : '') + ShortedPath
           }
         }
@@ -142,7 +134,7 @@ const useChannelPath = () => {
         formattedChannels.push(child_name ?? '')
         return (hashed ? '#' : '') + formattedChannels.join("/")
       }
-    } else if (channels.length == 2){
+    } else if (channels.length === 2){
       const child_name = channels.pop() ?? ''
       const parent_name = channels.pop() ?? ''
       const confusable_parents : string[] = []
@@ -154,7 +146,7 @@ const useChannelPath = () => {
       }
       const shorted_parent = stringMinimaze(confusable_parents,parent_name)
       return (hashed ? '#' : '') + shorted_parent + "/" + child_name
-    } else if (channels.length == 1){
+    } else if (channels.length === 1){
       const path = channels[0]
       return (hashed ? '#' : '') + path
     } else {


### PR DESCRIPTION
## 概要
現在の一文字略称(#g/t/n_and_over_3 など)をベースに
① 同じチャンネル名が存在するときは、親チャンネルを表示する
② ①の操作による名前の展開の、チャンネルパスの文字数の上限を設定する
③ ②の上限に対して、チャンネルが一意に定まるようにその上限の下限を設定する
ということを行った。

## 動作確認の手順
適当に検索する。あるいはアクティビティを見る。
特に、検索で、よくかぶっていそうなチャンネル名を調べてみる。

## UI 変更部分のスクリーンショット
いい感じに gps/times/**/sub の親チャンネルが表示されるようになった
![image](https://github.com/user-attachments/assets/7db4e903-bcab-4fc5-a951-9d99c181af1d)


## 見てほしいところ・聞きたいことなど
懸念点
・実際に動かして重くないか (Localhostだと実際の重さが分からない)
・ハッカソンのprogramチャンネルとかはうまく省略されない
　#event/hackathon/20spring/02/progress → #e/h/2/02/progress
　　　　　　　　　　　　　　　　　理想： #e/h/20_s/02/progress  (祖母チャンネルの名前まで弄るべき？)
・コードが汚い　(一旦動くものは作りましたが...指摘される限り頑張って直します)
