### PR TITLE
chore: vue-tsc を最新バージョンに

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "vite-svg-loader": "^5.1.0",
         "vitest": "^3.0.5",
         "vitest-github-actions-reporter": "^0.11.1",
-        "vue-tsc": "^2.2.10",
+        "vue-tsc": "^3.0.1",
         "workbox-cacheable-response": "^7.3.0",
         "workbox-core": "^7.3.0",
         "workbox-expiration": "^7.3.0",
@@ -3195,6 +3195,29 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5129,27 +5152,30 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
-      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+      "version": "2.4.17",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.17.tgz",
+      "integrity": "sha512-chmRZMbKmcGpKMoO7Reb70uiLrzo0KWC2CkFttKUuKvrE+VYgi+fL9vWMJ07Fv5ulX0V1TAyyacN9q3nc5/ecA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@volar/source-map": "2.4.11"
+        "@volar/source-map": "2.4.17"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
-      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
-      "dev": true
+      "version": "2.4.17",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.17.tgz",
+      "integrity": "sha512-QDybtQyO3Ms/NjFqNHTC5tbDN2oK5VH7ZaKrcubtfHBDj63n2pizHC3wlMQ+iT55kQXZUUAbmBX5L1C8CHFeBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@volar/typescript": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
-      "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
+      "version": "2.4.17",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.17.tgz",
+      "integrity": "sha512-3paEFNh4P5DkgNUB2YkTRrfUekN4brAXxd3Ow1syMqdIPtCZHbUy4AW99S5RO/7mzyTWPMdDSo3mqTpB/LPObQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.11",
+        "@volar/language-core": "2.4.17",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
@@ -5271,18 +5297,18 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.10.tgz",
-      "integrity": "sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.1.tgz",
+      "integrity": "sha512-sq+/Mc1IqIexWEQ+Q2XPiDb5SxSvY5JPqHnMOl/PlF5BekslzduX8dglSkpC17VeiAQB6dpS+4aiwNLJRduCNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "~2.4.11",
+        "@volar/language-core": "2.4.17",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/compiler-vue2": "^2.7.16",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^1.0.3",
-        "minimatch": "^9.0.3",
+        "alien-signals": "^2.0.5",
+        "minimatch": "^10.0.1",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1"
       },
@@ -5293,6 +5319,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -5446,9 +5488,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
-      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.5.tgz",
+      "integrity": "sha512-PdJB6+06nUNAClInE3Dweq7/2xVAYM64vvvS1IHVHSJmgeOtEdrAGyp7Z2oJtYm0B342/Exd2NT0uMJaThcjLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10276,7 +10318,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -12818,10 +12861,11 @@
       }
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue": {
       "version": "3.5.17",
@@ -12905,14 +12949,14 @@
       "integrity": "sha512-0sBjoYrdSrnRUb8d8xgg5d/DwfAhTp/m20yiLrCM/n6CiY5joFAac3Ofru1xjyDPbZftk7CdB8nbodJDpeWHBQ=="
     },
     "node_modules/vue-tsc": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.10.tgz",
-      "integrity": "sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.1.tgz",
+      "integrity": "sha512-UvMLQD0hAGL1g/NfEQelnSVB4H5gtf/gz2lJKjMMwWNOUmSNyWkejwJagAxEbSjtV5CPPJYslOtoSuqJ63mhdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/typescript": "~2.4.11",
-        "@vue/language-core": "2.2.10"
+        "@volar/typescript": "2.4.17",
+        "@vue/language-core": "3.0.1"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "vite-svg-loader": "^5.1.0",
     "vitest": "^3.0.5",
     "vitest-github-actions-reporter": "^0.11.1",
-    "vue-tsc": "^2.2.10",
+    "vue-tsc": "^3.0.1",
     "workbox-cacheable-response": "^7.3.0",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
@@ -118,6 +118,7 @@ const onClickIcon = (e: KeyboardEvent | MouseEvent) => {
     (!hasChildren.value || e.button !== LEFT_CLICK_BUTTON)
   ) {
     openChannel(e)
+    return
   }
   emit('clickHash', props.channel.id)
 }

--- a/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
@@ -7,7 +7,7 @@
     <!-- チャンネル表示本体 -->
     <div :class="$style.channelContainer">
       <channel-element-icon
-        :class="$style.channelHash"
+        :class="$style.channelIcon"
         :has-child="hasChildren"
         :is-selected="isSelected"
         :is-opened="isOpened"
@@ -15,10 +15,9 @@
         :has-notification-on-child="notificationState.hasNotificationOnChild"
         :is-inactive="!channel.active"
         :icon-name="iconName"
-        @mousedown.stop="onChannelHashClick"
-        @keydown.enter="onChannelHashKeydownEnter"
-        @mouseenter="onHashHovered"
-        @mouseleave="onHashHoveredLeave"
+        @click.stop="onClickIcon"
+        @mouseenter="onIconHovered"
+        @mouseleave="onIconHoveredLeave"
       />
       <router-link
         v-slot="{ href, navigate }"
@@ -113,17 +112,14 @@ const isSelected = computed(
     props.channel.id === primaryView.value.channelId
 )
 
-const onChannelHashKeydownEnter = () => {
-  if (hasChildren.value) {
-    emit('clickHash', props.channel.id)
-  }
-}
-const onChannelHashClick = (e: MouseEvent) => {
-  if (hasChildren.value && e.button === LEFT_CLICK_BUTTON) {
-    emit('clickHash', props.channel.id)
-  } else {
+const onClickIcon = (e: KeyboardEvent | MouseEvent) => {
+  if (
+    e instanceof MouseEvent &&
+    (!hasChildren.value || e.button !== LEFT_CLICK_BUTTON)
+  ) {
     openChannel(e)
   }
+  emit('clickHash', props.channel.id)
 }
 
 const { openLink } = useOpenLink()
@@ -139,20 +135,20 @@ const notificationState = useNotificationState(toRef(props, 'channel'))
 const { isHovered, onMouseEnter, onMouseLeave } = useHover()
 const { isFocused, onFocus, onBlur } = useFocus()
 const {
-  isHovered: isHashHovered,
-  onMouseEnter: onHashMouseEnter,
-  onMouseLeave: onHashMouseLeave
+  isHovered: isIconHovered,
+  onMouseEnter: onIconMouseEnter,
+  onMouseLeave: onIconMouseLeave
 } = useHover()
-const onHashHovered = () => {
-  onHashMouseEnter()
+const onIconHovered = () => {
+  onIconMouseEnter()
   onMouseEnter()
 }
-const onHashHoveredLeave = () => {
-  onHashMouseLeave()
+const onIconHoveredLeave = () => {
+  onIconMouseLeave()
   onMouseLeave()
 }
 const isChannelBgHovered = computed(
-  () => isHovered.value && !(hasChildren.value && isHashHovered.value)
+  () => isHovered.value && !(hasChildren.value && isIconHovered.value)
 )
 
 const iconName = computed(() => {
@@ -208,7 +204,7 @@ $bgLeftShift: 8px;
   margin-left: $bgLeftShift;
   width: calc(100% - $bgLeftShift);
 }
-.channelHash {
+.channelIcon {
   flex-shrink: 0;
   cursor: pointer;
   position: absolute;

--- a/src/components/Main/NavigationBar/ChannelList/ChannelElementIcon.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelElementIcon.vue
@@ -9,6 +9,10 @@
           ? 'チャンネルツリーを閉じる'
           : undefined
     "
+    @mousedown.stop="onChannelIconClick"
+    @keydown.enter="onChannelIconKeydownEnter"
+    @mouseenter="onIconHovered"
+    @mouseleave="onIconHoveredLeave"
   >
     <div
       :class="$style.hash"
@@ -30,7 +34,7 @@
 import AIcon from '/@/components/UI/AIcon.vue'
 import NotificationIndicator from '/@/components/UI/NotificationIndicator.vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     hasChild?: boolean
     isSelected?: boolean
@@ -50,6 +54,28 @@ withDefaults(
     iconName: 'hash'
   }
 )
+
+const emit = defineEmits<{
+  (e: 'click', event: KeyboardEvent | MouseEvent): void
+  (e: 'mouseenter'): void
+  (e: 'mouseleave'): void
+}>()
+
+const onChannelIconKeydownEnter = (e: KeyboardEvent) => {
+  if (props.hasChild) {
+    emit('click', e)
+  }
+}
+const onChannelIconClick = (e: MouseEvent) => {
+  emit('click', e)
+}
+
+const onIconHovered = () => {
+  emit('mouseenter')
+}
+const onIconHoveredLeave = () => {
+  emit('mouseleave')
+}
 </script>
 
 <style lang="scss" module>

--- a/src/views/Settings/ThemeTab.vue
+++ b/src/views/Settings/ThemeTab.vue
@@ -32,10 +32,7 @@
     <div :class="$style.element">
       <div :class="$style.container">
         <h3 :class="$style.header">カスタムテーマ</h3>
-        <edit-theme
-          v-if="state.type === 'custom'"
-          @change-theme="changeTheme"
-        />
+        <edit-theme v-if="state.type === 'custom'" />
       </div>
     </div>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
   },
   "vueCompilerOptions": {
     "strictTemplates": true,
-    "fallthroughAttributes": true
+    "fallthroughAttributes": true,
+    "strictVModel": false
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "public/**/*.js"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "vueCompilerOptions": {
-    "strictTemplates": true
+    "strictTemplates": true,
+    "fallthroughAttributes": true
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "public/**/*.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

vue-tsc のバージョンと Vue の公式拡張機能のバージョンはリンクしており、そのメジャーアップデートによって深刻なズレが生じている。現状 vue-tsc では型エラーが出ないのに VSCode で見ると型エラーになる、という事案が発生している。

vue-tsc を最新に追従することでこの問題を解決する。

## 動作確認の手順

Vue の VSCode 拡張機能 (v3以上) を入れて適当なコードを見る (↓など)

https://github.com/traPtitech/traQ_S-UI/blob/a74ac42e3bdaa6b6b8600b3f874f268e2ef637dc/src/components/Main/CommandPalette/SearchResultMessageElement.vue#L20

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

一応[このオプションの説明](https://github.com/vuejs/language-tools/wiki/Vue-Compiler-Options#fallthroughattributes-v210)には「重いから注意して使ってね」と書いてる (が、明示的に全ての箇所で指定するのもめんどくさいと思うので入れてよいと思う)

vue-tsc v3 で型検査が大幅に強化されたことにより、大量の型エラーが発生した。`"strictVModel": false` にすることで多くを無視したので、これは将来的に解決する必要があるだろう。