### PR TITLE
fix: チャンネル移動と `MESSAGE_CREATED` イベントが同時に発生したときにメッセージが移動先のチャンネルに表示される挙動を修正

### DIFF
--- a/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
+++ b/src/components/Main/MainView/MessagesScroller/composables/useMessagesFetcher.ts
@@ -195,11 +195,16 @@ const useMessageFetcher = (
   }
 
   const addNewMessage = async (messageId: MessageId) => {
+    const beforeId = id.value
     await renderMessageContent(messageId)
 
     // すでに追加済みの場合は追加しない
     // https://github.com/traPtitech/traQ_S-UI/issues/1748
     if (messageIds.value.includes(messageId)) return
+    // チャンネルの移動などで id が変化していたら追加しない
+    // https://github.com/traPtitech/traQ_S-UI/issues/4218
+    if (beforeId !== id.value) return
+
     messageIds.value.push(messageId)
   }
 


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

close #4218 

### この挙動が発生する流れ

1. `useChannelMessageFetcher.ts` で `MESSAGE_CREATED` イベントを受信
2.  `messageFetcher.addNewMessage(message.id)` が呼ばれる
    - チャンネル ID の一致チェックはこのタイミングで行われている
3. `await renderMessageContent(messageId)` が呼ばれる
    - 添付ファイルデータのフェッチ、 MD のレンダリング、 OGP 画像のフェッチをする関数
    - この**後**に `messageIds.value.push(messageId)` がある
4. 3 を `await` している最中にチャンネルが切り替わる
    - 特に OGP 画像の取得が長引きやすい模様
5. 3 の待機後、新しくなった `messageIds` に対して `messageIds.value.push(messageId)` が呼ばれてしまう
6. 別のチャンネルにメッセージが表示される

## 動作確認の手順

- `useChannelMessageFetcher.ts` の L234~ あたりを次のように変更します。
  ```diff
  + const { channelIdToLink } = useChannelPath()
  + const router = useRouter()
    
  useMittListener(messageMitt, 'addMessage', ({ message }) => {
    if (props.channelId !== message.channelId) return
    if (!messagesFetcher.isReachedLatest.value) return
  
  + router.push(channelIdToLink('<任意のチャンネルID>'))
    messagesFetcher.addNewMessage(message.id)
  })
  ```
- 上で ID を書いたチャンネルとは別のチャンネルに OGP 画像の取得が長引くリンクを投稿します。
  - 手元では Google Drive のリンクで再現性が高いです。
- 投稿後 ID を指定したチャンネルに遷移し、投稿したメッセージが遷移後のチャンネルに表示されていなければ正しいです。
  - 同様の手順を master で行うと元 Issue の挙動を高い確率で再現できます。

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [ ] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
