### PR TITLE
feat(navigation): リサイズ・折り畳み可能なナビゲーションバー

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationButton.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationButton.vue
@@ -91,14 +91,14 @@ const focusTrigger = () => {
 
   cursor: pointer;
   overflow: hidden;
-  height: 24px;
+  height: 32px;
   width: 24px;
   margin: 0 8px;
   display: grid;
   place-items: center;
   flex-shrink: 0;
   position: sticky;
-  right: 0;
+  right: -1px;
 
   transition: transform 0.1s;
 

--- a/src/components/Main/NavigationBar/ChannelList/ChannelListSelector.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelListSelector.vue
@@ -13,6 +13,7 @@
       :tabindex="isStarred ? -1 : 0"
       @click="unselectStarFilter"
     />
+    <div :class="$style.spacer" />
     <ATab
       ref="staredTabRef"
       label="お気に入り"
@@ -79,8 +80,17 @@ const unselectStarFilter = () => {
 <style lang="scss" module>
 .container {
   display: flex;
-  gap: 0.5rem;
+  padding-left: 0.2rem;
   margin-bottom: 0.75rem;
-  flex-wrap: wrap;
+
+  .spacer {
+    width: 0.9rem;
+    flex-shrink: 1;
+  }
+
+  button {
+    flex-shrink: 0;
+    padding-inline: 0.8rem;
+  }
 }
 </style>

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -37,7 +37,13 @@
         />
       </transition>
     </div>
-    <div :class="$style.resizer" @mousedown="startResizing" />
+    <div
+      ref="navigationResizerRef"
+      :class="$style.resizer"
+      @pointerdown="onDragStart"
+      @pointermove="onDragging"
+      @pointerup="onDragEnd"
+    />
   </div>
 </template>
 
@@ -59,10 +65,16 @@ const {
   onEphemeralEntryAdd
 } = useNavigation()
 
-const { navigationRef } = useNavigationLayoutStore()
+const { navigationRef, resizerRef: navigationResizerRef } =
+  useNavigationLayoutStore()
 
-const { isNavigationClosed, startResizing, navigationWidth } =
-  useNavigationResizer()
+const {
+  isNavigationClosed,
+  onDragStart,
+  onDragging,
+  onDragEnd,
+  navigationWidth
+} = useNavigationResizer()
 </script>
 
 <style lang="scss" module>

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -102,11 +102,11 @@ $ephemeralNavigationMinHeight: 64px;
   scrollbar-width: none;
 }
 .resizer {
-  width: 2px;
+  width: 3px;
   height: 100%;
   position: absolute;
   z-index: $z-index-sidebar;
-  right: 0;
+  right: -1px;
   top: 0;
   background-color: transparent;
   cursor: e-resize;
@@ -123,8 +123,8 @@ $ephemeralNavigationMinHeight: 64px;
   &::before {
     content: '';
     position: absolute;
-    left: -8px;
-    right: -8px;
+    left: -2px;
+    right: -12px;
     top: 0;
     bottom: 0;
     background-color: transparent;

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -111,12 +111,16 @@ $ephemeralNavigationMinHeight: 64px;
   background-color: transparent;
   cursor: e-resize;
 
+  transition: background-color 125ms linear;
+
   &:hover {
     background-color: $theme-accent-focus-default;
+    transition: background-color 0.1s ease-out;
   }
 
   &:active {
     background-color: $theme-accent-primary-default;
+    transition: background-color 0.1s ease-out;
   }
 
   // ヒット領域を拡張

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -20,6 +20,7 @@
       <DesktopToolBox />
     </div>
     <div
+      ref="navigations"
       :style="{ width: `${navigationWidth}px` }"
       :class="[$style.navigations, { [$style.hidden]: isNavigationClosed }]"
     >

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -54,7 +54,7 @@ import EphemeralNavigationContent from '/@/components/Main/NavigationBar/Ephemer
 import DesktopNavigationSelector from '/@/components/Main/NavigationBar/DesktopNavigationSelector.vue'
 import DesktopToolBox from '/@/components/Main/NavigationBar/DesktopToolBox.vue'
 import useNavigation from './composables/useNavigation'
-import { useNavigationResizer } from '/@/composables/dom/useNavigationResizer'
+import useNavigationResizer from './composables/useNavigationResizer'
 import { useNavigationLayoutStore } from '/@/store/ui/navigationLayout'
 
 const {

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -1,6 +1,11 @@
 <template>
   <div :class="$style.container">
-    <div :class="$style.selector">
+    <div
+      :class="[
+        $style.selector,
+        { [$style.scrollbarHidden]: isNavigationClosed }
+      ]"
+    >
       <DesktopNavigationSelector
         :current-navigation="navigationSelectorState.currentNavigation"
         :current-ephemeral-navigation="
@@ -17,6 +22,7 @@
       <NavigationContent
         :current-navigation="navigationSelectorState.currentNavigation"
         :style="{ width: `${navigationWidth}px` }"
+        :class="{ [$style.hidden]: isNavigationClosed }"
       />
       <transition name="fade-bottom">
         <EphemeralNavigationContent
@@ -49,7 +55,8 @@ const {
   onEphemeralEntryAdd
 } = useNavigation()
 
-const { startResizing, navigationWidth } = useNavigationResizer()
+const { isNavigationClosed, startResizing, navigationWidth } =
+  useNavigationResizer()
 </script>
 
 <style lang="scss" module>
@@ -85,6 +92,12 @@ $ephemeralNavigationMinHeight: 64px;
   width: #{calc(100% - #{$ephemeralNavigationSideMargin * 2})};
   margin: 0 $ephemeralNavigationSideMargin;
   flex: 0 1 $ephemeralNavigationMinHeight;
+}
+.hidden {
+  display: none;
+}
+.scrollbarHidden {
+  scrollbar-width: none;
 }
 .resizer {
   width: 2px;

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -20,7 +20,7 @@
       <DesktopToolBox />
     </div>
     <div
-      ref="navigations"
+      ref="navigationRef"
       :style="{ width: `${navigationWidth}px` }"
       :class="[$style.navigations, { [$style.hidden]: isNavigationClosed }]"
     >
@@ -48,6 +48,7 @@ import DesktopNavigationSelector from '/@/components/Main/NavigationBar/DesktopN
 import DesktopToolBox from '/@/components/Main/NavigationBar/DesktopToolBox.vue'
 import useNavigation from './composables/useNavigation'
 import { useNavigationResizer } from '/@/composables/dom/useNavigationResizer'
+import { useNavigationLayoutStore } from '/@/store/ui/navigationLayout'
 
 const {
   navigationSelectorState,
@@ -57,6 +58,8 @@ const {
   onEphemeralEntryRemove,
   onEphemeralEntryAdd
 } = useNavigation()
+
+const { navigationRef } = useNavigationLayoutStore()
 
 const { isNavigationClosed, startResizing, navigationWidth } =
   useNavigationResizer()

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -19,11 +19,12 @@
       />
       <DesktopToolBox />
     </div>
-    <div :class="$style.navigations">
+    <div
+      :style="{ width: `${navigationWidth}px` }"
+      :class="[$style.navigations, { [$style.hidden]: isNavigationClosed }]"
+    >
       <NavigationContent
         :current-navigation="navigationSelectorState.currentNavigation"
-        :style="{ width: `${navigationWidth}px` }"
-        :class="{ [$style.hidden]: isNavigationClosed }"
       />
       <transition name="fade-bottom">
         <EphemeralNavigationContent

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -11,6 +11,7 @@
         :current-ephemeral-navigation="
           ephemeralNavigationSelectorState.currentNavigation
         "
+        :show-current="!isNavigationClosed"
         @navigation-change="onNavigationChange"
         @ephemeral-navigation-change="onEphemeralNavigationChange"
         @ephemeral-entry-remove="onEphemeralEntryRemove"

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -43,6 +43,7 @@
       @pointerdown="onDragStart"
       @pointermove="onDragging"
       @pointerup="onDragEnd"
+      @dblclick="initializeNavigationWidth"
     />
   </div>
 </template>
@@ -67,6 +68,7 @@ const {
 
 const {
   isNavigationClosed,
+  initializeNavigationWidth,
   navigationRef,
   resizerRef: navigationResizerRef
 } = useNavigationLayoutStore()

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -15,8 +15,8 @@
     </div>
     <div :class="$style.navigations">
       <NavigationContent
-        :class="$style.navigation"
         :current-navigation="navigationSelectorState.currentNavigation"
+        :style="{ width: `${navigationWidth}px` }"
       />
       <transition name="fade-bottom">
         <EphemeralNavigationContent
@@ -28,6 +28,7 @@
         />
       </transition>
     </div>
+    <div :class="$style.resizer" @mousedown="startResizing" />
   </div>
 </template>
 
@@ -37,6 +38,7 @@ import EphemeralNavigationContent from '/@/components/Main/NavigationBar/Ephemer
 import DesktopNavigationSelector from '/@/components/Main/NavigationBar/DesktopNavigationSelector.vue'
 import DesktopToolBox from '/@/components/Main/NavigationBar/DesktopToolBox.vue'
 import useNavigation from './composables/useNavigation'
+import { useNavigationResizer } from '/@/composables/dom/useNavigationResizer'
 
 const {
   navigationSelectorState,
@@ -46,6 +48,8 @@ const {
   onEphemeralEntryRemove,
   onEphemeralEntryAdd
 } = useNavigation()
+
+const { startResizing, navigationWidth } = useNavigationResizer()
 </script>
 
 <style lang="scss" module>
@@ -54,8 +58,9 @@ $ephemeralNavigationMinHeight: 64px;
 
 .container {
   @include color-ui-primary;
+  position: relative;
   display: flex;
-  width: 100%;
+  width: fit-content;
   height: 100%;
   background: var(--specific-navigation-bar-desktop-background);
 }
@@ -76,12 +81,38 @@ $ephemeralNavigationMinHeight: 64px;
   min-width: 0;
   flex: 1;
 }
-.navigation {
-  width: 100%;
-}
 .ephemeralNavigation {
   width: #{calc(100% - #{$ephemeralNavigationSideMargin * 2})};
   margin: 0 $ephemeralNavigationSideMargin;
   flex: 0 1 $ephemeralNavigationMinHeight;
+}
+.resizer {
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  z-index: $z-index-sidebar;
+  right: 0;
+  top: 0;
+  background-color: transparent;
+  cursor: e-resize;
+
+  &:hover {
+    background-color: $theme-accent-focus-default;
+  }
+
+  &:active {
+    background-color: $theme-accent-primary-default;
+  }
+
+  // ヒット領域を拡張
+  &::before {
+    content: '';
+    position: absolute;
+    left: -8px;
+    right: -8px;
+    top: 0;
+    bottom: 0;
+    background-color: transparent;
+  }
 }
 </style>

--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -65,16 +65,14 @@ const {
   onEphemeralEntryAdd
 } = useNavigation()
 
-const { navigationRef, resizerRef: navigationResizerRef } =
-  useNavigationLayoutStore()
-
 const {
   isNavigationClosed,
-  onDragStart,
-  onDragging,
-  onDragEnd,
-  navigationWidth
-} = useNavigationResizer()
+  navigationRef,
+  resizerRef: navigationResizerRef
+} = useNavigationLayoutStore()
+
+const { onDragStart, onDragging, onDragEnd, navigationWidth } =
+  useNavigationResizer()
 </script>
 
 <style lang="scss" module>

--- a/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
@@ -40,6 +40,7 @@ import {
 import type { EphemeralNavigationSelectorEntry } from './composables/useNavigationSelectorEntry'
 import useNavigationSelectorEntry from './composables/useNavigationSelectorEntry'
 import { VERSION } from '/@/lib/define'
+import { useNavigationResizer } from '/@/composables/dom/useNavigationResizer'
 
 withDefaults(
   defineProps<{
@@ -58,11 +59,23 @@ const emit = defineEmits<{
   (e: 'ephemeralEntryAdd', _entry: EphemeralNavigationSelectorEntry): void
 }>()
 
-const { onNavigationItemClick } = useNavigationSelectorItem(emit)
-const { onNavigationItemClick: onEphemeralNavigationItemClick } =
+const { onNavigationItemClick: onNavigationItemClickImpl } =
+  useNavigationSelectorItem(emit)
+const { onNavigationItemClick: onEphemeralNavigationItemClickImpl } =
   useEphemeralNavigationSelectorItem(emit)
 const { entries, ephemeralEntries } = useNavigationSelectorEntry()
 const showSeparator = computed(() => ephemeralEntries.value.length > 0)
+const { restoreNavigationWidth } = useNavigationResizer()
+
+const onNavigationItemClick = (item: NavigationItemType) => {
+  onNavigationItemClickImpl(item)
+  restoreNavigationWidth()
+}
+
+const onEphemeralNavigationItemClick = (item: EphemeralNavigationItemType) => {
+  onEphemeralNavigationItemClickImpl(item)
+  restoreNavigationWidth()
+}
 
 watch(ephemeralEntries, (entries, prevEntries) => {
   prevEntries

--- a/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
@@ -5,7 +5,7 @@
       v-for="item in entries"
       :key="item.type"
       :class="$style.item"
-      :is-selected="currentNavigation === item.type"
+      :is-selected="showCurrent && currentNavigation === item.type"
       :has-notification="item.hasNotification"
       :icon-mdi="item.iconMdi"
       :icon-name="item.iconName"
@@ -16,7 +16,7 @@
       v-for="item in ephemeralEntries"
       :key="item.type"
       :class="$style.item"
-      :is-selected="currentEphemeralNavigation === item.type"
+      :is-selected="showCurrent && currentEphemeralNavigation === item.type"
       :icon-mdi="item.iconMdi"
       :icon-name="item.iconName"
       :color-claim="item.colorClaim"
@@ -46,9 +46,11 @@ withDefaults(
   defineProps<{
     currentNavigation?: NavigationItemType
     currentEphemeralNavigation?: EphemeralNavigationItemType
+    showCurrent?: boolean
   }>(),
   {
-    currentNavigation: 'home' as const
+    currentNavigation: 'home' as const,
+    showCurrent: true as const
   }
 )
 

--- a/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
@@ -42,7 +42,7 @@ import useNavigationSelectorEntry from './composables/useNavigationSelectorEntry
 import { VERSION } from '/@/lib/define'
 import { useNavigationResizer } from '/@/composables/dom/useNavigationResizer'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     currentNavigation?: NavigationItemType
     currentEphemeralNavigation?: EphemeralNavigationItemType
@@ -67,17 +67,31 @@ const { onNavigationItemClick: onEphemeralNavigationItemClickImpl } =
   useEphemeralNavigationSelectorItem(emit)
 const { entries, ephemeralEntries } = useNavigationSelectorEntry()
 const showSeparator = computed(() => ephemeralEntries.value.length > 0)
-const { restoreNavigationWidth } = useNavigationResizer()
+const { isNavigationClosed, restoreNavigationWidth } = useNavigationResizer()
 
 const onNavigationItemClick = (item: NavigationItemType) => {
   onNavigationItemClickImpl(item)
   restoreNavigationWidth()
 }
 
+let previousEphemeralNavigation: EphemeralNavigationItemType | null = null
+
 const onEphemeralNavigationItemClick = (item: EphemeralNavigationItemType) => {
+  previousEphemeralNavigation = null
   onEphemeralNavigationItemClickImpl(item)
   restoreNavigationWidth()
 }
+
+watch(isNavigationClosed, closed => {
+  if (closed) {
+    if (!props.currentEphemeralNavigation) return
+    previousEphemeralNavigation = props.currentEphemeralNavigation
+  } else {
+    if (!previousEphemeralNavigation) return
+  }
+
+  onEphemeralNavigationItemClickImpl(previousEphemeralNavigation)
+})
 
 watch(ephemeralEntries, (entries, prevEntries) => {
   prevEntries

--- a/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationSelector.vue
@@ -40,7 +40,7 @@ import {
 import type { EphemeralNavigationSelectorEntry } from './composables/useNavigationSelectorEntry'
 import useNavigationSelectorEntry from './composables/useNavigationSelectorEntry'
 import { VERSION } from '/@/lib/define'
-import { useNavigationResizer } from '/@/composables/dom/useNavigationResizer'
+import { useNavigationLayoutStore } from '/@/store/ui/navigationLayout'
 
 const props = withDefaults(
   defineProps<{
@@ -67,7 +67,8 @@ const { onNavigationItemClick: onEphemeralNavigationItemClickImpl } =
   useEphemeralNavigationSelectorItem(emit)
 const { entries, ephemeralEntries } = useNavigationSelectorEntry()
 const showSeparator = computed(() => ephemeralEntries.value.length > 0)
-const { isNavigationClosed, restoreNavigationWidth } = useNavigationResizer()
+const { isNavigationClosed, restoreNavigationWidth } =
+  useNavigationLayoutStore()
 
 const onNavigationItemClick = (item: NavigationItemType) => {
   onNavigationItemClickImpl(item)

--- a/src/components/Main/NavigationBar/NavigationContent/ToggleButton.vue
+++ b/src/components/Main/NavigationBar/NavigationContent/ToggleButton.vue
@@ -33,7 +33,7 @@ const toggle = () => {
 <style lang="scss" module>
 .container {
   @include background-primary;
-  padding: 4px 28px;
+  padding: 4px 14px;
   border-radius: 4px;
   text-align: center;
   cursor: pointer;

--- a/src/components/Main/NavigationBar/NavigationSelectorItem.vue
+++ b/src/components/Main/NavigationBar/NavigationSelectorItem.vue
@@ -66,7 +66,7 @@ const containerStyle = computed(() => ({
   }
   &[aria-selected='true']::after,
   &:hover::after,
-  &:focus::after {
+  &:active::after {
     opacity: 0.1;
   }
 }

--- a/src/components/Main/NavigationBar/composables/useNavigationResizer.ts
+++ b/src/components/Main/NavigationBar/composables/useNavigationResizer.ts
@@ -11,7 +11,9 @@ import useInnerWindowSize from '/@/composables/dom/useInnerWindowSize'
 const useNavigationResizer = () => {
   const animationFrame = createAnimationFrameController()
 
-  const { width: windowWidth } = useInnerWindowSize({ width: Infinity })
+  const { width: windowWidth } = useInnerWindowSize({
+    fallback: { width: Infinity }
+  })
 
   const {
     resizerRef,

--- a/src/components/Main/NavigationBar/composables/useNavigationResizer.ts
+++ b/src/components/Main/NavigationBar/composables/useNavigationResizer.ts
@@ -6,9 +6,9 @@ import {
   NAVIGATION_CLOSING_THRESHOLD
 } from '/@/store/ui/navigationLayout'
 import { createAnimationFrameController } from '/@/lib/dom/animationFrame'
-import useInnerWindowSize from './useInnerWindowSize'
+import useInnerWindowSize from '/@/composables/dom/useInnerWindowSize'
 
-export const useNavigationResizer = () => {
+const useNavigationResizer = () => {
   const animationFrame = createAnimationFrameController()
 
   const { width: windowWidth } = useInnerWindowSize({ width: Infinity })
@@ -99,3 +99,5 @@ export const useNavigationResizer = () => {
     onDragEnd
   }
 }
+
+export default useNavigationResizer

--- a/src/composables/dom/useInnerWindowSize.ts
+++ b/src/composables/dom/useInnerWindowSize.ts
@@ -1,19 +1,35 @@
 import { debounce } from 'throttle-debounce'
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, type ComputedRef } from 'vue'
 
-type Option = {
+type Fallback = {
+  width?: number
+  height?: number
+}
+
+type Options<F extends Fallback = object> = {
+  fallback?: F
   delay?: number
 }
 
-export const useInnerWindowSize = (
-  fallback?: {
-    width?: number
-    height?: number
-  },
-  { delay = 64 }: Option = {}
-) => {
-  const width = ref<number>(fallback?.width ?? NaN)
-  const height = ref<number>(fallback?.height ?? NaN)
+type ReturnWidth<F> =
+  | number
+  | (F extends { width: infer T extends number } ? T : undefined)
+
+type ReturnHeight<F> =
+  | number
+  | (F extends { height: infer T extends number } ? T : undefined)
+
+type Return<F> = {
+  width: ComputedRef<ReturnWidth<F>>
+  height: ComputedRef<ReturnHeight<F>>
+}
+
+function useInnerWindowSize<F extends Fallback>({
+  fallback = {} as F,
+  delay = 64
+}: Options<F> = {}) {
+  const width = ref(fallback.width)
+  const height = ref(fallback.height)
 
   const updateSize = debounce(delay, () => {
     if (typeof window === 'undefined') return
@@ -33,7 +49,9 @@ export const useInnerWindowSize = (
   return {
     width,
     height
-  }
+  } as Return<F>
 }
+
+export { useInnerWindowSize }
 
 export default useInnerWindowSize

--- a/src/composables/dom/useInnerWindowSize.ts
+++ b/src/composables/dom/useInnerWindowSize.ts
@@ -1,17 +1,25 @@
+import { debounce } from 'throttle-debounce'
 import { ref, onMounted, onUnmounted } from 'vue'
 
-export const useInnerWindowSize = (fallback?: {
-  width?: number
-  height?: number
-}) => {
+type Option = {
+  delay?: number
+}
+
+export const useInnerWindowSize = (
+  fallback?: {
+    width?: number
+    height?: number
+  },
+  { delay = 64 }: Option = {}
+) => {
   const width = ref<number>(fallback?.width ?? NaN)
   const height = ref<number>(fallback?.height ?? NaN)
 
-  const updateSize = () => {
+  const updateSize = debounce(delay, () => {
     if (typeof window === 'undefined') return
     width.value = window.innerWidth
     height.value = window.innerHeight
-  }
+  })
 
   onMounted(() => {
     updateSize()

--- a/src/composables/dom/useInnerWindowSize.ts
+++ b/src/composables/dom/useInnerWindowSize.ts
@@ -1,0 +1,31 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+export const useInnerWindowSize = (fallback?: {
+  width?: number
+  height?: number
+}) => {
+  const width = ref<number>(fallback?.width ?? NaN)
+  const height = ref<number>(fallback?.height ?? NaN)
+
+  const updateSize = () => {
+    if (typeof window === 'undefined') return
+    width.value = window.innerWidth
+    height.value = window.innerHeight
+  }
+
+  onMounted(() => {
+    updateSize()
+    window.addEventListener('resize', updateSize)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('resize', updateSize)
+  })
+
+  return {
+    width,
+    height
+  }
+}
+
+export default useInnerWindowSize

--- a/src/composables/dom/useNavigationResizer.ts
+++ b/src/composables/dom/useNavigationResizer.ts
@@ -18,7 +18,6 @@ export const useNavigationResizer = () => {
     navigationWidth,
     isNavigationClosed,
     saveNavigationWidth,
-    restoreNavigationWidth,
     navigationLeft,
     updateNavigationLeft
   } = useNavigationLayoutStore()
@@ -40,11 +39,6 @@ export const useNavigationResizer = () => {
 
   const isResizing = ref(false)
   let pointerId: null | number = null
-
-  const restoreWidth = () => {
-    if (navigationWidth.value > 0) return
-    restoreNavigationWidth()
-  }
 
   const cleanup = () => {
     animationFrame.cancel()
@@ -99,9 +93,7 @@ export const useNavigationResizer = () => {
 
   return {
     isNavigationResizing: isResizing,
-    isNavigationClosed,
     navigationWidth: clampedNavigationWidth,
-    restoreNavigationWidth: restoreWidth,
     onDragStart,
     onDragging,
     onDragEnd

--- a/src/composables/dom/useNavigationResizer.ts
+++ b/src/composables/dom/useNavigationResizer.ts
@@ -1,0 +1,100 @@
+import { ref, onUnmounted, computed } from 'vue'
+import { useNavigationLayoutStore } from '/@/store/ui/navigationLayout'
+import { createAnimationFrameController } from '/@/lib/dom/animationFrame'
+import useInnerWindowSize from './useInnerWindowSize'
+
+export const useNavigationResizer = () => {
+  const MIN_NAVIGATION_WIDTH = 200
+  const MAX_NAVIGATION_WIDTH_RATIO = 0.5
+  const NAVIGATION_CLOSING_RATIO = 0.5
+
+  const animationFrame = createAnimationFrameController()
+
+  const { width: innerWidth } = useInnerWindowSize()
+
+  const { navigationWidth, saveNavigationWidth, restoreNavigationWidth } =
+    useNavigationLayoutStore()
+
+  const clampWidth = (width: number) => {
+    return Math.min(
+      Math.max(width, MIN_NAVIGATION_WIDTH),
+      innerWidth.value * MAX_NAVIGATION_WIDTH_RATIO
+    )
+  }
+
+  const setNavigationWidth = (width: number) => {
+    navigationWidth.value = clampWidth(width)
+  }
+
+  const clampedNavigationWidth = computed(() => {
+    return clampWidth(navigationWidth.value)
+  })
+
+  const isResizing = ref(false)
+  let startX: number = 0
+  let startWidth: number = 0
+
+  const restoreWidth = () => {
+    if (navigationWidth.value > 0) return
+    restoreNavigationWidth()
+  }
+
+  const cleanup = () => {
+    animationFrame.cancel()
+
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('mouseup', onMouseUp)
+  }
+
+  const onMouseDown = (e: MouseEvent) => {
+    isResizing.value = true
+    startX = e.clientX
+    startWidth = clampedNavigationWidth.value
+
+    document.body.style.cursor = 'e-resize'
+    document.body.style.userSelect = 'none'
+
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+
+    e.preventDefault()
+  }
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!isResizing.value) return
+
+    animationFrame.request(() => {
+      const deltaX = e.clientX - startX
+      const newWidth = startWidth + deltaX
+
+      if (e.clientX <= MIN_NAVIGATION_WIDTH * NAVIGATION_CLOSING_RATIO) {
+        navigationWidth.value = 0
+      } else {
+        setNavigationWidth(newWidth)
+      }
+    })
+
+    e.preventDefault()
+  }
+
+  const onMouseUp = () => {
+    if (!isResizing.value) return
+
+    if (navigationWidth.value > 0) saveNavigationWidth()
+
+    isResizing.value = false
+    cleanup()
+  }
+
+  onUnmounted(cleanup)
+
+  return {
+    isNavigationResizing: isResizing,
+    navigationWidth: clampedNavigationWidth,
+    restoreNavigationWidth: restoreWidth,
+    startResizing: onMouseDown
+  }
+}

--- a/src/composables/dom/useNavigationResizer.ts
+++ b/src/composables/dom/useNavigationResizer.ts
@@ -30,6 +30,10 @@ export const useNavigationResizer = () => {
     return clampWidth(navigationWidth.value)
   })
 
+  const isNavigationClosed = computed(() => {
+    return navigationWidth.value === 0
+  })
+
   const isResizing = ref(false)
   let startX: number = 0
   let startWidth: number = 0
@@ -93,6 +97,7 @@ export const useNavigationResizer = () => {
 
   return {
     isNavigationResizing: isResizing,
+    isNavigationClosed,
     navigationWidth: clampedNavigationWidth,
     restoreNavigationWidth: restoreWidth,
     startResizing: onMouseDown

--- a/src/composables/dom/useNavigationResizer.ts
+++ b/src/composables/dom/useNavigationResizer.ts
@@ -15,9 +15,11 @@ export const useNavigationResizer = () => {
 
   const {
     navigationWidth,
+    isNavigationClosed,
     saveNavigationWidth,
     restoreNavigationWidth,
-    navigationLeft
+    navigationLeft,
+    updateNavigationLeft
   } = useNavigationLayoutStore()
 
   const clampWidth = (width: number) => {
@@ -33,10 +35,6 @@ export const useNavigationResizer = () => {
 
   const clampedNavigationWidth = computed(() => {
     return clampWidth(navigationWidth.value)
-  })
-
-  const isNavigationClosed = computed(() => {
-    return navigationWidth.value === 0
   })
 
   const isResizing = ref(false)
@@ -58,6 +56,8 @@ export const useNavigationResizer = () => {
 
   const onMouseDown = (e: MouseEvent) => {
     isResizing.value = true
+
+    if (!isNavigationClosed.value) updateNavigationLeft()
 
     document.body.style.cursor = 'e-resize'
     document.body.style.userSelect = 'none'

--- a/src/lib/dom/animationFrame.ts
+++ b/src/lib/dom/animationFrame.ts
@@ -1,0 +1,20 @@
+export const createAnimationFrameController = () => {
+  let frameId: number | null = null
+
+  return {
+    request(callback: FrameRequestCallback) {
+      if (frameId !== null) window.cancelAnimationFrame(frameId)
+      frameId = window.requestAnimationFrame(callback)
+    },
+
+    cancel() {
+      if (frameId === null) return
+      window.cancelAnimationFrame(frameId)
+      frameId = null
+    },
+
+    get isActive() {
+      return frameId !== null
+    }
+  }
+}

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -53,6 +53,11 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
     restoreNavigationWidthImpl()
   }
 
+  const initializeNavigationWidth = () => {
+    navigationWidth.value = DEFAULT_NAVIGATION_WIDTH
+    saveNavigationWidth()
+  }
+
   onMounted(() => {
     restoringPromise.value.then(() => {
       restoreNavigationWidthImpl()
@@ -67,6 +72,7 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
     isNavigationClosed,
     saveNavigationWidth,
     restoreNavigationWidth,
+    initializeNavigationWidth,
     updateNavigationLeft
   }
 })

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -25,6 +25,8 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
   )
 
   const navigationRef = shallowRef<HTMLDivElement>()
+  const resizerRef = shallowRef<HTMLDivElement>()
+
   const navigationLeft = ref(0)
 
   const updateNavigationLeft = () => {
@@ -52,6 +54,7 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
 
   return {
     navigationRef,
+    resizerRef,
     navigationLeft,
     navigationWidth,
     isNavigationClosed,

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -1,0 +1,51 @@
+import { defineStore, acceptHMRUpdate } from 'pinia'
+import { onMounted, ref } from 'vue'
+import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
+import useIndexedDbValue from '/@/composables/utils/useIndexedDbValue'
+
+type State = {
+  navigationWidth: number
+}
+
+const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
+  const initialValue: State = {
+    navigationWidth: 260
+  }
+
+  const [state, _restoring, restoringPromise] = useIndexedDbValue(
+    'store/ui/navigationLayout',
+    1,
+    {},
+    initialValue
+  )
+
+  const navigationWidth = ref(initialValue.navigationWidth)
+
+  const saveNavigationWidth = () => {
+    state.navigationWidth = navigationWidth.value
+  }
+
+  const restoreNavigationWidth = () => {
+    navigationWidth.value = state.navigationWidth
+  }
+
+  onMounted(() => {
+    restoringPromise.value.then(restoreNavigationWidth)
+  })
+
+  return {
+    navigationWidth,
+    saveNavigationWidth,
+    restoreNavigationWidth
+  }
+})
+
+export const useNavigationLayoutStore = convertToRefsStore(
+  useNavigationLayoutStorePinia
+)
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useNavigationLayoutStorePinia, import.meta.hot)
+  )
+}

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -1,5 +1,5 @@
 import { defineStore, acceptHMRUpdate } from 'pinia'
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref, useTemplateRef } from 'vue'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import useIndexedDbValue from '/@/composables/utils/useIndexedDbValue'
 
@@ -7,9 +7,14 @@ type State = {
   navigationWidth: number
 }
 
+export const MIN_NAVIGATION_WIDTH = 200
+export const DEFAULT_NAVIGATION_WIDTH = 260
+export const NAVIGATION_CLOSING_THRESHOLD = MIN_NAVIGATION_WIDTH * 0.4
+export const MAX_NAVIGATION_WIDTH_RATIO = 0.5
+
 const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
   const initialValue: State = {
-    navigationWidth: 260
+    navigationWidth: DEFAULT_NAVIGATION_WIDTH
   }
 
   const [state, _restoring, restoringPromise] = useIndexedDbValue(
@@ -19,7 +24,12 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
     initialValue
   )
 
-  const navigationWidth = ref(initialValue.navigationWidth)
+  const navigationRef = useTemplateRef<HTMLDivElement>('navigations')
+  const navigationLeft = computed(() => {
+    return navigationRef.value?.getBoundingClientRect().left ?? 0
+  })
+
+  const navigationWidth = ref(state.navigationWidth)
 
   const saveNavigationWidth = () => {
     state.navigationWidth = navigationWidth.value
@@ -34,6 +44,7 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
   })
 
   return {
+    navigationLeft,
     navigationWidth,
     saveNavigationWidth,
     restoreNavigationWidth

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -1,5 +1,5 @@
 import { defineStore, acceptHMRUpdate } from 'pinia'
-import { computed, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, onMounted, ref, shallowRef } from 'vue'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import useIndexedDbValue from '/@/composables/utils/useIndexedDbValue'
 
@@ -24,7 +24,7 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
     initialValue
   )
 
-  const navigationRef = useTemplateRef<HTMLDivElement>('navigations')
+  const navigationRef = shallowRef<HTMLDivElement>()
   const navigationLeft = ref(0)
 
   const updateNavigationLeft = () => {
@@ -51,6 +51,7 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
   })
 
   return {
+    navigationRef,
     navigationLeft,
     navigationWidth,
     isNavigationClosed,

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -44,12 +44,19 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
     state.navigationWidth = navigationWidth.value
   }
 
-  const restoreNavigationWidth = () => {
+  const restoreNavigationWidthImpl = () => {
     navigationWidth.value = state.navigationWidth
   }
 
+  const restoreNavigationWidth = () => {
+    if (navigationWidth.value > 0) return
+    restoreNavigationWidthImpl()
+  }
+
   onMounted(() => {
-    restoringPromise.value.then(restoreNavigationWidth)
+    restoringPromise.value.then(() => {
+      restoreNavigationWidthImpl()
+    })
   })
 
   return {

--- a/src/store/ui/navigationLayout.ts
+++ b/src/store/ui/navigationLayout.ts
@@ -25,11 +25,18 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
   )
 
   const navigationRef = useTemplateRef<HTMLDivElement>('navigations')
-  const navigationLeft = computed(() => {
-    return navigationRef.value?.getBoundingClientRect().left ?? 0
-  })
+  const navigationLeft = ref(0)
+
+  const updateNavigationLeft = () => {
+    navigationLeft.value =
+      navigationRef.value?.getBoundingClientRect().left ?? 0
+  }
 
   const navigationWidth = ref(state.navigationWidth)
+
+  const isNavigationClosed = computed(() => {
+    return navigationWidth.value === 0
+  })
 
   const saveNavigationWidth = () => {
     state.navigationWidth = navigationWidth.value
@@ -46,8 +53,10 @@ const useNavigationLayoutStorePinia = defineStore('ui/navigationLayout', () => {
   return {
     navigationLeft,
     navigationWidth,
+    isNavigationClosed,
     saveNavigationWidth,
-    restoreNavigationWidth
+    restoreNavigationWidth,
+    updateNavigationLeft
   }
 })
 

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -170,18 +170,6 @@ useViewStateSender()
 </script>
 
 <style lang="scss" module>
-// ナビゲーションバーの幅
-$min-nav-width: 260px;
-$max-nav-width: 400px;
-// ナビゲーションバーの幅が最小・最大になる画面幅
-$min-nav-width-display-width: 700px;
-$max-nav-width-display-width: 2560px;
-// それぞれの差と二つの比率
-$nav-width-diff: $max-nav-width - $min-nav-width;
-$nav-width-display-width-diff: $max-nav-width-display-width -
-  $min-nav-width-display-width;
-$nav-width-ratio: math.div($nav-width-diff, $nav-width-display-width-diff);
-
 .homeWrapper {
   height: 100%;
 }
@@ -195,12 +183,7 @@ $nav-width-ratio: math.div($nav-width-diff, $nav-width-display-width-diff);
 }
 .navigationWrapper {
   height: 100%;
-  max-width: 400px;
-  min-width: 260px;
-  flex-shrink: 0;
-  flex-basis: calc(
-    260px + ((100vw - #{$min-nav-width-display-width}) * #{$nav-width-ratio})
-  );
+  width: fit-content;
   [data-is-mobile] & {
     position: absolute;
     top: 0;
@@ -210,6 +193,7 @@ $nav-width-ratio: math.div($nav-width-diff, $nav-width-display-width-diff);
 }
 .mainViewWrapper {
   z-index: $z-index-main-view-wrapper;
+  flex: 1;
 }
 .sidebarWrapper {
   @include background-secondary;


### PR DESCRIPTION
## 概要

### やったこと・変更点
- 左のナビゲーションバーが VS Code の Side Bar と同じような挙動をするようになります．
- nav bar と main view の間をドラッグしてサイズ変更できます．
  - ダブルクリックするとデフォルトの幅 (260px) に戻ります．
- ブラウザにはドラッグし終えたときの幅のみが保存されます．(開閉状態は保持されません．)
- デフォルトの幅が固定値 (260px) になるので，現在のように画面幅に応じて伸び縮みすることはなくなります．

### やってないこと
- ショートカットによる開閉の実装
- チャンネル名省略アルゴリズム (#4666) の `MAX_SHORT_PATH_LENGTH` をナビゲーション幅に依って可変に

## なぜこの PR を入れたいのか
- closes #707
- 私が欲しかった / 欲しいという声が少々あった

## UI 変更部分のスクリーンショット
### 折りたたまれたとき
<img width="320" height="748" alt="image" src="https://github.com/user-attachments/assets/ad164790-6c89-49a4-a634-0a882e826287" />

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう