### PR TITLE
fix: サイドバーから読み込まれていないメッセージのピン留めを削除するとピン留めリストに反映されない問題の修正

### DIFF
--- a/src/composables/message/usePinnedMessages.ts
+++ b/src/composables/message/usePinnedMessages.ts
@@ -52,25 +52,19 @@ const usePinnedMessages = (channelId: Ref<ChannelId>) => {
   useMittListener(messageMitt, 'deleteMessage', messageId => {
     removePinnedMessage(messageId)
   })
-  useMittListener(
-    messageMitt,
-    'changeMessagePinned',
-    async ({ message, pinned }) => {
-      if (channelId.value !== message.channelId) return
+  useMittListener(messageMitt, 'pinMessage', async message => {
+    if (channelId.value !== message.channelId) return
 
-      if (!pinned) {
-        removePinnedMessage(message.id)
-        return
-      }
-
-      const { data: pin } = await apis.getPin(message.id)
-      addPinnedMessage({
-        userId: pin.userId,
-        message,
-        pinnedAt: pin.pinnedAt
-      })
-    }
-  )
+    const { data: pin } = await apis.getPin(message.id)
+    addPinnedMessage({
+      userId: pin.userId,
+      message,
+      pinnedAt: pin.pinnedAt
+    })
+  })
+  useMittListener(messageMitt, 'unpinMessage', messageId => {
+    removePinnedMessage(messageId)
+  })
   useMittListener(wsListener, 'reconnect', async () => {
     await fetchPins(channelId.value)
   })


### PR DESCRIPTION
## 概要
今まではIDからメッセージ本体を取得する処理を挟んでいた
しかしピン留めの削除ではIDしか必要ではない

## なぜこの PR を入れたいのか

close: #3248

## 動作確認の手順

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
