### PR TITLE
Caddyを2.10.0にダウングレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN NODE_ENV=production npm run build:with-font
 
 
-FROM caddy:2.10.2-alpine
+FROM caddy:2.10.0-alpine
 EXPOSE 80
 
 COPY build/docker/Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->
一部ファイルのレスポンスが206になってService Workerが正常に動作しないため

<img width="804" height="103" alt="image" src="https://github.com/user-attachments/assets/44599b3f-2117-4b0e-91b0-aa1cc7d2af91" />

しっかり調べたわけではありませんが、[Caddy 2.10.1](https://github.com/caddyserver/caddy/releases/tag/v2.10.1)でprecompressedのファイルにRangeヘッダーが付与されるようになったことでPartial Contentが返るようになったのではと推測しています

## 動作確認の手順

Dockerビルドして上記のエラーが出ないことを確認する
（僕は2.10.2だとローカルでも同様のエラーが出て、2.10.0にすると出なくなることを確認しました。2.10.1のイメージは存在しないようです）

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
