### PR TITLE
チャンネル名の省略案(最終版)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-plugin-cypress": "^5.0.1",
         "eslint-plugin-unused-imports": "^4.1.4",
         "eslint-plugin-vue": "^10.2.0",
+        "fake-indexeddb": "^6.0.1",
         "fonteditor-core": "^2.4.1",
         "jsdom": "^26.1.0",
         "patch-package": "^8.0.0",
@@ -7791,6 +7792,16 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-cypress": "^5.0.1",
     "eslint-plugin-unused-imports": "^4.1.4",
     "eslint-plugin-vue": "^10.2.0",
+    "fake-indexeddb": "^6.0.1",
     "fonteditor-core": "^2.4.1",
     "jsdom": "^26.1.0",
     "patch-package": "^8.0.0",

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -144,6 +144,10 @@ const useChannelPath = () => {
           formattedChannels[replaceInitialChannelIndex] = channelsInit[replaceInitialChannelIndex]
           replaceInitialChannelIndex++;
         }
+        if (formattedChannels.join('/').length <= maxPathLength){
+          return (hashed ? '#' : '') + formattedChannels.join("/")
+        }
+        formattedChannels[channelsSimple.length-2] = ChannelIdToUniqueInital(channelsId[channelsSimple.length-2]!)
         return (hashed ? '#' : '') + formattedChannels.join("/")
       } else {  
         return (hashed ? '#' : '') + formattedChannels.join("/")

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -48,10 +48,7 @@ const useChannelPath = () => {
     return (hashed ? '#' : '') + channelIdToPath(id).join('/')
   }
 
-  const stringMinimazer = (
-    data: string[],
-    text: string
-  ): string => {
+  const stringMinimazer = (data: string[], text: string): string => {
     let data_: string[] = data.concat()
     const index: number = data_.indexOf(text)
     if (index !== -1) {
@@ -196,4 +193,3 @@ const useChannelPath = () => {
 }
 
 export default useChannelPath
-

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -12,7 +12,6 @@ const useChannelPath = () => {
   const { usersMap } = useUsersStore()
   const { topLevelChannels } = useChannelTree()
 
-
   const getUserNameByDMChannelId = (dmChannelId: DMChannelId) => {
     const dmChannel = dmChannelsMap.value.get(dmChannelId)
     if (!dmChannel) return ''
@@ -49,62 +48,65 @@ const useChannelPath = () => {
     return (hashed ? '#' : '') + channelIdToPath(id).join('/')
   }
 
-  const stringMinimazer = (  //引数を直接変更してるのなんとかしろや ← 何とかしてやったぞ過去の俺よ
-    data : string[],
-    text : string
+  const stringMinimazer = (
+    //引数を直接変更してるのなんとかしろや ← 何とかしてやったぞ過去の俺よ
+    data: string[],
+    text: string
   ): string => {
-    let data_ : string[] = data.concat()
-    const index: number = data_.indexOf(text);
+    let data_: string[] = data.concat()
+    const index: number = data_.indexOf(text)
     if (index !== -1) {
-      data_.splice(index, 1);
+      data_.splice(index, 1)
     }
-    for (let i=0;i < text.length;i++){
-      data_ = data_.filter((word) => word[i] === text[i])
-      if (data_.length === 0){
-        return text.slice(0,i+1)
+    for (let i = 0; i < text.length; i++) {
+      data_ = data_.filter(word => word[i] === text[i])
+      if (data_.length === 0) {
+        return text.slice(0, i + 1)
       }
     }
-    return text;
+    return text
   }
 
-  const channelIdToBrotherId = (
-    id : string
-  ): string[] => {
+  const channelIdToBrotherId = (id: string): string[] => {
     const parentId = channelsMap.value.get(id)?.parentId
-    if (parentId === null){
-      return topLevelChannels.value.filter((c) => !c.archived).map((c) => c.id)
-    } else if (parentId === undefined){
-      return [""]   // もはや言い訳のような返り値である。Asertionよりまし？
+    if (parentId === null) {
+      return topLevelChannels.value.filter(c => !c.archived).map(c => c.id)
+    } else if (parentId === undefined) {
+      return [''] // もはや言い訳のような返り値である。Asertionよりまし？
     } else {
-      return channelsMap.value.get(parentId)?.children.filter((c) => !channelsMap.value.get(c)?.archived) ?? [""]
+      return (
+        channelsMap.value
+          .get(parentId)
+          ?.children.filter(c => !channelsMap.value.get(c)?.archived) ?? ['']
+      )
     }
   }
 
-  const isHavingSameNameCousin = (
-    id : string
-  ): boolean => {
+  const isHavingSameNameCousin = (id: string): boolean => {
     const selfName = channelsMap.value.get(id)?.name
     const parentId = channelsMap.value.get(id)?.parentId
-    const parentbrothersId = channelIdToBrotherId(parentId!).filter((c) => c !== parentId)
-    for (const brother of parentbrothersId){
+    const parentbrothersId = channelIdToBrotherId(parentId ?? '').filter(
+      c => c !== parentId
+    )
+    for (const brother of parentbrothersId) {
       const brotherChildId = channelsMap.value.get(brother)?.children ?? []
-      for (const cousinId of brotherChildId){
+      for (const cousinId of brotherChildId) {
         const cousinName = channelsMap.value.get(cousinId)?.name
-        if (cousinName === selfName){
-          return true;
+        if (cousinName === selfName) {
+          return true
         }
       }
     }
-    return false;
+    return false
   }
 
-  const ChannelIdToUniqueInital = (
-    id : string
-  ): string => {
+  const ChannelIdToUniqueInital = (id: string): string => {
     const selfName = channelsMap.value.get(id)?.name
-    const brothersId = channelIdToBrotherId(id).filter((c) => c !== id)
-    const brothersName = brothersId.map((c) => channelsMap.value.get(c)?.name ?? "")
-    return stringMinimazer(brothersName,selfName!)
+    const brothersId = channelIdToBrotherId(id).filter(c => c !== id)
+    const brothersName = brothersId.map(
+      c => channelsMap.value.get(c)?.name ?? ''
+    )
+    return stringMinimazer(brothersName, selfName ?? '')
   }
 
   const channelIdToShortPathString = (
@@ -116,43 +118,59 @@ const useChannelPath = () => {
     }
     const maxPathLength = 20
     const channelsSimple = channelIdToSimpleChannelPath(id)
-    const channelsId = channelsSimple.map((simpchan) =>  simpchan.id)
-    const channelsName = channelsSimple.map((simpchan) =>  simpchan.name)
-    const channelsInit = channelsName.map((c) => c[0])
-    const formattedChannels = channelsInit.slice(0,-1)
-    formattedChannels.push(channelsName[channelsName.length-1])
-    if (formattedChannels.join('/').length >= maxPathLength){
+    const channelsId = channelsSimple.map(simpchan => simpchan.id)
+    const channelsName = channelsSimple.map(simpchan => simpchan.name)
+    const channelsInit = channelsName.map(c => c[0])
+    const formattedChannels = channelsInit.slice(0, -1)
+    formattedChannels.push(channelsName[channelsName.length - 1])
+    if (formattedChannels.join('/').length >= maxPathLength) {
       return formattedChannels.join('/')
     }
-    if (channelsId.length >= 2){
-      let extendChannelIndex = channelsSimple.length-1 // その名前のいとこチャンネルがいないかを検査するべきチャンネルのindex
-      while (extendChannelIndex > 0 && isHavingSameNameCousin(channelsId[extendChannelIndex]!) && formattedChannels.join('/').length < maxPathLength){
-        formattedChannels[extendChannelIndex-1] = channelsName[extendChannelIndex-1]
-        extendChannelIndex--;
+    if (channelsId.length >= 2) {
+      let extendChannelIndex = channelsSimple.length - 1 // その名前のいとこチャンネルがいないかを検査するべきチャンネルのindex
+      while (
+        extendChannelIndex > 0 &&
+        isHavingSameNameCousin(channelsId[extendChannelIndex] ?? '') &&
+        formattedChannels.join('/').length < maxPathLength
+      ) {
+        formattedChannels[extendChannelIndex - 1] =
+          channelsName[extendChannelIndex - 1]
+        extendChannelIndex--
       }
-      if (formattedChannels.join('/').length > maxPathLength){   //この先の処理をもっと続ける必要がある。頑張って省略処理を書く
-        let shortenChannelIndex = extendChannelIndex;
-        while (formattedChannels.join('/').length > maxPathLength && shortenChannelIndex < channelsSimple.length-2){
-          formattedChannels[shortenChannelIndex] = ChannelIdToUniqueInital(channelsId[shortenChannelIndex]!)
-          shortenChannelIndex++;
+      if (formattedChannels.join('/').length > maxPathLength) {
+        let shortenChannelIndex = extendChannelIndex
+        while (
+          formattedChannels.join('/').length > maxPathLength &&
+          shortenChannelIndex < channelsSimple.length - 2
+        ) {
+          formattedChannels[shortenChannelIndex] = ChannelIdToUniqueInital(
+            channelsId[shortenChannelIndex] ?? ''
+          )
+          shortenChannelIndex++
         }
-        if (formattedChannels.join('/').length <= maxPathLength){
-          return (hashed ? '#' : '') + formattedChannels.join("/")
+        if (formattedChannels.join('/').length <= maxPathLength) {
+          return (hashed ? '#' : '') + formattedChannels.join('/')
         }
-        let replaceInitialChannelIndex = extendChannelIndex;
-        while (formattedChannels.join('/').length > maxPathLength && replaceInitialChannelIndex < channelsSimple.length-2){
-          formattedChannels[replaceInitialChannelIndex] = channelsInit[replaceInitialChannelIndex]
-          replaceInitialChannelIndex++;
+        let replaceInitialChannelIndex = extendChannelIndex
+        while (
+          formattedChannels.join('/').length > maxPathLength &&
+          replaceInitialChannelIndex < channelsSimple.length - 2
+        ) {
+          formattedChannels[replaceInitialChannelIndex] =
+            channelsInit[replaceInitialChannelIndex]
+          replaceInitialChannelIndex++
         }
-        if (formattedChannels.join('/').length <= maxPathLength){
-          return (hashed ? '#' : '') + formattedChannels.join("/")
+        if (formattedChannels.join('/').length <= maxPathLength) {
+          return (hashed ? '#' : '') + formattedChannels.join('/')
         }
-        formattedChannels[channelsSimple.length-2] = ChannelIdToUniqueInital(channelsId[channelsSimple.length-2]!)
-        return (hashed ? '#' : '') + formattedChannels.join("/")
-      } else {  
-        return (hashed ? '#' : '') + formattedChannels.join("/")
+        formattedChannels[channelsSimple.length - 2] = ChannelIdToUniqueInital(
+          channelsId[channelsSimple.length - 2] ?? ''
+        )
+        return (hashed ? '#' : '') + formattedChannels.join('/')
+      } else {
+        return (hashed ? '#' : '') + formattedChannels.join('/')
       }
-    } else if (channelsId.length === 1){
+    } else if (channelsId.length === 1) {
       const path = channelsName[0]
       return (hashed ? '#' : '') + path
     } else {

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -49,7 +49,6 @@ const useChannelPath = () => {
   }
 
   const stringMinimazer = (
-    //引数を直接変更してるのなんとかしろや ← 何とかしてやったぞ過去の俺よ
     data: string[],
     text: string
   ): string => {
@@ -72,7 +71,7 @@ const useChannelPath = () => {
     if (parentId === null) {
       return topLevelChannels.value.filter(c => !c.archived).map(c => c.id)
     } else if (parentId === undefined) {
-      return [''] // もはや言い訳のような返り値である。Asertionよりまし？
+      return []
     } else {
       return (
         channelsMap.value
@@ -197,3 +196,4 @@ const useChannelPath = () => {
 }
 
 export default useChannelPath
+

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -125,23 +125,24 @@ const useChannelPath = () => {
       return formattedChannels.join('/')
     }
     if (channelsId.length >= 2){
-      let channelIndex = channelsSimple.length-1 // その名前のいとこチャンネルがいないかを検査するべきチャンネルのindex
-      while (channelIndex > 0 && isHavingSameNameCousin(channelsId[channelIndex]!) && formattedChannels.join('/').length < maxPathLength){
-        formattedChannels[channelIndex-1] = channelsName[channelIndex-1]
-        channelIndex--;
+      let extendChannelIndex = channelsSimple.length-1 // その名前のいとこチャンネルがいないかを検査するべきチャンネルのindex
+      while (extendChannelIndex > 0 && isHavingSameNameCousin(channelsId[extendChannelIndex]!) && formattedChannels.join('/').length < maxPathLength){
+        formattedChannels[extendChannelIndex-1] = channelsName[extendChannelIndex-1]
+        extendChannelIndex--;
       }
       if (formattedChannels.join('/').length > maxPathLength){   //この先の処理をもっと続ける必要がある。頑張って省略処理を書く
-        //以降、channelIndexは、そのチャンネルをUniqueIniatalに変えるか検討するチャンネルのindexを指す
-        while (formattedChannels.join('/').length > maxPathLength && channelIndex < channelsSimple.length-2){
-          formattedChannels[channelIndex] = ChannelIdToUniqueInital(channelsId[channelIndex]!)
-          channelIndex++;
+        let shortenChannelIndex = extendChannelIndex;
+        while (formattedChannels.join('/').length > maxPathLength && shortenChannelIndex < channelsSimple.length-2){
+          formattedChannels[shortenChannelIndex] = ChannelIdToUniqueInital(channelsId[shortenChannelIndex]!)
+          shortenChannelIndex++;
         }
         if (formattedChannels.join('/').length <= maxPathLength){
           return (hashed ? '#' : '') + formattedChannels.join("/")
         }
-        while (formattedChannels.join('/').length > maxPathLength && channelIndex < channelsSimple.length-2){
-          formattedChannels[channelIndex] = channelsInit[channelIndex]
-          channelIndex++;
+        let replaceInitialChannelIndex = extendChannelIndex;
+        while (formattedChannels.join('/').length > maxPathLength && replaceInitialChannelIndex < channelsSimple.length-2){
+          formattedChannels[replaceInitialChannelIndex] = channelsInit[replaceInitialChannelIndex]
+          replaceInitialChannelIndex++;
         }
         return (hashed ? '#' : '') + formattedChannels.join("/")
       } else {  

--- a/tests/unit/composables/channels/useChannelPath.spec.ts
+++ b/tests/unit/composables/channels/useChannelPath.spec.ts
@@ -1,0 +1,385 @@
+import { createTestingPinia } from '@pinia/testing'
+import { useChannelsStore } from '/@/store/entities/channels'
+import type { Channel } from '@traptitech/traq'
+import { useChannelTree } from '/@/store/domain/channelTree'
+import useChannel from '/@/composables/useChannelPath'
+
+
+describe('useChannelPath', () => {
+  beforeEach(() => {
+    createTestingPinia()
+    const {channelsMap} = useChannelsStore()
+    channelsMap.value = new Map(channels.map((c) => [c.id, c]))
+    for (const c of channelsMap.value){
+        if (c[1].parentId !== null){
+            channelsMap.value.get(c[1].parentId)?.children.push(c[0])
+        }
+    }
+
+    
+    // 初期化処理 (Arrange)
+    // チャンネルの一覧を初期化
+  })
+
+
+
+  it("Shortfy chnnels path",() => {
+  const {channelIdToShortPathString, channelIdToPath} = useChannel()
+    
+    expect(channelIdToPath('442154db-b6c2-4941-801f-60fe14bae4e2')).toEqual(['gps', 'times', 'Naru_18', 'sub'])
+    expect(channelIdToShortPathString('442154db-b6c2-4941-801f-60fe14bae4e2')).toBe("g/t/Naru_18/sub")
+
+    expect(channelIdToPath('0d425611-823c-4177-933c-ec06c44ab347')).toEqual(['gps', 'times', 'Naru_18', 'lec_jikkyo'])
+    expect(channelIdToShortPathString('0d425611-823c-4177-933c-ec06c44ab347')).toBe("g/t/N/lec_jikkyo")
+
+    expect(channelIdToPath('a76c14d0-259c-4d3c-aceb-9b82b3d82bce')).toEqual(['gps', 'times', 'Naru_18', 'ChildLongNameIsNotCut'])
+    expect(channelIdToShortPathString('a76c14d0-259c-4d3c-aceb-9b82b3d82bce')).toBe("g/t/N/ChildLongNameIsNotCut")
+
+    expect(channelIdToPath('cad1904f-2f09-4330-aa22-69387e5e09c6')).toEqual(['gps', 'times', 'ParentLongNameMayBeCut', 'sub'])
+    expect(channelIdToShortPathString('cad1904f-2f09-4330-aa22-69387e5e09c6')).toBe("g/t/P/sub")
+
+    expect(channelIdToPath('3de8179a-3b0a-4ac3-9876-f70d5b9a2628')).toEqual(['gps', 'times', 'yasao', 'sub'])
+    expect(channelIdToShortPathString('3de8179a-3b0a-4ac3-9876-f70d5b9a2628')).toBe("g/times/yasao/sub")
+
+
+    expect(channelIdToPath('6eebbc37-7025-4ced-be0d-581321e91c11')).toEqual(['gps', 'times', 'unsignedintger'])
+    expect(channelIdToShortPathString('6eebbc37-7025-4ced-be0d-581321e91c11')).toBe("g/t/unsignedintger")
+
+
+    expect(channelIdToPath('7ebe3c61-20cc-4a5e-8836-603162b273d4')).toEqual(['gps', 'times', 'unsignedintger', 'unsignedintger_sup'])
+    expect(channelIdToShortPathString('7ebe3c61-20cc-4a5e-8836-603162b273d4')).toBe("g/t/u/unsignedintger_sup")
+
+
+    expect(channelIdToPath('774374b6-ad61-4b0c-844e-7338412c7d85')).toEqual(['gps', 'times', 'unsignedintger2', 'test'])
+    expect(channelIdToShortPathString('774374b6-ad61-4b0c-844e-7338412c7d85')).toBe("g/t/unsignedintger2/test")
+
+
+    expect(channelIdToPath('1f83dc32-8db0-4237-8440-a0fb4fe52301')).toEqual(['event', 'hackathon', '24_spring', '02', "program"])
+    expect(channelIdToShortPathString("1f83dc32-8db0-4237-8440-a0fb4fe52301")).toBe("e/h/24_s/02/program")
+
+      // -----------------------------|---------|----------|---------|---------|------------------------
+      // File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s      
+      // -----------------------------|---------|----------|---------|---------|------------------------
+      // useChannelPath.ts            |   77.34 |    67.24 |   66.66 |   77.34 | ...165,174-178,182-187 
+  })
+})
+
+
+const channels: Channel[] = [
+  {
+    id: 'e50e2c2b-d9d5-4fc6-a30b-908a0f65d425',
+    name: 'event',
+    archived: false,
+    children: [],
+    force: false,
+    parentId: null,
+    topic: '',
+  },
+  {
+    id: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c',
+    name: 'gps',
+    archived: false,
+    children: [],
+    force: false,
+    parentId: null,
+    topic: '',
+  },
+    {
+        id: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+        name: 'times',
+        archived: false,
+        children: [],
+        force: false,
+        parentId: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c',
+        topic: '',
+    },
+        {
+            id: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
+            name: 'Naru_18',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+            topic: '',
+        },
+            {
+                id: '442154db-b6c2-4941-801f-60fe14bae4e2',
+                name: 'sub',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
+                topic: '',
+            },
+            {
+                id: '0d425611-823c-4177-933c-ec06c44ab347',
+                name: 'lec_jikkyo',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
+                topic: '',
+            },
+            {
+                id: 'a76c14d0-259c-4d3c-aceb-9b82b3d82bce',
+                name: 'ChildLongNameIsNotCut',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
+                topic: '',
+            },
+        {
+            id: '2b287559-12a5-4a95-a420-ee08aad2208c',
+            name: 'yasao',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+            topic: '',
+        },
+            {
+                id: '3de8179a-3b0a-4ac3-9876-f70d5b9a2628',
+                name: 'sub',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '2b287559-12a5-4a95-a420-ee08aad2208c',
+                topic: '',
+            },
+            {
+                id: 'e915b068-dc6e-4997-b44b-3ec045d226ca',
+                name: 'bot',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: null,
+                topic: '2b287559-12a5-4a95-a420-ee08aad2208c',
+            },
+        {
+            id: '6eebbc37-7025-4ced-be0d-581321e91c11',
+            name: 'unsignedintger',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+            topic: '',
+        },
+            {
+                id: '7ebe3c61-20cc-4a5e-8836-603162b273d4',
+                name: 'unsignedintger_sup',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '6eebbc37-7025-4ced-be0d-581321e91c11',
+                topic: '',
+            },
+            {
+                id: 'c0217492-3c4e-40b4-bd89-26f14e838150',
+                name: 'test',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '6eebbc37-7025-4ced-be0d-581321e91c11',
+                topic: '',
+            },
+        {
+            id: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
+            name: 'unsignedintger2',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+            topic: '',
+        },
+            {
+                id: '23c816cd-6239-411c-a2ef-a7dcd94430bd',
+                name: 'unsignedintger_sup',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
+                topic: '',
+            },
+            {
+                id: '774374b6-ad61-4b0c-844e-7338412c7d85',
+                name: 'test',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
+                topic: '',
+            },
+        {
+            id: '6636d7bf-8b4f-464e-b1c6-a8ed462b61aa',
+            name: 'ParentLongNameMayBeCut',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+            topic: '',
+        },
+            {
+                id: 'cad1904f-2f09-4330-aa22-69387e5e09c6',
+                name: 'sub',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '6636d7bf-8b4f-464e-b1c6-a8ed462b61aa',
+                topic: '',
+            },
+    {
+        id: 'f56e6d34-1f8b-4065-85b9-b85d8762daaf',
+        name: 'tips',
+        archived: false,
+        children: [],
+        force: false,
+        parentId: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c',
+        topic: '',
+    },
+        {
+            id: '268e5380-fbd3-4d97-846f-d15cf7f101ce',
+            name: 'yasao',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: 'f56e6d34-1f8b-4065-85b9-b85d8762daaf',
+            topic: '',
+        },
+            {
+                id: '96721686-2267-4ac7-ab6b-cd2780ecfe2d',
+                name: 'sub',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: "268e5380-fbd3-4d97-846f-d15cf7f101ce",
+                topic: '',
+            },
+            {
+                id: '4b8b5efd-7eed-454d-b59d-b76c52658048',
+                name: 'bot',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: '268e5380-fbd3-4d97-846f-d15cf7f101ce',
+                topic: '',
+            },
+  {
+    id: '17da19ef-2744-4550-8468-b01517db2905',
+    name: 'team',
+    archived: false,
+    children: [],
+    force: false,
+    parentId: null,
+    topic: '',
+  },
+  {
+    id: '734b0017-e1d3-4ef1-9200-d45f197b1df5',
+    name: 'event',
+    archived: false,
+    children: [],
+    force: false,
+    parentId: null,
+    topic: '',
+  },
+    {
+        id: '89a71d67-71de-4df5-bebd-abcc0c93614f',
+        name: 'hackathon',
+        archived: false,
+        children: [],
+        force: false,
+        parentId: '734b0017-e1d3-4ef1-9200-d45f197b1df5',
+        topic: '',
+    },
+        {
+            id: "d84082bd-9712-48a7-8329-67a13bf403e2",
+            name: '24_spring',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '89a71d67-71de-4df5-bebd-abcc0c93614f',
+            topic: '',
+        },
+            {
+                id: "97b6b3ee-760c-45bb-8968-53e71c00e373",
+                name: '01',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: "d84082bd-9712-48a7-8329-67a13bf403e2",
+                topic: '',
+            },
+                {
+                    id: "cc0d6a67-1e6e-424e-be96-6e121698301e",
+                    name: 'program',
+                    archived: false,
+                    children: [],
+                    force: false,
+                    parentId: "97b6b3ee-760c-45bb-8968-53e71c00e373",
+                    topic: '',
+                },
+            {
+                id: "6b57c3fc-6e0b-4d17-bfaa-f071b365a64e",
+                name: '02',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: "d84082bd-9712-48a7-8329-67a13bf403e2",
+                topic: '',
+            },
+                {
+                    id: "1f83dc32-8db0-4237-8440-a0fb4fe52301",
+                    name: 'program',
+                    archived: false,
+                    children: [],
+                    force: false,
+                    parentId: "6b57c3fc-6e0b-4d17-bfaa-f071b365a64e",
+                    topic: '',
+                },
+        {
+            id: "aad91ac9-b68e-4672-81aa-e70d439d1457",
+            name: '24_winter',
+            archived: false,
+            children: [],
+            force: false,
+            parentId: '89a71d67-71de-4df5-bebd-abcc0c93614f',
+            topic: '',
+        },
+            {
+                id: "20d544e4-64af-4849-a631-78b965c60b9c",
+                name: '01',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: 'aad91ac9-b68e-4672-81aa-e70d439d1457',
+                topic: '',
+            },
+                {
+                    id: "ebd67d81-a9e6-4510-8a72-5cdccb0f1116",
+                    name: 'program',
+                    archived: false,
+                    children: [],
+                    force: false,
+                    parentId: "20d544e4-64af-4849-a631-78b965c60b9c",
+                    topic: '',
+                },
+            {
+                id: "f9c17526-2e47-444f-86cf-e0a68e994247",
+                name: '02',
+                archived: false,
+                children: [],
+                force: false,
+                parentId: 'aad91ac9-b68e-4672-81aa-e70d439d1457',
+                topic: '',
+            },
+                {
+                    id: "314c5bb6-9646-43bd-9461-c0bfdbbbcfb5",
+                    name: 'program',
+                    archived: false,
+                    children: [],
+                    force: false,
+                    parentId: "f9c17526-2e47-444f-86cf-e0a68e994247",
+                    topic: '',
+                },
+  
+]

--- a/tests/unit/composables/channels/useChannelPath.spec.ts
+++ b/tests/unit/composables/channels/useChannelPath.spec.ts
@@ -1,385 +1,353 @@
 import { createTestingPinia } from '@pinia/testing'
 import { useChannelsStore } from '/@/store/entities/channels'
 import type { Channel } from '@traptitech/traq'
-import { useChannelTree } from '/@/store/domain/channelTree'
 import useChannel from '/@/composables/useChannelPath'
-
 
 describe('useChannelPath', () => {
   beforeEach(() => {
     createTestingPinia()
-    const {channelsMap} = useChannelsStore()
-    channelsMap.value = new Map(channels.map((c) => [c.id, c]))
-    for (const c of channelsMap.value){
-        if (c[1].parentId !== null){
-            channelsMap.value.get(c[1].parentId)?.children.push(c[0])
-        }
-    }
 
-    
-    // 初期化処理 (Arrange)
-    // チャンネルの一覧を初期化
+    const { channelsMap } = useChannelsStore()
+    const refinedChannels: Channel[] = channels.map(c => ({
+      ...c,
+      force: false,
+      topic: '',
+      children: []
+    }))
+    channelsMap.value = new Map(refinedChannels.map(c => [c.id, c]))
+    for (const c of channelsMap.value) {
+      if (c[1].parentId !== null) {
+        channelsMap.value.get(c[1].parentId)?.children.push(c[0])
+      }
+    }
   })
 
+  test('channelIdToShortPathString', () => {
+    const { channelIdToShortPathString, channelIdToPath } = useChannel()
 
+    expect(channelIdToPath('442154db-b6c2-4941-801f-60fe14bae4e2')).toEqual([
+      'gps',
+      'times',
+      'Naru_18',
+      'sub'
+    ])
+    expect(
+      channelIdToShortPathString('442154db-b6c2-4941-801f-60fe14bae4e2')
+    ).toBe('g/t/Naru_18/sub')
 
-  it("Shortfy chnnels path",() => {
-  const {channelIdToShortPathString, channelIdToPath} = useChannel()
-    
-    expect(channelIdToPath('442154db-b6c2-4941-801f-60fe14bae4e2')).toEqual(['gps', 'times', 'Naru_18', 'sub'])
-    expect(channelIdToShortPathString('442154db-b6c2-4941-801f-60fe14bae4e2')).toBe("g/t/Naru_18/sub")
+    expect(channelIdToPath('0d425611-823c-4177-933c-ec06c44ab347')).toEqual([
+      'gps',
+      'times',
+      'Naru_18',
+      'lec_jikkyo'
+    ])
+    expect(
+      channelIdToShortPathString('0d425611-823c-4177-933c-ec06c44ab347')
+    ).toBe('g/t/N/lec_jikkyo')
 
-    expect(channelIdToPath('0d425611-823c-4177-933c-ec06c44ab347')).toEqual(['gps', 'times', 'Naru_18', 'lec_jikkyo'])
-    expect(channelIdToShortPathString('0d425611-823c-4177-933c-ec06c44ab347')).toBe("g/t/N/lec_jikkyo")
+    expect(channelIdToPath('a76c14d0-259c-4d3c-aceb-9b82b3d82bce')).toEqual([
+      'gps',
+      'times',
+      'Naru_18',
+      'ChildLongNameIsNotCut'
+    ])
+    expect(
+      channelIdToShortPathString('a76c14d0-259c-4d3c-aceb-9b82b3d82bce')
+    ).toBe('g/t/N/ChildLongNameIsNotCut')
 
-    expect(channelIdToPath('a76c14d0-259c-4d3c-aceb-9b82b3d82bce')).toEqual(['gps', 'times', 'Naru_18', 'ChildLongNameIsNotCut'])
-    expect(channelIdToShortPathString('a76c14d0-259c-4d3c-aceb-9b82b3d82bce')).toBe("g/t/N/ChildLongNameIsNotCut")
+    expect(channelIdToPath('cad1904f-2f09-4330-aa22-69387e5e09c6')).toEqual([
+      'gps',
+      'times',
+      'ParentLongNameMayBeCut',
+      'sub'
+    ])
+    expect(
+      channelIdToShortPathString('cad1904f-2f09-4330-aa22-69387e5e09c6')
+    ).toBe('g/t/P/sub')
 
-    expect(channelIdToPath('cad1904f-2f09-4330-aa22-69387e5e09c6')).toEqual(['gps', 'times', 'ParentLongNameMayBeCut', 'sub'])
-    expect(channelIdToShortPathString('cad1904f-2f09-4330-aa22-69387e5e09c6')).toBe("g/t/P/sub")
+    expect(channelIdToPath('3de8179a-3b0a-4ac3-9876-f70d5b9a2628')).toEqual([
+      'gps',
+      'times',
+      'yasao',
+      'sub'
+    ])
+    expect(
+      channelIdToShortPathString('3de8179a-3b0a-4ac3-9876-f70d5b9a2628')
+    ).toBe('g/times/yasao/sub')
 
-    expect(channelIdToPath('3de8179a-3b0a-4ac3-9876-f70d5b9a2628')).toEqual(['gps', 'times', 'yasao', 'sub'])
-    expect(channelIdToShortPathString('3de8179a-3b0a-4ac3-9876-f70d5b9a2628')).toBe("g/times/yasao/sub")
+    expect(channelIdToPath('6eebbc37-7025-4ced-be0d-581321e91c11')).toEqual([
+      'gps',
+      'times',
+      'unsignedintger'
+    ])
+    expect(
+      channelIdToShortPathString('6eebbc37-7025-4ced-be0d-581321e91c11')
+    ).toBe('g/t/unsignedintger')
 
+    expect(channelIdToPath('7ebe3c61-20cc-4a5e-8836-603162b273d4')).toEqual([
+      'gps',
+      'times',
+      'unsignedintger',
+      'unsignedintger_sup'
+    ])
+    expect(
+      channelIdToShortPathString('7ebe3c61-20cc-4a5e-8836-603162b273d4')
+    ).toBe('g/t/u/unsignedintger_sup')
 
-    expect(channelIdToPath('6eebbc37-7025-4ced-be0d-581321e91c11')).toEqual(['gps', 'times', 'unsignedintger'])
-    expect(channelIdToShortPathString('6eebbc37-7025-4ced-be0d-581321e91c11')).toBe("g/t/unsignedintger")
+    expect(channelIdToPath('774374b6-ad61-4b0c-844e-7338412c7d85')).toEqual([
+      'gps',
+      'times',
+      'unsignedintger2',
+      'test'
+    ])
+    expect(
+      channelIdToShortPathString('774374b6-ad61-4b0c-844e-7338412c7d85')
+    ).toBe('g/t/unsignedintger2/test')
 
+    expect(channelIdToPath('1f83dc32-8db0-4237-8440-a0fb4fe52301')).toEqual([
+      'event',
+      'hackathon',
+      '24_spring',
+      '02',
+      'program'
+    ])
+    expect(
+      channelIdToShortPathString('1f83dc32-8db0-4237-8440-a0fb4fe52301')
+    ).toBe('e/h/24_s/02/program')
 
-    expect(channelIdToPath('7ebe3c61-20cc-4a5e-8836-603162b273d4')).toEqual(['gps', 'times', 'unsignedintger', 'unsignedintger_sup'])
-    expect(channelIdToShortPathString('7ebe3c61-20cc-4a5e-8836-603162b273d4')).toBe("g/t/u/unsignedintger_sup")
-
-
-    expect(channelIdToPath('774374b6-ad61-4b0c-844e-7338412c7d85')).toEqual(['gps', 'times', 'unsignedintger2', 'test'])
-    expect(channelIdToShortPathString('774374b6-ad61-4b0c-844e-7338412c7d85')).toBe("g/t/unsignedintger2/test")
-
-
-    expect(channelIdToPath('1f83dc32-8db0-4237-8440-a0fb4fe52301')).toEqual(['event', 'hackathon', '24_spring', '02', "program"])
-    expect(channelIdToShortPathString("1f83dc32-8db0-4237-8440-a0fb4fe52301")).toBe("e/h/24_s/02/program")
-
-      // -----------------------------|---------|----------|---------|---------|------------------------
-      // File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s      
-      // -----------------------------|---------|----------|---------|---------|------------------------
-      // useChannelPath.ts            |   77.34 |    67.24 |   66.66 |   77.34 | ...165,174-178,182-187 
+    expect(channelIdToPath('254b4e17-049c-4c0c-a27b-57d37d9eb573')).toEqual([
+      'gps',
+      'times',
+      'Naru_18',
+      'yasao_ignore'
+    ])
+    expect(
+      channelIdToShortPathString('254b4e17-049c-4c0c-a27b-57d37d9eb573')
+    ).toBe('g/t/N/yasao_ignore')
   })
 })
 
-
-const channels: Channel[] = [
+const channels: Omit<Channel, 'children' | 'topic' | 'force'>[] = [
   {
     id: 'e50e2c2b-d9d5-4fc6-a30b-908a0f65d425',
     name: 'event',
     archived: false,
-    children: [],
-    force: false,
-    parentId: null,
-    topic: '',
+    parentId: null
   },
   {
     id: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c',
     name: 'gps',
     archived: false,
-    children: [],
-    force: false,
-    parentId: null,
-    topic: '',
+    parentId: null
   },
-    {
-        id: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
-        name: 'times',
-        archived: false,
-        children: [],
-        force: false,
-        parentId: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c',
-        topic: '',
-    },
-        {
-            id: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
-            name: 'Naru_18',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
-            topic: '',
-        },
-            {
-                id: '442154db-b6c2-4941-801f-60fe14bae4e2',
-                name: 'sub',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
-                topic: '',
-            },
-            {
-                id: '0d425611-823c-4177-933c-ec06c44ab347',
-                name: 'lec_jikkyo',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
-                topic: '',
-            },
-            {
-                id: 'a76c14d0-259c-4d3c-aceb-9b82b3d82bce',
-                name: 'ChildLongNameIsNotCut',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
-                topic: '',
-            },
-        {
-            id: '2b287559-12a5-4a95-a420-ee08aad2208c',
-            name: 'yasao',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
-            topic: '',
-        },
-            {
-                id: '3de8179a-3b0a-4ac3-9876-f70d5b9a2628',
-                name: 'sub',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '2b287559-12a5-4a95-a420-ee08aad2208c',
-                topic: '',
-            },
-            {
-                id: 'e915b068-dc6e-4997-b44b-3ec045d226ca',
-                name: 'bot',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: null,
-                topic: '2b287559-12a5-4a95-a420-ee08aad2208c',
-            },
-        {
-            id: '6eebbc37-7025-4ced-be0d-581321e91c11',
-            name: 'unsignedintger',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
-            topic: '',
-        },
-            {
-                id: '7ebe3c61-20cc-4a5e-8836-603162b273d4',
-                name: 'unsignedintger_sup',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '6eebbc37-7025-4ced-be0d-581321e91c11',
-                topic: '',
-            },
-            {
-                id: 'c0217492-3c4e-40b4-bd89-26f14e838150',
-                name: 'test',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '6eebbc37-7025-4ced-be0d-581321e91c11',
-                topic: '',
-            },
-        {
-            id: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
-            name: 'unsignedintger2',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
-            topic: '',
-        },
-            {
-                id: '23c816cd-6239-411c-a2ef-a7dcd94430bd',
-                name: 'unsignedintger_sup',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
-                topic: '',
-            },
-            {
-                id: '774374b6-ad61-4b0c-844e-7338412c7d85',
-                name: 'test',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
-                topic: '',
-            },
-        {
-            id: '6636d7bf-8b4f-464e-b1c6-a8ed462b61aa',
-            name: 'ParentLongNameMayBeCut',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
-            topic: '',
-        },
-            {
-                id: 'cad1904f-2f09-4330-aa22-69387e5e09c6',
-                name: 'sub',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '6636d7bf-8b4f-464e-b1c6-a8ed462b61aa',
-                topic: '',
-            },
-    {
-        id: 'f56e6d34-1f8b-4065-85b9-b85d8762daaf',
-        name: 'tips',
-        archived: false,
-        children: [],
-        force: false,
-        parentId: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c',
-        topic: '',
-    },
-        {
-            id: '268e5380-fbd3-4d97-846f-d15cf7f101ce',
-            name: 'yasao',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: 'f56e6d34-1f8b-4065-85b9-b85d8762daaf',
-            topic: '',
-        },
-            {
-                id: '96721686-2267-4ac7-ab6b-cd2780ecfe2d',
-                name: 'sub',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: "268e5380-fbd3-4d97-846f-d15cf7f101ce",
-                topic: '',
-            },
-            {
-                id: '4b8b5efd-7eed-454d-b59d-b76c52658048',
-                name: 'bot',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: '268e5380-fbd3-4d97-846f-d15cf7f101ce',
-                topic: '',
-            },
+  {
+    id: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c',
+    name: 'times',
+    archived: false,
+    parentId: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c'
+  },
+  {
+    id: '26f396b1-2233-4e2f-b217-a3fb511a4bf4',
+    name: 'Naru_18',
+    archived: false,
+    parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c'
+  },
+  {
+    id: '442154db-b6c2-4941-801f-60fe14bae4e2',
+    name: 'sub',
+    archived: false,
+    parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4'
+  },
+  {
+    id: '0d425611-823c-4177-933c-ec06c44ab347',
+    name: 'lec_jikkyo',
+    archived: false,
+    parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4'
+  },
+  {
+    id: '254b4e17-049c-4c0c-a27b-57d37d9eb573',
+    name: 'yasao_ignore',
+    archived: false,
+    parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4'
+  },
+  {
+    id: 'a76c14d0-259c-4d3c-aceb-9b82b3d82bce',
+    name: 'ChildLongNameIsNotCut',
+    archived: false,
+    parentId: '26f396b1-2233-4e2f-b217-a3fb511a4bf4'
+  },
+  {
+    id: '2b287559-12a5-4a95-a420-ee08aad2208c',
+    name: 'yasao',
+    archived: false,
+    parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c'
+  },
+  {
+    id: '3de8179a-3b0a-4ac3-9876-f70d5b9a2628',
+    name: 'sub',
+    archived: false,
+    parentId: '2b287559-12a5-4a95-a420-ee08aad2208c'
+  },
+  {
+    id: 'e915b068-dc6e-4997-b44b-3ec045d226ca',
+    name: 'bot',
+    archived: false,
+    parentId: '2b287559-12a5-4a95-a420-ee08aad2208c'
+  },
+  {
+    id: 'bb9cfb69-1adc-404b-ad94-5d59ee34dca1',
+    name: 'yasao_ignore',
+    archived: true,
+    parentId: '2b287559-12a5-4a95-a420-ee08aad2208c'
+  },
+  {
+    id: '6eebbc37-7025-4ced-be0d-581321e91c11',
+    name: 'unsignedintger',
+    archived: false,
+    parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c'
+  },
+  {
+    id: '7ebe3c61-20cc-4a5e-8836-603162b273d4',
+    name: 'unsignedintger_sup',
+    archived: false,
+    parentId: '6eebbc37-7025-4ced-be0d-581321e91c11'
+  },
+  {
+    id: 'c0217492-3c4e-40b4-bd89-26f14e838150',
+    name: 'test',
+    archived: false,
+    parentId: '6eebbc37-7025-4ced-be0d-581321e91c11'
+  },
+  {
+    id: '5d9210f0-9809-474d-bfbb-287cd05a7fd5',
+    name: 'unsignedintger2',
+    archived: false,
+    parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c'
+  },
+  {
+    id: '23c816cd-6239-411c-a2ef-a7dcd94430bd',
+    name: 'unsignedintger_sup',
+    archived: false,
+    parentId: '5d9210f0-9809-474d-bfbb-287cd05a7fd5'
+  },
+  {
+    id: '774374b6-ad61-4b0c-844e-7338412c7d85',
+    name: 'test',
+    archived: false,
+    parentId: '5d9210f0-9809-474d-bfbb-287cd05a7fd5'
+  },
+  {
+    id: '6636d7bf-8b4f-464e-b1c6-a8ed462b61aa',
+    name: 'ParentLongNameMayBeCut',
+    archived: false,
+    parentId: '220832c7-9e86-40e6-bf84-b3bb28eb7c3c'
+  },
+  {
+    id: 'cad1904f-2f09-4330-aa22-69387e5e09c6',
+    name: 'sub',
+    archived: false,
+    parentId: '6636d7bf-8b4f-464e-b1c6-a8ed462b61aa'
+  },
+  {
+    id: 'f56e6d34-1f8b-4065-85b9-b85d8762daaf',
+    name: 'tips',
+    archived: false,
+    parentId: 'a89ae3f4-64c5-49cc-acc9-aaafa4d5ee4c'
+  },
+  {
+    id: '268e5380-fbd3-4d97-846f-d15cf7f101ce',
+    name: 'yasao',
+    archived: false,
+    parentId: 'f56e6d34-1f8b-4065-85b9-b85d8762daaf'
+  },
+  {
+    id: '96721686-2267-4ac7-ab6b-cd2780ecfe2d',
+    name: 'sub',
+    archived: false,
+    parentId: '268e5380-fbd3-4d97-846f-d15cf7f101ce'
+  },
+  {
+    id: '4b8b5efd-7eed-454d-b59d-b76c52658048',
+    name: 'bot',
+    archived: false,
+    parentId: '268e5380-fbd3-4d97-846f-d15cf7f101ce'
+  },
   {
     id: '17da19ef-2744-4550-8468-b01517db2905',
     name: 'team',
     archived: false,
-    children: [],
-    force: false,
-    parentId: null,
-    topic: '',
+    parentId: null
   },
   {
     id: '734b0017-e1d3-4ef1-9200-d45f197b1df5',
     name: 'event',
     archived: false,
-    children: [],
-    force: false,
-    parentId: null,
-    topic: '',
+    parentId: null
   },
-    {
-        id: '89a71d67-71de-4df5-bebd-abcc0c93614f',
-        name: 'hackathon',
-        archived: false,
-        children: [],
-        force: false,
-        parentId: '734b0017-e1d3-4ef1-9200-d45f197b1df5',
-        topic: '',
-    },
-        {
-            id: "d84082bd-9712-48a7-8329-67a13bf403e2",
-            name: '24_spring',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '89a71d67-71de-4df5-bebd-abcc0c93614f',
-            topic: '',
-        },
-            {
-                id: "97b6b3ee-760c-45bb-8968-53e71c00e373",
-                name: '01',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: "d84082bd-9712-48a7-8329-67a13bf403e2",
-                topic: '',
-            },
-                {
-                    id: "cc0d6a67-1e6e-424e-be96-6e121698301e",
-                    name: 'program',
-                    archived: false,
-                    children: [],
-                    force: false,
-                    parentId: "97b6b3ee-760c-45bb-8968-53e71c00e373",
-                    topic: '',
-                },
-            {
-                id: "6b57c3fc-6e0b-4d17-bfaa-f071b365a64e",
-                name: '02',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: "d84082bd-9712-48a7-8329-67a13bf403e2",
-                topic: '',
-            },
-                {
-                    id: "1f83dc32-8db0-4237-8440-a0fb4fe52301",
-                    name: 'program',
-                    archived: false,
-                    children: [],
-                    force: false,
-                    parentId: "6b57c3fc-6e0b-4d17-bfaa-f071b365a64e",
-                    topic: '',
-                },
-        {
-            id: "aad91ac9-b68e-4672-81aa-e70d439d1457",
-            name: '24_winter',
-            archived: false,
-            children: [],
-            force: false,
-            parentId: '89a71d67-71de-4df5-bebd-abcc0c93614f',
-            topic: '',
-        },
-            {
-                id: "20d544e4-64af-4849-a631-78b965c60b9c",
-                name: '01',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: 'aad91ac9-b68e-4672-81aa-e70d439d1457',
-                topic: '',
-            },
-                {
-                    id: "ebd67d81-a9e6-4510-8a72-5cdccb0f1116",
-                    name: 'program',
-                    archived: false,
-                    children: [],
-                    force: false,
-                    parentId: "20d544e4-64af-4849-a631-78b965c60b9c",
-                    topic: '',
-                },
-            {
-                id: "f9c17526-2e47-444f-86cf-e0a68e994247",
-                name: '02',
-                archived: false,
-                children: [],
-                force: false,
-                parentId: 'aad91ac9-b68e-4672-81aa-e70d439d1457',
-                topic: '',
-            },
-                {
-                    id: "314c5bb6-9646-43bd-9461-c0bfdbbbcfb5",
-                    name: 'program',
-                    archived: false,
-                    children: [],
-                    force: false,
-                    parentId: "f9c17526-2e47-444f-86cf-e0a68e994247",
-                    topic: '',
-                },
-  
+  {
+    id: '89a71d67-71de-4df5-bebd-abcc0c93614f',
+    name: 'hackathon',
+    archived: false,
+    parentId: '734b0017-e1d3-4ef1-9200-d45f197b1df5'
+  },
+  {
+    id: 'd84082bd-9712-48a7-8329-67a13bf403e2',
+    name: '24_spring',
+    archived: false,
+    parentId: '89a71d67-71de-4df5-bebd-abcc0c93614f'
+  },
+  {
+    id: '97b6b3ee-760c-45bb-8968-53e71c00e373',
+    name: '01',
+    archived: false,
+    parentId: 'd84082bd-9712-48a7-8329-67a13bf403e2'
+  },
+  {
+    id: 'cc0d6a67-1e6e-424e-be96-6e121698301e',
+    name: 'program',
+    archived: false,
+    parentId: '97b6b3ee-760c-45bb-8968-53e71c00e373'
+  },
+  {
+    id: '6b57c3fc-6e0b-4d17-bfaa-f071b365a64e',
+    name: '02',
+    archived: false,
+    parentId: 'd84082bd-9712-48a7-8329-67a13bf403e2'
+  },
+  {
+    id: '1f83dc32-8db0-4237-8440-a0fb4fe52301',
+    name: 'program',
+    archived: false,
+    parentId: '6b57c3fc-6e0b-4d17-bfaa-f071b365a64e'
+  },
+  {
+    id: 'aad91ac9-b68e-4672-81aa-e70d439d1457',
+    name: '24_winter',
+    archived: false,
+    parentId: '89a71d67-71de-4df5-bebd-abcc0c93614f'
+  },
+  {
+    id: '20d544e4-64af-4849-a631-78b965c60b9c',
+    name: '01',
+    archived: false,
+    parentId: 'aad91ac9-b68e-4672-81aa-e70d439d1457'
+  },
+  {
+    id: 'ebd67d81-a9e6-4510-8a72-5cdccb0f1116',
+    name: 'program',
+    archived: false,
+    parentId: '20d544e4-64af-4849-a631-78b965c60b9c'
+  },
+  {
+    id: 'f9c17526-2e47-444f-86cf-e0a68e994247',
+    name: '02',
+    archived: false,
+    parentId: 'aad91ac9-b68e-4672-81aa-e70d439d1457'
+  },
+  {
+    id: '314c5bb6-9646-43bd-9461-c0bfdbbbcfb5',
+    name: 'program',
+    archived: false,
+    parentId: 'f9c17526-2e47-444f-86cf-e0a68e994247'
+  }
 ]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -134,7 +134,7 @@ export default defineConfig(({ command, mode }) => ({
     },
     include: ['tests/unit/**/*.spec.ts'],
     globals: true,
-    setupFiles: ['tests/unit/setup.ts', 'tests/unit/expectExtends.ts'],
+    setupFiles: ['tests/unit/setup.ts', 'tests/unit/expectExtends.ts', 'fake-indexeddb/auto'],
     environment: 'jsdom',
     reporters: process.env.CI ? new GithubActionsReporter() : 'default',
     coverage: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -134,7 +134,11 @@ export default defineConfig(({ command, mode }) => ({
     },
     include: ['tests/unit/**/*.spec.ts'],
     globals: true,
-    setupFiles: ['tests/unit/setup.ts', 'tests/unit/expectExtends.ts', 'fake-indexeddb/auto'],
+    setupFiles: [
+      'tests/unit/setup.ts',
+      'tests/unit/expectExtends.ts',
+      'fake-indexeddb/auto'
+    ],
     environment: 'jsdom',
     reporters: process.env.CI ? new GithubActionsReporter() : 'default',
     coverage: {


### PR DESCRIPTION
## 概要

### モチベーション

close #4306

### やったこと

[チャンネル名の省略案3](https://github.com/traPtitech/traQ_S-UI/pull/4663) の処理を、親チャンネル、祖母チャンネル、曾祖母チャンネル...と任意に遡って処理をするようになった。具体的な挙動は[具体例](https://q.trap.jp/messages/0197d050-fdea-7c17-8fac-f2f6eb01460b)を参照すると分かりやすい。

※IndexedDBのモックのために`fake-indexeddb`を導入した

### 具体的な省略ロジック

- ① 現行の一文字略称 (ex: #g/t/n_and_n_over_3) を生成する
  - ①-corner 既存の1文字略称でもMAX_PATH_LENGTH(=20 (default))を超える場合はそのまま返す(return)
- ②「親チャンネルを遡って順々に名前を展開(フル名に置き換え)する」という操作を繰り返す。
  - 同名の従兄弟チャンネルが存在しなくなったら、この段階でのチャンネル名を返す(return)
↓途中でMAX_PATH_LENGTHを超えた場合、以下は短くしていく作業に入る
- ③ さっき展開したチャンネルから祖母チャンネルに向かって、「兄弟の中で一意に決定できる接頭辞部分に置き換える」という操作を繰り返す。
  - 途中でMAX_PATH_LENGTH文字以下になったら、この段階でのチャンネル名を返す(return)
↑操作を祖母チャンネルまで行った場合、このループを抜ける
- ④ フル名に展開したチャンネルしたチャンネルから祖母チャンネルに向かって、「チャンネル名の頭文字に置き換える」という操作を繰り返す。
  - 途中でMAX_PATH_LENGTH文字以下になったら、この段階でのチャンネル名を返す(return)
↑操作を祖母チャンネルまで行った場合、このループを抜ける
- ⑤ 求めるチャンネルの親チャンネルを、兄弟の中で一意に決定できる接頭辞部分に置き換えて出力する(return)
　(つまり、求めるチャンネルに同名の従兄弟チャンネルがある場合、最低でも親の一意接頭辞部分は表示する) 

### テストケースの解説

Ex) #gps/times/Naru_18/sub
- ① まず #g/t/N/sub とします。
- ② 従兄弟チャンネルとして #gps/times/yasao/sub があるので、親チャンネルを展開して #g/t/Naru_18/sub とします
- #gps/times/Naru_18 に同名の従兄弟チャンネルは存在しないので、これを出力します

出力：#g/t/Naru_18/sub
> コメント：この親の展開を基本動作とします

Ex) #gps/times/Naru_18/lec_jikkyo
- ① まず #g/t/N/lec_jikkyo とします。
- #gps/times/Naru_18/lec_jikkyo に同名の従兄弟チャンネルは存在しないので、これを出力します

出力：#g/t/N/lec_jikkyo
> コメント：今までと同様の省略形が渡されることもあります

Ex) #gps/times/Naru_18/ChildLongNameIsNotCut
- ① まず #g/t/N/ChildLongNameIsNotCut とします。
- ①-corner このパス名はMAX_PATH_LENGTH=20文字を超えています。よって、これを出力します
出力：#g/t/N/ChildLongNameIsNotCut
 
> コメント：子チャンネルは常にフルで表示されます

Ex) #gps/times/ParentLongNameMayBeCut/sub
- ① まず #g/t/P/sub とします。
- ② 従兄弟チャンネルとして #gps/times/yasao/sub があるので、親チャンネルを展開して #g/t/ParentLongNameMayBeCut/sub とします
しかし、ここでMAX_PATH_LENGTH(=20)文字を超えてしまうので、この処理は終了します
- ③ 先ほどは、ParentLongNameMayBeCutまで展開したので、これを短縮したいのですが、これは親チャンネルであるためこの段階では変更されません。よってまだMAX_PATH_LENGTH(=20)文字を超えています。
- ④ 同様に、ParentLongNameMayBeCutを1文字に置き換えたいのですが、これは親チャンネルであるためこの段階では変更されません。よってまだMAX_PATH_LENGTH(=20)文字を超えています。
- ⑤ この段階になると、親チャンネルを、兄弟チャンネルの名前の中で一意に定まる部分に省略することができます。よって、#g/t/P/sub となります 
出力：#g/t/P/sub 
 
> コメント：親チャンネルは、兄弟の中で一意に定まる部分にまで省略されます

Ex) #gps/times/yasao/sub
- ① まず #g/t/y/sub とします。
- ② 従兄弟チャンネルとして #gps/times/Naru_18/sub があるので、親チャンネルを展開して #g/t/yasao/sub とします
- ② 従兄弟チャンネルとして #gps/tips/yasao があるので、親チャンネルを展開して #g/times/yasao/sub とします
これ以上従兄弟は存在しないので、これを出力します
出力： #g/times/yasao/sub'

> コメント：親チャンネルへの展開は、祖母チャンネルなど上位のチャンネルに波及します

Ex) #gps/times/unsignedintger2/test
- ① まず #g/t/u/test とします。
- ② 従兄弟チャンネルとして #gps/times/unsignedintger/test があるので、親チャンネルを展開して #gps/times/unsignedintger2/test とします
しかし、ここでMAX_PATH_LENGTH(=20)文字を超えてしまうので、この処理は終了します
- ③ 先ほどは、ParentLongNameMayBeCutまで展開したので、これを短縮したいのですが、これは親チャンネルであるためこの段階では変更されません。よってまだMAX_PATH_LENGTH(=20)文字を超えています。
- ④ 同様に、unsignedintger2を1文字に置き換えたいのですが、これは親チャンネルであるためこの段階では変更されません。よってまだMAX_PATH_LENGTH(=20)文字を超えています。
- ⑤ この段階になると、親チャンネルを、兄弟チャンネルの名前の中で一意に定まる部分に省略することができます。よって、#g/t/unsignedintger2/test となります 
出力：#g/t/unsignedintger2/test

> コメント：親チャンネルの一意省略形によって、MAX_PATH_LENGTHを超えて可能性があります

Ex) #event/hackathon/24_spring/02/program
- ① まず #e/h/2/0/program とします。
- ② 従兄弟チャンネルとして #event/hackathon/24_spring/01/program があるので、親チャンネルを展開して #e/h/2/02/program とします
- ② 従兄弟チャンネルとして #event/hackathon/25_spring/02 があるので、親チャンネルを展開して #e/h/24_spring/02/program とします
この段階でMAX_PATH_LENGTH(=20)を超えたので、この操作を終了します
- ③ 先ほど展開したチャンネル(25_spring)を、兄弟の中で一意に定まるようにすると、24_sになるので、#e/h/24_s/02/programnになります。
MAX_PATH_LENGTH(=20)以下になったので出力します
出力：#e/h/24_s/02/program
> コメント：こんな感じ省略されることを望んでました

↓テストケースにおけるチャンネル構造
![image](https://github.com/user-attachments/assets/578c36fa-6ded-4226-8554-2a572b78d46d)


## 動作確認の手順
適当に検索する。あるいはアクティビティを見る。
特に、検索で、よくかぶっていそうなチャンネル名を調べてみる。

## UI 変更部分のスクリーンショット
![スクリーンショット 2025-07-04 004426](https://github.com/user-attachments/assets/8ef9d916-3ae7-4d36-b4c2-28041bed7a7a)
![スクリーンショット 2025-07-04 004347](https://github.com/user-attachments/assets/101dab8e-4656-4c4c-8a54-172674f169cd)
![スクリーンショット 2025-07-04 004525](https://github.com/user-attachments/assets/9de404db-0251-4736-810b-9995b600369c)

## 見てほしいところ・聞きたいことなど
- 改善点
  - 設計を見直し、深さ2の時と3以上の時で場合分けを無くした
  - ロジックを単純化し、いくつかの計算を関数にして、可読性が上がった （と思います）
  - 祖母チャンネルにも変更が波及するようになった （もしかしたら想定通りの挙動って感じではないかも）
- 課題
  - maxPathLengthの動的な変更ができていない
  - ~NonNullAssertionが残っていたり、などコードが綺麗でない （ここはcp20さんに見てもらって修正します）~
  - ~テストケースが不十分~
  - 挙動が不安定に見える(これは仕様で、いとこチャンネルじゃなくてはとこまで見ることで解決できそう)
