### PR TITLE
fix(settings/stamp-palette): スタンプパレット作成/編集の二重作成/二重ダイアログ防止と離脱確認の安定化

### DIFF
--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -97,10 +97,7 @@ onBeforeUnmount(async () => {
 
 useBeforeUnload(
   shouldWarnOnLeave,
-  '未保存の編集内容があります。ページを離れますか？',
-  _event => {
-    suppressLeaveWarning.value = true
-  }
+  '未保存の編集内容があります。ページを離れますか？'
 )
 </script>
 

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -56,10 +56,10 @@ const discardWithConfirm = () => {
 }
 
 const addSuccessToast = () => {
-  addInfoToast('スタンプパレットを保存しました')
+  addInfoToast('スタンプパレットを作成しました')
 }
 const addFailureToast = () => {
-  addErrorToast('スタンプパレットの保存に失敗しました')
+  addErrorToast('スタンプパレットの作成に失敗しました')
 }
 
 const finalizeWithToast = async () => {

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -50,7 +50,7 @@ const discardWithConfirm = () => {
     !isDraftDirty.value ||
     window.confirm('未保存の編集内容が破棄されますが、よろしいですか？')
   ) {
-    skipLeaveGuard.value = true
+    suppressLeaveWarning.value = true
     goToSettingsStampPalette()
   }
 }
@@ -69,7 +69,7 @@ const finalizeWithToast = async () => {
   }
   try {
     await createStampPaletteWrapper(draftPalette.value)
-    skipLeaveGuard.value = true
+    suppressLeaveWarning.value = true
     addSuccessToast()
     goToSettingsStampPalette()
   } catch (_) {
@@ -77,11 +77,15 @@ const finalizeWithToast = async () => {
   }
 }
 
-const skipLeaveGuard = ref(false)
+const suppressLeaveWarning = ref(false)
+
+const shouldWarnOnLeave = computed(
+  () => isDraftDirty.value && !suppressLeaveWarning.value
+)
 
 onBeforeUnmount(async () => {
-  if (!isDraftDirty.value || skipLeaveGuard.value) return
-  skipLeaveGuard.value = true
+  if (!shouldWarnOnLeave.value) return
+  suppressLeaveWarning.value = true
   if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {
     await createStampPaletteWrapper(draftPalette.value)
@@ -92,10 +96,10 @@ onBeforeUnmount(async () => {
 })
 
 useBeforeUnload(
-  computed(() => isDraftDirty.value && !skipLeaveGuard.value),
+  shouldWarnOnLeave,
   '未保存の編集内容があります。ページを離れますか？',
   _event => {
-    skipLeaveGuard.value = true
+    suppressLeaveWarning.value = true
   }
 )
 </script>

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -50,6 +50,7 @@ const discardWithConfirm = () => {
     !isDraftDirty.value ||
     window.confirm('未保存の編集内容が破棄されますが、よろしいですか？')
   ) {
+    skipLeaveGuard.value = true
     goToSettingsStampPalette()
   }
 }
@@ -68,6 +69,7 @@ const finalizeWithToast = async () => {
   }
   try {
     await createStampPaletteWrapper(draftPalette.value)
+    skipLeaveGuard.value = true
     addSuccessToast()
     goToSettingsStampPalette()
   } catch (_) {

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -25,11 +25,9 @@ import {
   goToSettingsStampPalette
 } from '/@/components/Settings/StampPaletteTab/utils'
 import { useBeforeUnload } from '/@/composables/dom/useBeforeUnload'
-import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
 import { useToastStore } from '/@/store/ui/toast'
 import type { StampId, StampPaletteId } from '/@/types/entity-ids'
 
-const { stampPalettesMap } = useStampPalettesStore()
 const { addInfoToast, addErrorToast } = useToastStore()
 
 const emptyStampPalette: StampPalette = {
@@ -42,15 +40,10 @@ const emptyStampPalette: StampPalette = {
   description: ''
 }
 const newStampPalette = ref(structuredClone(emptyStampPalette))
-const savedStampPalette = computed(() =>
-  stampPalettesMap.value.get(newStampPalette.value.id)
-)
 
-const hasPaletteUnsavedChanges = computed(() => {
-  if (!savedStampPalette.value)
-    return !areStampPalettesEqual(newStampPalette.value, emptyStampPalette)
-  return !areStampPalettesEqual(newStampPalette.value, savedStampPalette.value)
-})
+const hasPaletteUnsavedChanges = computed(
+  () => !areStampPalettesEqual(newStampPalette.value, emptyStampPalette)
+)
 
 const discardWithConfirm = () => {
   if (

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -108,10 +108,10 @@ const discardWithConfirm = () => {
 }
 
 const addSuccessToast = () => {
-  addInfoToast('スタンプパレットを保存しました')
+  addInfoToast('スタンプパレットを更新しました')
 }
 const addFailureToast = () => {
-  addErrorToast('スタンプパレットの保存に失敗しました')
+  addErrorToast('スタンプパレットの更新に失敗しました')
 }
 
 const finalizeWithToast = async () => {

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -150,10 +150,7 @@ onBeforeUnmount(async () => {
 
 useBeforeUnload(
   shouldWarnOnLeave,
-  '未保存の編集内容があります。ページを離れますか？',
-  _event => {
-    suppressLeaveWarning.value = true
-  }
+  '未保存の編集内容があります。ページを離れますか？'
 )
 </script>
 

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -102,6 +102,7 @@ const discardWithConfirm = () => {
     !isDraftDirty.value ||
     window.confirm('未保存の編集内容が破棄されますが、よろしいですか？')
   ) {
+    skipLeaveGuard.value = true
     goToSettingsStampPalette()
   }
 }
@@ -121,6 +122,7 @@ const finalizeWithToast = async () => {
   try {
     if (!draftPalette.value) throw new Error('draftPalette is null')
     await editStampPaletteWrapper(draftPalette.value)
+    skipLeaveGuard.value = true
     addSuccessToast()
     goToSettingsStampPalette()
   } catch (_) {
@@ -143,7 +145,7 @@ onBeforeUnmount(async () => {
 })
 
 useBeforeUnload(
-  isDraftDirty,
+  computed(() => isDraftDirty.value && !skipLeaveGuard.value),
   '未保存の編集内容があります。ページを離れますか？',
   _event => {
     skipLeaveGuard.value = true

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -7,16 +7,16 @@
     <div v-if="!isStampPaletteFetched">
       <p>読み込み中...</p>
     </div>
-    <div v-else-if="!stampPaletteToEdit">
+    <div v-else-if="!draftPalette">
       <p>{{ stampPaletteFetchErrorMessage }}</p>
     </div>
     <div v-else-if="!isMyPalette">
       <p>スタンプパレットの編集権限がありません。</p>
     </div>
     <div v-else>
-      <stamp-palette-editor v-model:palette="stampPaletteToEdit" />
+      <stamp-palette-editor v-model:palette="draftPalette" />
       <stamp-palette-action-buttons
-        :palette="stampPaletteToEdit"
+        :palette="draftPalette"
         @finalize="finalizeWithToast"
         @cancel="discardWithConfirm"
       />
@@ -50,12 +50,12 @@ const { fetchStampPalette, stampPalettesMap } = useStampPalettesStore()
 const { addInfoToast, addErrorToast } = useToastStore()
 const { myId } = useMeStore()
 
-const savedStampPalette = computed(() => stampPalettesMap.value.get(paletteId))
-const stampPaletteToEdit = ref<StampPalette | null>(null)
+const savedPalette = computed(() => stampPalettesMap.value.get(paletteId))
+const draftPalette = ref<StampPalette | null>(null)
 
 const isMyPalette = computed(() => {
-  if (!savedStampPalette.value) return false
-  return savedStampPalette.value.creatorId === myId.value
+  if (!savedPalette.value) return false
+  return savedPalette.value.creatorId === myId.value
 })
 
 const stampPaletteFetchErrorMessage = ref('')
@@ -85,24 +85,21 @@ onBeforeMount(async () => {
   } catch (e: unknown) {
     setStampPaletteFetchErrorMessage(e)
   } finally {
-    stampPaletteToEdit.value = structuredClone(
+    draftPalette.value = structuredClone(
       toRaw(stampPalettesMap.value.get(paletteId)) ?? null
     )
     isStampPaletteFetched.value = true
   }
 })
 
-const hasPaletteUnsavedChanges = computed(() => {
-  if (!stampPaletteToEdit.value || !savedStampPalette.value) return false
-  return !areStampPalettesEqual(
-    stampPaletteToEdit.value,
-    savedStampPalette.value
-  )
+const isDraftDirty = computed(() => {
+  if (!draftPalette.value || !savedPalette.value) return false
+  return !areStampPalettesEqual(draftPalette.value, savedPalette.value)
 })
 
 const discardWithConfirm = () => {
   if (
-    !hasPaletteUnsavedChanges.value ||
+    !isDraftDirty.value ||
     window.confirm('未保存の編集内容が破棄されますが、よろしいですか？')
   ) {
     goToSettingsStampPalette()
@@ -117,13 +114,13 @@ const addFailureToast = () => {
 }
 
 const finalizeWithToast = async () => {
-  if (!hasPaletteUnsavedChanges.value) {
+  if (!isDraftDirty.value) {
     goToSettingsStampPalette()
     return
   }
   try {
-    if (!stampPaletteToEdit.value) throw new Error('stampPaletteToEdit is null')
-    await editStampPaletteWrapper(stampPaletteToEdit.value)
+    if (!draftPalette.value) throw new Error('draftPalette is null')
+    await editStampPaletteWrapper(draftPalette.value)
     addSuccessToast()
     goToSettingsStampPalette()
   } catch (_) {
@@ -131,19 +128,14 @@ const finalizeWithToast = async () => {
   }
 }
 
-const isConfirmed = ref(false)
+const skipLeaveGuard = ref(false)
 
 onBeforeUnmount(async () => {
-  if (
-    !hasPaletteUnsavedChanges.value ||
-    !stampPaletteToEdit.value ||
-    isConfirmed.value
-  )
-    return
-  isConfirmed.value = true
+  if (!isDraftDirty.value || !draftPalette.value || skipLeaveGuard.value) return
+  skipLeaveGuard.value = true
   if (!window.confirm('未保存の編集内容を保存しますか？')) return
   try {
-    await editStampPaletteWrapper(stampPaletteToEdit.value)
+    await editStampPaletteWrapper(draftPalette.value)
     addSuccessToast()
   } catch (_) {
     addFailureToast()
@@ -151,10 +143,10 @@ onBeforeUnmount(async () => {
 })
 
 useBeforeUnload(
-  hasPaletteUnsavedChanges,
+  isDraftDirty,
   '未保存の編集内容があります。ページを離れますか？',
   _event => {
-    isConfirmed.value = true
+    skipLeaveGuard.value = true
   }
 )
 </script>


### PR DESCRIPTION
## 概要

- 作成/編集時の離脱確認とアンマウント時の自動保存の競合で発生していた不具合を修正。
- 作成時にパレットが二重に作成される、保存確認ダイアログが二重に出る/2回目以降に出ない問題を解消。
- 作成/更新トースト文言を用途に合わせて明確化。

背景/原因
- 作成確定に伴うナビゲーション時、アンマウントフックでの「未保存の編集内容を保存しますか？」が再度走り、重複作成が発生。
- `useBeforeUnload` での `isConfirmed` フラグ操作により、2回目以降の離脱確認が出なくなる状態が発生。

変更点
- 抑止フラグ `suppressLeaveWarning` を導入し、確定/キャンセル後は離脱警告と自動保存を抑止。
- 離脱警告条件を `shouldWarnOnLeave = isDraftDirty && !suppressLeaveWarning` に統一し、`useBeforeUnload` と `onBeforeUnmount` の両方で共通利用。
- 作成/編集画面のドラフト管理を共通化・名称整理:
  - `newStampPalette`/`stampPaletteToEdit` → `draftPalette`
  - `savedStampPalette` → `savedPalette`
  - `hasPaletteUnsavedChanges` → `isDraftDirty`
  - 作成画面は `initialPalette` との比較に簡素化（常に `undefined` だった `savedStampPalette` を排除）。
- トースト文言を用途別に変更:
  - 作成: 「スタンプパレットを作成しました / 作成に失敗しました」
  - 更新: 「スタンプパレットを更新しました / 更新に失敗しました」

確認方法

## なぜこの PR を入れたいのか

close: #4786

## 動作確認の手順

- 作成タブ:
  - 変更後に「作成」→ トースト「作成しました」、二重作成なし、不要な離脱確認なし。
  - 変更がある状態でページ離脱を試す → 確認ダイアログが表示される。キャンセル後、再度離脱でも継続して表示。
- 詳細（編集）タブ:
  - 変更後に「更新」→ トースト「更新しました」、離脱確認/自動保存の二重発火なし。
  - キャンセル時は離脱確認が1回のみで、以降の不要ダイアログなし。

## UI 変更部分のスクリーンショット

なし

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
