### PR TITLE
feat(markdown): コピー可能なコードブロック

### DIFF
--- a/src/assets/mdi.ts
+++ b/src/assets/mdi.ts
@@ -23,6 +23,8 @@ import {
   mdiChevronLeft,
   mdiChevronRight,
   mdiChevronUp,
+  mdiClipboardCheckMultipleOutline,
+  mdiClipboardTextMultipleOutline,
   mdiClose,
   mdiCloseCircle,
   mdiCodeGreaterThan,
@@ -191,7 +193,9 @@ const mdi: MdiIconsMapping = {
   'video-off': mdiVideoOff,
   'comment-outline': mdiCommentTextMultipleOutline,
   'comment-off-outline': mdiCommentOffOutline,
-  'palette-outline': mdiPaletteOutline
+  'palette-outline': mdiPaletteOutline,
+  'clipboard-text-multiple-outline': mdiClipboardTextMultipleOutline,
+  'clipboard-check-multiple-outline': mdiClipboardCheckMultipleOutline
 }
 
 export default mdi

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -20,7 +20,7 @@
     <SpinNumber :value="stamp.sum" :class="$style.count" />
   </div>
   <StampScaledElement
-    :show="(isLongHovered || RemainScaled) && !isDetailShown && !isTouchDevice"
+    :show="(isHovered || RemainScaled) && !isDetailShown && !isTouchDevice"
     :stamp="stamp"
     :target-rect="hoveredRect"
     @scaled-hover="onScaledElementHover"
@@ -36,8 +36,8 @@ import { useStampsStore } from '/@/store/entities/stamps'
 import { useResponsiveStore } from '/@/store/ui/responsive'
 import type { MessageStampById } from '/@/lib/messageStampList'
 import StampScaledElement from './StampScaledElement.vue'
-import useHover from '/@/composables/dom/useHover'
 import { useToastStore } from '/@/store/ui/toast'
+import useHover from '/@/composables/dom/useHover'
 
 const props = defineProps<{
   stamp: MessageStampById
@@ -107,7 +107,8 @@ watch(
   }
 )
 
-const { isLongHovered, onMouseEnter, onMouseLeave } = useHover()
+const { isHovered, onMouseEnter, onMouseLeave } = useHover(500)
+
 const stampRoot = ref<HTMLElement | null>(null)
 const hoveredRect = ref<DOMRect | undefined>(undefined)
 const hoverTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
@@ -126,7 +127,7 @@ const leaveScaledElementHover = () => {
   hoveredRect.value = undefined
 }
 
-watch(isLongHovered, beginHover => {
+watch(isHovered, beginHover => {
   if (beginHover) {
     if (hoverTimeout.value) {
       clearTimeout(hoverTimeout.value)

--- a/src/components/UI/CopyButton.vue
+++ b/src/components/UI/CopyButton.vue
@@ -1,0 +1,65 @@
+<template>
+  <IconButton
+    :class="$style.button"
+    icon-mdi
+    :icon-name="
+      copied
+        ? 'clipboard-check-multiple-outline'
+        : 'clipboard-text-multiple-outline'
+    "
+    :title="copied ? 'copied!' : 'copy'"
+    @click.stop="copy"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+  />
+</template>
+
+<script lang="ts" setup>
+import { ref, toValue, type MaybeRefOrGetter } from 'vue'
+import IconButton from '/@/components/UI/IconButton.vue'
+import useHover from '/@/composables/dom/useHover'
+import useExecWithToast from '/@/composables/toast/useExecWithToast'
+
+const { contentsSource } = defineProps<{
+  contentsSource: MaybeRefOrGetter<string | undefined | null>
+}>()
+
+const { execWithToast } = useExecWithToast()
+const copied = ref(false)
+const { isHovered, onMouseEnter, onMouseLeave: onMouseLeaveImpl } = useHover()
+
+let timeout: NodeJS.Timeout | null = null
+
+const onMouseLeave = () => {
+  onMouseLeaveImpl()
+  if (!timeout) copied.value = false
+}
+
+const copy = async () => {
+  const content = toValue(contentsSource)
+  if (!content) return
+
+  execWithToast(undefined, 'コピーに失敗しました', async () => {
+    await navigator.clipboard.writeText(content)
+    copied.value = true
+
+    timeout = setTimeout(() => {
+      timeout = null
+      if (isHovered.value) return
+      copied.value = false
+    }, 1500)
+  })
+}
+</script>
+
+<style lang="scss" module>
+.button {
+  @include color-ui-primary;
+
+  opacity: 0.6;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/UI/FoldButton.vue
+++ b/src/components/UI/FoldButton.vue
@@ -6,7 +6,7 @@
     <AIcon
       v-if="showIcon"
       :name="isFold ? 'down' : 'up'"
-      :class="$style['icon']"
+      :class="$style.icon"
     />
     {{ isFold ? 'さらに表示' : '折りたたむ' }}
   </button>

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -48,7 +48,7 @@ const content = computed(() => {
   return props.preContent.textContent?.replace(/\n$/, '')
 })
 
-const line_count = computed(() => {
+const lineCount = computed(() => {
   if (!content.value) return 0
 
   const lines = content.value.split('\n')
@@ -56,7 +56,7 @@ const line_count = computed(() => {
 })
 
 const isLong = computed(() => {
-  return line_count.value > MAX_LINES
+  return lineCount.value > MAX_LINES
 })
 
 const preWrapRef = ref<HTMLDivElement>()

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -1,31 +1,38 @@
 <template>
-  <div
-    v-if="isLong"
-    :class="[$style.wrap]"
-    :data-is-fold="isFold"
-    @click="unfold"
-  >
-    <div ref="preWrapRef" :class="wrapClass" v-html="preContent.outerHTML" />
-    <FoldButton
-      show-icon
-      :is-fold="isFold"
-      :class="$style.button"
-      :aria-controls="foldBlockId"
-      :aria-expanded="!isFold"
-      @click="toggle"
+  <div :class="$style.container">
+    <div
+      v-if="isLong"
+      :class="[$style.wrap]"
+      :data-is-fold="isFold"
+      @click="unfold"
+    >
+      <div ref="preWrapRef" :class="wrapClass" v-html="preContent.outerHTML" />
+      <FoldButton
+        show-icon
+        :is-fold="isFold"
+        :class="$style.foldButton"
+        :aria-controls="foldBlockId"
+        :aria-expanded="!isFold"
+        @click="toggle"
+      />
+    </div>
+    <div
+      v-else
+      ref="preWrapRef"
+      :class="wrapClass"
+      v-html="preContent.outerHTML"
     />
+
+    <div :class="$style.copyButton">
+      <CopyButton :contents-source="() => preContent.textContent" />
+    </div>
   </div>
-  <div
-    v-else
-    ref="preWrapRef"
-    :class="wrapClass"
-    v-html="preContent.outerHTML"
-  />
 </template>
 
 <script lang="ts" setup>
 import { computed, onMounted, ref } from 'vue'
 import FoldButton from '/@/components/UI/FoldButton.vue'
+import CopyButton from '/@/components/UI/CopyButton.vue'
 import { randomString } from '/@/lib/basic/randomString'
 
 const MAX_LINES = 5
@@ -72,12 +79,37 @@ const toggle = (e: MouseEvent) => {
 </script>
 
 <style lang="scss" module>
-.wrap {
+.container {
   position: relative;
+
+  code {
+    padding-right: 46px !important;
+  }
+}
+
+.copyButton {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+
+  padding: 8px 8px 4px 14px;
+
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--markdown-code-background) 30%
+  );
+
+  width: fit-content;
+}
+
+.wrap {
   overflow: hidden;
+
   pre {
     margin-bottom: 0;
   }
+
   margin-bottom: 16px;
 
   &[data-is-fold='true'] {
@@ -98,7 +130,7 @@ const toggle = (e: MouseEvent) => {
     }
   }
 
-  .button {
+  .foldButton {
     position: absolute;
     bottom: 8px;
     margin: auto;
@@ -109,13 +141,13 @@ const toggle = (e: MouseEvent) => {
   }
 
   @media (any-hover: hover) {
-    .button {
+    .foldButton {
       transform: translateY(-8px);
       opacity: 0;
     }
 
     &:hover {
-      .button {
+      .foldButton {
         transform: translateY(0);
         opacity: 1;
       }

--- a/src/components/UI/FoldableCodeBlock.vue
+++ b/src/components/UI/FoldableCodeBlock.vue
@@ -24,7 +24,7 @@
     />
 
     <div :class="$style.copyButton">
-      <CopyButton :contents-source="() => preContent.textContent" />
+      <CopyButton :contents-source="() => content" />
     </div>
   </div>
 </template>
@@ -44,10 +44,14 @@ const props = defineProps<{
 
 const isFold = ref(true)
 
+const content = computed(() => {
+  return props.preContent.textContent?.replace(/\n$/, '')
+})
+
 const line_count = computed(() => {
-  const content = props.preContent.textContent
-  if (content === null) return 0
-  const lines = content.split('\n')
+  if (!content.value) return 0
+
+  const lines = content.value.split('\n')
   return lines.length - (lines.at(-1) === '' ? 1 : 0) // 末尾の改行は行数に含めない
 })
 

--- a/src/components/UI/MarkdownContent.vue
+++ b/src/components/UI/MarkdownContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <span
+  <div
     ref="contentRef"
     class="markdown-body"
     :class="$style.content"

--- a/src/composables/dom/useHover.ts
+++ b/src/composables/dom/useHover.ts
@@ -1,29 +1,32 @@
-import { ref } from 'vue'
 import useToggle from '/@/composables/utils/useToggle'
 
-const useHover = (LongHoverTime = 500) => {
-  const { value: isHovered, open, close } = useToggle()
-  const isLongHovered = ref(false)
-  const hoverTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
+const useHover = (delay: number = 0) => {
+  const { value, open, close } = useToggle()
+  let timeoutId: NodeJS.Timeout | null = null
+
   const onMouseEnter = () => {
-    open()
-    isHovered.value = true
-    hoverTimeout.value = setTimeout(() => {
-      if (isHovered.value) {
-        isLongHovered.value = true
-      }
-    }, LongHoverTime)
+    if (delay <= 0) {
+      open()
+    } else {
+      timeoutId = setTimeout(() => {
+        open()
+      }, delay)
+    }
   }
+
   const onMouseLeave = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+      timeoutId = null
+    }
+
     close()
-    if (hoverTimeout.value) clearTimeout(hoverTimeout.value)
-    isLongHovered.value = false
   }
+
   return {
-    isHovered,
-    isLongHovered,
     onMouseEnter,
-    onMouseLeave
+    onMouseLeave,
+    isHovered: value
   }
 }
 


### PR DESCRIPTION
## 概要

- `useHover` composable のパフォーマンスと型を改善
  - optimize: 不要なリアクティビティ (`hoverTimeout`) を削除
- feat: `CopyButton` component を作成
- feat: `FoldableCodeBlock` に CopyButton を配置
- fix: コンテンツモデルに沿ったタグを用いる
  - `<span>` の子要素として許容されるのは phrasing content のみであるが，`<div>` 等は phrasing content でないので，markdown-body として `<span>` を用いるべきでないと思われる．
- refactor: `FoldButton` component の `$style` のアクセサーを dot notation にする

## なぜこの PR を入れたいのか

closes: #3819
- すでに他の方の assign がありますが，traQ (https://q.trap.jp/channels/team/SysAd/traQ/Client/1?message=019844be-76c9-709d-accf-ea57a9ca8fc3 あたり) を読む限りないことになっていそうなので触ってみました

- ボタンの配置やデザインに関しては要検討だと思うのですが，たたき台として一旦 PR だけ立ててみます．

## 動作確認の手順

## UI 変更部分のスクリーンショット
<img width="1546" height="515" alt="image" src="https://github.com/user-attachments/assets/5ec6a547-bb94-41da-8172-dc6759661da1" />


## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう