### PR TITLE
feat: 検索結果に引用メッセージを表示できるようにする

### DIFF
--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -19,11 +19,12 @@
             :content="renderedContent"
             @click="toggleSpoilerHandler"
           />
-          <message-quote-list
+          <MessageQuoteList
             v-if="quotedMessageIds.length > 0"
             :class="$style.quoteList"
             :parent-message-channel-id="message.channelId"
             :message-ids="quotedMessageIds"
+            disable-item-footer-links
           />
         </div>
         <div

--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -19,6 +19,12 @@
             :content="renderedContent"
             @click="toggleSpoilerHandler"
           />
+          <message-quote-list
+            v-if="quotedMessageIds.length > 0"
+            :class="$style.quoteList"
+            :parent-message-channel-id="message.channelId"
+            :message-ids="quotedMessageIds"
+          />
         </div>
         <div
           v-if="oversized && !expanded"
@@ -52,7 +58,8 @@ import type { SearchMessageSortKey } from '/@/lib/searchMessage/queryParser'
 import { useUsersStore } from '/@/store/entities/users'
 import type { MarkdownRenderResult } from '@traptitech/traq-markdown-it'
 import { render } from '/@/lib/markdown/markdown'
-import { isFile } from '/@/lib/guard/embeddingOrUrl'
+import { isFile, isMessage } from '/@/lib/guard/embeddingOrUrl'
+import MessageQuoteList from '/@/components/Main/MainView/MessageElement/MessageQuoteList.vue'
 import AIcon from '/@/components/UI/AIcon.vue'
 import UserIcon from '/@/components/UI/UserIcon.vue'
 import SearchResultMessageFileList from './SearchResultMessageFileList.vue'
@@ -113,7 +120,11 @@ watchEffect(async () => {
 const renderedContent = computed(() => renderedResult.value?.renderedText ?? '')
 const fileIds = computed(
   () =>
-    renderedResult.value?.embeddings.filter(isFile).map(file => file.id) ?? []
+    renderedResult.value?.embeddings.filter(isFile).map(({ id }) => id) ?? []
+)
+const quotedMessageIds = computed(
+  () =>
+    renderedResult.value?.embeddings.filter(isMessage).map(({ id }) => id) ?? []
 )
 
 const onClick = (e: MouseEvent) => {
@@ -208,6 +219,9 @@ $expand-button-height: 32px;
       transparent 100%
     );
   }
+}
+.quoteList {
+  margin-top: 16px;
 }
 .expandButton {
   position: absolute;

--- a/src/components/Main/CommandPalette/SearchResultMessageElement.vue
+++ b/src/components/Main/CommandPalette/SearchResultMessageElement.vue
@@ -221,7 +221,7 @@ $expand-button-height: 32px;
   }
 }
 .quoteList {
-  margin-top: 16px;
+  margin-block: 16px;
 }
 .expandButton {
   position: absolute;

--- a/src/components/Main/MainView/MessageElement/MessageQuoteList.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteList.vue
@@ -6,6 +6,7 @@
       :class="$style.item"
       :parent-message-channel-id="parentMessageChannelId"
       :message-id="id"
+      :disable-footer-links="disableItemFooterLinks"
     />
   </div>
 </template>
@@ -18,9 +19,11 @@ withDefaults(
   defineProps<{
     parentMessageChannelId: ChannelId | DMChannelId
     messageIds?: MessageId[]
+    disableItemFooterLinks?: boolean
   }>(),
   {
-    messageIds: () => []
+    messageIds: () => [],
+    disableItemFooterLinks: false
   }
 )
 </script>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -31,7 +31,11 @@
         @click="toggleFold"
       />
     </div>
-    <MessageQuoteListItemFooter :class="$style.footer" :message="message" />
+    <MessageQuoteListItemFooter
+      :class="$style.footer"
+      :message="message"
+      :disable-links="disableFooterLinks"
+    />
   </div>
   <div v-else :class="$style.body">
     存在しないか表示できないメッセージの引用です
@@ -56,6 +60,7 @@ import useBoxSize from '/@/composables/dom/useBoxSize'
 const props = defineProps<{
   parentMessageChannelId: ChannelId | DMChannelId
   messageId: MessageId
+  disableFooterLinks: boolean
 }>()
 
 const { renderedContentMap, renderMessageContent } = useMessagesView()

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -94,7 +94,12 @@ const oversized = computed(
 )
 
 const markdownId = randomString()
-const { value: isFold, toggle: toggleFold } = useToggle(true)
+const { value: isFold, toggle: toggleFoldImpl } = useToggle(true)
+
+const toggleFold = (e: MouseEvent) => {
+  e.stopPropagation()
+  toggleFoldImpl()
+}
 </script>
 
 <style lang="scss" module>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItemFooter.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItemFooter.vue
@@ -1,12 +1,15 @@
 <template>
   <div :class="$style.container">
     <span :class="$style.description">
-      <router-link :to="channelLink">
+      <span v-if="disableLinks">
+        {{ channelPath }}
+      </span>
+      <router-link v-else :to="channelLink">
         {{ channelPath }}
       </router-link>
       - {{ date }}
     </span>
-    <router-link :class="$style.link" :to="messageLink">
+    <router-link v-if="!disableLinks" :class="$style.link" :to="messageLink">
       メッセージへ
     </router-link>
   </div>
@@ -19,9 +22,15 @@ import useChannelPath from '/@/composables/useChannelPath'
 import { getDateRepresentation } from '/@/lib/basic/date'
 import { constructMessagesPath } from '/@/router'
 
-const props = defineProps<{
-  message?: Message
-}>()
+const props = withDefaults(
+  defineProps<{
+    message?: Message
+    disableLinks?: boolean
+  }>(),
+  {
+    disableLinks: false
+  }
+)
 
 const { channelIdToPathString, channelIdToLink } = useChannelPath()
 


### PR DESCRIPTION
## 概要
最初の 2 commits は #4777 と同じです．

## なぜこの PR を入れたいのか

closes: #4113

## やったこと
- feat: message が fetch 済みキャッシュにないときは fetch してから render するようにする
  - `messagesStore.fetchMessage` はそもそもキャッシュを読む
- feat: quoted message が render 済みキャッシュにないときは mount 前に render するようにする
- feat: `SearchResultMessageElement` で `MessageQuoteList` を呼び出す
feat: SearchResultMessageElement における引用メッセージの MessageQuoteListItemFooter のリンクを無効にする
- feat: `MessageQuoteListItemFooter` のリンクを無効化できるようにする
- fix: `MessageQuoteListItem` の `FoldButton` が押されたとき，`click` event が伝播しないようにする

## UI 変更部分のスクリーンショット
<img width="999" height="319" alt="image" src="https://github.com/user-attachments/assets/eb2ab621-31d8-4d51-888a-64b984e9516b" />
<img width="995" height="703" alt="image" src="https://github.com/user-attachments/assets/9d06e4be-9eb7-4c02-b1cc-7a88009f75a1" />
<img width="1003" height="743" alt="image" src="https://github.com/user-attachments/assets/4f75ecda-1cc9-4a72-86c1-75f11c2e0067" />
<img width="1000" height="733" alt="image" src="https://github.com/user-attachments/assets/f3b04208-c70f-4737-9a27-e54868c38d86" />



## 動作確認の方法
- `dev.config.ts` の `DEV_SERVER_PROXY_HOST` を本番環境のもので書き換え，`npm run dev` で立ち上げたクライアントを用いて検索を行った．
- `stopPropagation` の追加によって既存の UX が破損していないか検証した．

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう