### PR TITLE
fix: `ModalHeader` の `edit` イベントの発火を `@mousedown` ではなく `@click` にする

### DIFF
--- a/src/components/Modal/Common/ModalHeader.vue
+++ b/src/components/Modal/Common/ModalHeader.vue
@@ -20,7 +20,7 @@
       :class="$style.editButton"
       icon-name="pencil"
       icon-mdi
-      @mousedown="emit('edit', $event)"
+      @click="emit('edit', $event)"
     />
   </div>
 </template>


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

#4760 に修正したい箇所があったため．
- マウスを押下しただけで遷移してしまうのは違和感

## 動作確認の方法
GroupModal を開き、ペン型の編集ボタンをクリックして group manager に遷移できるか確かめる．

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう