### PR TITLE
chore: use addEventListener for MediaQueryList, now supported in safari

### DIFF
--- a/src/store/app/themeSettings.ts
+++ b/src/store/app/themeSettings.ts
@@ -78,8 +78,7 @@ const useThemeSettingsPinia = defineStore('ui/themeSettings', () => {
 
   const queryList = window.matchMedia('(prefers-color-scheme: dark)')
   const isOsDarkTheme = ref(queryList.matches)
-  // safariではaddEventListener('change', func)が未対応なため
-  queryList.addListener((event: MediaQueryListEvent) => {
+  queryList.addEventListener('change', (event: MediaQueryListEvent) => {
     isOsDarkTheme.value = event.matches
   })
 

--- a/src/store/ui/responsive.ts
+++ b/src/store/ui/responsive.ts
@@ -11,11 +11,10 @@ const useResponsiveStorePinia = defineStore('ui/responsive', () => {
 
   const isMobile = ref(queryList.matches)
   const isTouchDevice = ref(!isHoverSupported.matches)
-  // safariではaddEventListener('change', func)が未対応なため
-  queryList.addListener((event: MediaQueryListEvent) => {
+  queryList.addEventListener('change', (event: MediaQueryListEvent) => {
     isMobile.value = event.matches
   })
-  isHoverSupported.addListener((event: MediaQueryListEvent) => {
+  isHoverSupported.addEventListener('change', (event: MediaQueryListEvent) => {
     isTouchDevice.value = event.matches
   })
 


### PR DESCRIPTION
(First time contributing, bored at home in a Saturday morning, I can try adding tests but I don't think cypress has a safari environment 😿 ) 
## 概要

## なぜこの PR を入れたいのか
- Safari now supports <#MediaQueryList>.addEventListener

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->
https://github.com/traPtitech/traQ_S-UI/issues/4790


