### PR TITLE
スタンプ削除の際に権限を確認するように

### DIFF
--- a/src/components/Modal/StampCreateModal/StampInfoEdit.vue
+++ b/src/components/Modal/StampCreateModal/StampInfoEdit.vue
@@ -64,6 +64,10 @@ const useStampCreate = (newStampName: Ref<string>, stampImage: File) => {
   const isCreating = ref(false)
 
   const createStamp = async () => {
+    if (!confirm(`本当に「:${newStampName.value}:」を作成しますか？（作成後のスタンプの削除はできません。）`)) {
+      return
+    }
+
     try {
       isCreating.value = true
       await apis.createStamp(newStampName.value, stampImage)

--- a/src/components/Modal/StampCreateModal/StampInfoEdit.vue
+++ b/src/components/Modal/StampCreateModal/StampInfoEdit.vue
@@ -64,7 +64,11 @@ const useStampCreate = (newStampName: Ref<string>, stampImage: File) => {
   const isCreating = ref(false)
 
   const createStamp = async () => {
-    if (!confirm(`本当に「:${newStampName.value}:」を作成しますか？（作成後のスタンプの削除はできません。）`)) {
+    if (
+      !confirm(
+        `本当に「:${newStampName.value}:」を作成しますか？（作成後のスタンプの削除はできません。）`
+      )
+    ) {
       return
     }
 

--- a/src/components/Settings/StampTab/StampContextMenu.vue
+++ b/src/components/Settings/StampTab/StampContextMenu.vue
@@ -10,6 +10,7 @@
         スタンプを編集する
       </button>
       <button
+        v-if="canDeleteStamp"
         :class="[$style.button, $style.dangerButton]"
         @click="withClose(deleteStamp)"
       >
@@ -29,6 +30,10 @@ import { useFileSelect } from '/@/composables/dom/useFileSelect'
 import apis from '/@/lib/apis'
 import useExecWithToast from '/@/composables/toast/useExecWithToast'
 import AIcon from '/@/components/UI/AIcon.vue'
+import { useMeStore } from '/@/store/domain/me'
+import { useStampsStore } from '/@/store/entities/stamps'
+import { UserPermission } from '@traptitech/traq'
+import { computed } from 'vue'
 
 const props = defineProps<{
   position: Point
@@ -41,6 +46,25 @@ const emit = defineEmits<{
 
 const { pushModal } = useModalStore()
 const { execWithToast } = useExecWithToast()
+const { detail, myId } = useMeStore()
+const { stampsMap } = useStampsStore()
+
+const canDeleteStamp = computed(() => {
+  if (detail.value?.permissions.includes(UserPermission.DeleteStamp)) {
+    return true
+  }
+  
+  if (!detail.value?.permissions.includes(UserPermission.DeleteMyStamp)) {
+    return false
+  }
+
+  const stamp = stampsMap.value.get(props.stampId)
+  if (!stamp) {
+    return false
+  }
+  
+  return stamp.creatorId === myId.value
+})
 
 const acceptImageType = [
   'image/jpeg',

--- a/src/components/Settings/StampTab/StampContextMenu.vue
+++ b/src/components/Settings/StampTab/StampContextMenu.vue
@@ -53,7 +53,7 @@ const canDeleteStamp = computed(() => {
   if (detail.value?.permissions.includes(UserPermission.DeleteStamp)) {
     return true
   }
-  
+
   if (!detail.value?.permissions.includes(UserPermission.DeleteMyStamp)) {
     return false
   }
@@ -62,7 +62,7 @@ const canDeleteStamp = computed(() => {
   if (!stamp) {
     return false
   }
-  
+
   return stamp.creatorId === myId.value
 })
 


### PR DESCRIPTION
## 概要

スタンプ削除の際に権限を確認するようにする

## なぜこの PR を入れたいのか

close: #4670 

バックエンド側で deleteMyStamp パーミッションを削除したので、それに合わせて

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

* 本番環境はまだ deleteMyStamp 権限があるので普通に表示される
* 開発環境は権限がないので削除ボタンが出なくなる

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
