### PR TITLE
fix: アクティビティ内でメッセージが重複することがある問題に対処

### DIFF
--- a/src/components/Main/NavigationBar/NavigationContent/composables/useActivityStream.ts
+++ b/src/components/Main/NavigationBar/NavigationContent/composables/useActivityStream.ts
@@ -77,7 +77,6 @@ const useActivityStream = () => {
 
     // メッセージが重複した場合を無視
     // WebSocket の再接続による refetch と `MESSAGE_CREATED` イベントが同時に発生して、どちらからも同じメッセージを受け取る場合への対応
-    // https://github.com/traPtitech/traQ_S-UI/issues/4767
     if (timeline.value.some(({ id }) => id === addedMessage.id)) {
       return
     }


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

close #4156 

## 動作確認の手順

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

Issue の挙動を再現できておらず、根本的な原因が分からないまま暫定的な対処のみをしています ( なので元 Issue は close するべきではないかもしれません ) 。
アクティビティの refetch と `MESSAGE_CREATED` イベントが同時に発生すると重複しうる気がしますが、確認できていません。