### PR TITLE
refactor: `FeatureFlag.vue`で`defineModel`を使うように変更

### DIFF
--- a/src/components/Settings/FeatureFlagTab/FeatureFlag.vue
+++ b/src/components/Settings/FeatureFlagTab/FeatureFlag.vue
@@ -19,7 +19,6 @@
 
 <script lang="ts" setup>
 import AToggle from '/@/components/UI/AToggle.vue'
-import { useModelValueSyncer } from '/@/composables/useModelSyncer'
 import { useFeatureFlagSettings } from '/@/store/app/featureFlagSettings'
 
 const { featureFlags } = useFeatureFlagSettings()
@@ -27,15 +26,12 @@ const { featureFlags } = useFeatureFlagSettings()
 const props = defineProps<{
   title: string
   description: string
-  modelValue: boolean
   endAt: Date
 }>()
 
-const emit = defineEmits<{
-  (e: 'update:modelValue', _val: boolean): void
-}>()
-
-const value = useModelValueSyncer(props, emit)
+const value = defineModel<boolean>({
+  required: true
+})
 </script>
 
 <style lang="scss" module>


### PR DESCRIPTION
## 概要

`useModelValueSyncer`を`defineModel`に置き換え

## なぜこの PR を入れたいのか

`useModelValueSyncer`は技術的負債であるため

## 動作確認の手順

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
