### PR TITLE
fix: DetailButton、QallMessageView、QallViewコンポーネントにUI要素の色を追加

### DIFF
--- a/src/components/Main/MainView/QallView/DetailButton.vue
+++ b/src/components/Main/MainView/QallView/DetailButton.vue
@@ -31,5 +31,7 @@ function handleClick() {
   background-color: $theme-background-primary-default;
   width: 24px;
   height: 24px;
+  @include color-ui-primary;
+  @include background-tertiary;
 }
 </style>

--- a/src/components/Main/MainView/QallView/QallMessageView.vue
+++ b/src/components/Main/MainView/QallView/QallMessageView.vue
@@ -115,6 +115,7 @@ const handleScroll = () => {
           <IconButton
             :icon-name="`chevron-double-${isMessageShow ? 'down' : 'up'}`"
             icon-mdi
+            :class="$style.uiElement"
             @click="
               () => {
                 if (isMessageShow) {
@@ -212,6 +213,7 @@ const handleScroll = () => {
 }
 .uiElement {
   pointer-events: all;
+  @include color-ui-primary;
 }
 
 .uiToggleButton {

--- a/src/components/Main/MainView/QallView/QallView.vue
+++ b/src/components/Main/MainView/QallView/QallView.vue
@@ -194,9 +194,10 @@ const toggleDanmaku = () => {
         <IconButton
           :icon-name="`comment${showDanmaku ? '' : '-off'}-outline`"
           icon-mdi
+          :class="$style.closeButton"
           @click="toggleDanmaku"
         />
-        <IconButton icon-name="close" icon-mdi @click="isSubView = true" />
+        <IconButton icon-name="close" icon-mdi :class="$style.closeButton" @click="isSubView = true" />
       </div>
       <div :class="$style.stackContainer">
         <UserList :class="$style.userList" />
@@ -379,9 +380,7 @@ const toggleDanmaku = () => {
 }
 
 .closeButton {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
+  @include color-ui-primary;
 }
 
 .iconContainer {


### PR DESCRIPTION
## 概要
Qall のボタンのUIを修正

## なぜこの PR を入れたいのか
QallView内のUI要素（ボタン）の色合いが環境によって見やすさが変わってしまい、視認性やデザインの一貫性に問題があったため、適切な色指定を追加してUIの一貫性を向上させる。
close: #4689

## 動作確認の手順
1. Qallビューを開く
2. 各ボタンの色を確認。
3. ダークテーマ・ライトテーマ両方で確認。

## UI 変更部分のスクリーンショット

### before
現環境

### after
<img width="162" height="87" alt="image" src="https://github.com/user-attachments/assets/4fb52ee9-8db7-4d26-80ee-a3e370afbe8c" />


## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [ ] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
右上ボタンのスタイルクラスの名前をcloseButtonにしたが、もっとよい命名があるかもしれないです。
