### PR TITLE
feat: メッセージ投稿時のプレビューに引用メッセージを表示できるようにする

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -2,13 +2,13 @@
   <div v-if="shouldShow" :class="$style.body" data-is-shown>
     <UserIcon
       :class="$style.userIcon"
-      :user-id="message.userId"
+      :user-id="message!.userId"
       :size="24"
       prevent-modal
     />
     <MessageQuoteListItemHeader
       :class="$style.messageHeader"
-      :user-id="message.userId"
+      :user-id="message!.userId"
     />
     <div :class="$style.messageContents">
       <div
@@ -42,7 +42,7 @@
 import UserIcon from '/@/components/UI/UserIcon.vue'
 import MessageQuoteListItemHeader from './MessageQuoteListItemHeader.vue'
 import MessageQuoteListItemFooter from './MessageQuoteListItemFooter.vue'
-import { computed, ref } from 'vue'
+import { computed, onBeforeMount, ref } from 'vue'
 import type { MessageId, ChannelId, DMChannelId } from '/@/types/entity-ids'
 import { useMessagesView } from '/@/store/domain/messagesView'
 import { useMessagesStore } from '/@/store/entities/messages'
@@ -58,12 +58,17 @@ const props = defineProps<{
   messageId: MessageId
 }>()
 
-const { renderedContentMap } = useMessagesView()
+const { renderedContentMap, renderMessageContent } = useMessagesView()
 const { messagesMap } = useMessagesStore()
 const { dmChannelsMap } = useChannelsStore()
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const message = computed(() => messagesMap.value.get(props.messageId)!)
+onBeforeMount(() => {
+  if (!renderedContentMap.value.has(props.messageId)) {
+    renderMessageContent(props.messageId)
+  }
+})
+
+const message = computed(() => messagesMap.value.get(props.messageId))
 const shouldShow = computed(
   () =>
     !!message.value &&

--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -16,6 +16,7 @@
     <MessageInputUploadProgress v-if="isPosting" :progress="progress" />
     <MessageInputPreview
       v-if="isPreviewShown && state.text !== ''"
+      :channel-id="channelId"
       :class="$style.preview"
       :text="state.text"
     />

--- a/src/components/Main/MainView/MessageInput/MessageInputPreview.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputPreview.vue
@@ -1,36 +1,37 @@
 <template>
   <div :class="$style.preview" :data-is-mobile="isMobile">
     <MarkdownContent :content="previewRendered" />
-    <div
-      v-for="quoteMessage in quoteMessages"
-      :key="quoteMessage.id"
-      :class="$style.quote"
-    >
-      引用メッセージ
-    </div>
+    <MessageQuoteList
+      v-if="quoteMessageIds.length > 0"
+      :class="$style.quoteList"
+      :parent-message-channel-id="channelId"
+      :message-ids="quoteMessageIds"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
-import type { EmbeddingMessage } from '@traptitech/traq-markdown-it'
 import { ref, watchEffect } from 'vue'
 import { isMessage } from '/@/lib/guard/embeddingOrUrl'
 import { render } from '/@/lib/markdown/markdown'
 import { useResponsiveStore } from '/@/store/ui/responsive'
+import MessageQuoteList from '/@/components/Main/MainView/MessageElement/MessageQuoteList.vue'
 import MarkdownContent from '/@/components/UI/MarkdownContent.vue'
+import type { MessageId } from '/@/types/entity-ids'
 
 const props = defineProps<{
+  channelId: string
   text: string
 }>()
 
 const { isMobile } = useResponsiveStore()
 
 const previewRendered = ref('')
-const quoteMessages = ref<EmbeddingMessage[]>([])
+const quoteMessageIds = ref<MessageId[]>([])
 watchEffect(async () => {
   const { renderedText, embeddings } = await render(props.text)
   previewRendered.value = renderedText
-  quoteMessages.value = embeddings.filter(isMessage)
+  quoteMessageIds.value = embeddings.filter(isMessage).map(({ id }) => id)
 })
 </script>
 
@@ -46,8 +47,7 @@ watchEffect(async () => {
   }
 }
 
-.quote {
-  padding-left: 16px;
-  border-left: solid 4px $theme-ui-tertiary-default;
+.quoteList {
+  margin-top: 16px;
 }
 </style>

--- a/src/store/domain/messagesView.ts
+++ b/src/store/domain/messagesView.ts
@@ -30,10 +30,8 @@ const useMessagesViewPinia = defineStore('domain/messagesView', () => {
   const embeddingsMap = ref(new Map<MessageId, EmbeddingOrUrl[]>())
 
   const renderMessageContent = async (messageId: string) => {
-    const content =
-      messagesStore.messagesMap.value.get(messageId)?.content ?? ''
-
-    const rendered = await render(content)
+    const message = await messagesStore.fetchMessage({ messageId })
+    const rendered = await render(message.content)
 
     const filePromises = rendered.embeddings.filter(isFile).map(async e => {
       try {


### PR DESCRIPTION
## 概要
最初の 2 commits は #4778 と同じです．

## なぜこの PR を入れたいのか

closes #4709

## やったこと
- feat: message が fetch 済みキャッシュにないときは fetch してから render するようにする
  - `messagesStore.fetchMessage` はそもそもキャッシュを読む
- feat: quoted message が render 済みキャッシュにないときは mount 前に render するようにする
- feat: `MessageInputPreview` で `MessageQuoteList` を呼び出す
  - `MessageInput` から `MessagePreview` へ channel id を渡す

## UI 変更部分のスクリーンショット
<img width="612" height="236" alt="image" src="https://github.com/user-attachments/assets/58b1e8a5-c13a-4a78-b930-f05146a65f22" />

## PR を出す前の確認事項
- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
