### PR TITLE
feat:グループ管理画面の一番下に余白を追加

### DIFF
--- a/src/components/GroupManager/DesktopGroupManager.vue
+++ b/src/components/GroupManager/DesktopGroupManager.vue
@@ -53,7 +53,7 @@ const { openGroupCreateModal } = useGroupCreateModalOpener()
   margin: 0 auto;
 }
 .item {
-  margin: 24px 0px;
+  margin: 24px 0;
   &:first-child {
     margin-top: 0;
   }

--- a/src/components/GroupManager/DesktopGroupManager.vue
+++ b/src/components/GroupManager/DesktopGroupManager.vue
@@ -53,7 +53,7 @@ const { openGroupCreateModal } = useGroupCreateModalOpener()
   margin: 0 auto;
 }
 .item {
-  margin: 24px 0;
+  margin: 24px 0px;
   &:first-child {
     margin-top: 0;
   }
@@ -81,6 +81,6 @@ const { openGroupCreateModal } = useGroupCreateModalOpener()
   @include color-ui-secondary;
 }
 .list {
-  padding: 0 16px;
+  padding: 0px 16px 50px 16px;
 }
 </style>


### PR DESCRIPTION
## 概要

グループ管理画面の一番下に余白を追加
## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->
fix: #3484
## 動作確認の手順

## UI 変更部分のスクリーンショット

### before
<img width="1140" height="946" alt="image" src="https://github.com/user-attachments/assets/ec64ef7c-771e-41e0-a346-1e83cb6fef12" />

### after
<img width="1137" height="938" alt="image" src="https://github.com/user-attachments/assets/6f91e83e-3a09-4886-8d0d-d4b5bc2ef6d2" />
## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [ ] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
