### PR TITLE
perf: チャンネル名の省略アルゴリズムにキャッシュを入れて高速化

### DIFF
--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -6,6 +6,8 @@ import { channelPathToId } from '/@/lib/channelTree'
 import { useChannelsStore } from '/@/store/entities/channels'
 import { useUsersStore } from '../store/entities/users'
 import { useChannelTree } from '/@/store/domain/channelTree'
+import { memoizeWithPurge } from '/@/lib/memoize'
+import { watch } from 'vue'
 
 const MAX_SHORT_PATH_LENGTH = 20
 
@@ -246,6 +248,12 @@ const useChannelPath = () => {
     )
   }
 
+  const memoizedChannelIdToPathString = memoizeWithPurge(channelIdToPathString)
+
+  watch(channelsMap, () => {
+    memoizedChannelIdToPathString.purge()
+  })
+
   const channelIdToLink = (id: ChannelId | DMChannelId) => {
     const pathString = channelIdToPathString(id, false)
     if (dmChannelsMap.value.has(id)) {
@@ -259,7 +267,7 @@ const useChannelPath = () => {
     channelIdToPath,
     channelIdToSimpleChannelPath,
     channelIdToPathString,
-    channelIdToShortPathString,
+    channelIdToShortPathString: memoizedChannelIdToPathString.memoized,
     channelIdToLink
   }
 }

--- a/src/lib/memoize.ts
+++ b/src/lib/memoize.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- 汎用的に全ての関数を許容する
+export const memoizeWithPurge = <T extends (...args: any[]) => any>(
+  fn: T
+): { memoized: T; purge: () => void } => {
+  const cache = new Map<string, ReturnType<T>>()
+
+  const memoized = ((...args: unknown[]) => {
+    const key = JSON.stringify(args)
+    if (cache.has(key)) {
+      return cache.get(key)
+    }
+    const result = fn(...args)
+    cache.set(key, result)
+    return result
+  }) as T
+
+  const purge = (): void => {
+    cache.clear()
+  }
+
+  return {
+    memoized,
+    purge
+  }
+}


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

#4666 で大幅に強化された 
`channelIdToShortPathString()` の実行時間が非常に大きくなり、無視できなくなっているため

## 動作確認の手順

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
