### PR TITLE
fix: (開発環境下での) 警告を一部修正

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderChannelName.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderChannelName.vue
@@ -42,14 +42,15 @@ type ChannelPathInfo = {
   link: string
 }
 /** 現在のチャンネルに至るまでのフルパスたち */
-const pathInfoList = computed((): ChannelPathInfo[] =>
-  channelIdToPath(props.channelId).map((p, i, arr) => {
-    const path = arr.slice(0, i + 1)
-    return {
-      name: p,
-      link: constructChannelPath(path.join('/'))
-    }
-  })
+const pathInfoList = computed(
+  (): ChannelPathInfo[] =>
+    channelIdToPath(props.channelId)?.map((p, i, arr) => {
+      const path = arr.slice(0, i + 1)
+      return {
+        name: p,
+        link: constructChannelPath(path.join('/'))
+      }
+    }) ?? []
 )
 
 const ancestorsPath = computed(() => pathInfoList.value.slice(0, -1))

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationListItem.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationListItem.vue
@@ -26,7 +26,7 @@ const focus = () => {
 }
 
 const { channelIdToLink } = useChannelPath()
-const channelLink = computed(() => channelIdToLink(props.channel.id))
+const channelLink = computed(() => channelIdToLink(props.channel.id) ?? '')
 
 const isTopicEmpty = computed(() => props.channel.topic.length === 0)
 const topic = computed(() =>

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/composables/useCopyChannelLink.ts
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/composables/useCopyChannelLink.ts
@@ -9,7 +9,7 @@ const useCopyChannelLink = (props: { channelId: ChannelId }) => {
   const { channelIdToPathString } = useChannelPath()
 
   const copyLink = async () => {
-    const channelPath = channelIdToPathString(props.channelId)
+    const channelPath = channelIdToPathString(props.channelId) as string
     const channelUrl = `${embeddingOrigin}${constructChannelPath(channelPath)}`
 
     await copyText(`[#${channelPath}](${channelUrl})`, 'チャンネルリンク')

--- a/src/components/Main/MainView/ChannelView/ChannelViewContent/ChannelViewContentMain.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelViewContent/ChannelViewContentMain.vue
@@ -123,7 +123,7 @@ const showToNewMessageButton = ref(false)
 const { channelIdToPathString } = useChannelPath()
 const toNewMessage = () => {
   if (props.entryMessageId) {
-    const channelPath = channelIdToPathString(props.channelId)
+    const channelPath = channelIdToPathString(props.channelId) as string
     if (dmChannelsMap.value.has(props.channelId)) {
       router.replace(constructUserPath(channelPath))
     } else {

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItem.vue
@@ -33,7 +33,7 @@
     </div>
     <MessageQuoteListItemFooter
       :class="$style.footer"
-      :message="message"
+      :message="message!"
       :disable-links="disableFooterLinks"
     />
   </div>

--- a/src/components/Main/MainView/MessageElement/MessageQuoteListItemFooter.vue
+++ b/src/components/Main/MainView/MessageElement/MessageQuoteListItemFooter.vue
@@ -28,7 +28,7 @@ import MessageLink from '/@/components/UI/MessageLink.vue'
 
 const props = withDefaults(
   defineProps<{
-    message?: Message
+    message: Message
     disableLinks?: boolean
   }>(),
   {
@@ -38,14 +38,14 @@ const props = withDefaults(
 
 const { channelIdToPathString, channelIdToLink } = useChannelPath()
 
-const channelPath = computed(() =>
-  props.message ? channelIdToPathString(props.message.channelId, true) : ''
+const channelPath = computed(
+  () => channelIdToPathString(props.message.channelId, true) ?? ''
 )
-const channelLink = computed(() =>
-  props.message ? channelIdToLink(props.message.channelId) : ''
+const channelLink = computed(
+  () => channelIdToLink(props.message.channelId) ?? ''
 )
-const date = computed(() =>
-  props.message ? getDateRepresentation(props.message.createdAt) : ''
+const date = computed(
+  () => getDateRepresentation(props.message.createdAt) ?? ''
 )
 </script>
 

--- a/src/components/Main/MainView/MessageElement/StampElement.vue
+++ b/src/components/Main/MainView/MessageElement/StampElement.vue
@@ -20,7 +20,6 @@
     <SpinNumber :value="stamp.sum" :class="$style.count" />
   </div>
   <StampScaledElement
-    :class="$style.scaleReaction"
     :show="(isLongHovered || RemainScaled) && !isDetailShown && !isTouchDevice"
     :stamp="stamp"
     :target-rect="hoveredRect"
@@ -176,19 +175,5 @@ watch(isLongHovered, beginHover => {
     left: 6px;
     right: 4px;
   }
-}
-
-.scaleReaction {
-  @include background-tertiary;
-  display: flex;
-  align-items: center;
-  padding: 0.125rem 0.25rem;
-  border-radius: 0.25rem;
-  user-select: none;
-  overflow: visible;
-  contain: content;
-  position: absolute;
-  bottom: 105%;
-  z-index: $z-index-message-element-scaled-stamp;
 }
 </style>

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggestionList.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggestionList.ts
@@ -15,6 +15,7 @@ import { useStampsStore } from '/@/store/entities/stamps'
 import useUserList from '/@/composables/users/useUserList'
 import { useChannelsStore } from '/@/store/entities/channels'
 import useChannelPath from '/@/composables/useChannelPath'
+import { isDefined } from '/@/lib/basic/array'
 
 const events: Array<keyof EntityEventMap> = [
   'setUser',
@@ -78,12 +79,19 @@ const useCandidateTree = () => {
         type: 'stamp-effect',
         text: `.${effectName}`
       })),
-      [...channelsMap.value.values()].map(channel => ({
-        type: 'channel',
-        text: channelIdToPathString(channel.id, true),
-        id: channel.id,
-        delimiter: '/'
-      }))
+      [...channelsMap.value.values()]
+        .map(channel => {
+          const path = channelIdToPathString(channel.id, true)
+          if (!path) return undefined
+
+          return {
+            type: 'channel',
+            text: path,
+            id: channel.id,
+            delimiter: '/'
+          } as const
+        })
+        .filter(isDefined)
     )
 
   const tree = ref<TrieTree<Word>>(constructTree())

--- a/src/components/Main/MainView/PrimaryViewSidebar/SidebarEvent/SidebarEventChildCreated.vue
+++ b/src/components/Main/MainView/PrimaryViewSidebar/SidebarEvent/SidebarEventChildCreated.vue
@@ -27,5 +27,7 @@ const newChildPath = computed(() =>
   channelIdToShortPathString(props.details.channelId, true)
 )
 
-const newChildLink = computed(() => channelIdToLink(props.details.channelId))
+const newChildLink = computed(
+  () => channelIdToLink(props.details.channelId) ?? ''
+)
 </script>

--- a/src/components/Main/MainView/PrimaryViewSidebar/SidebarEvent/SidebarEventParentChanged.vue
+++ b/src/components/Main/MainView/PrimaryViewSidebar/SidebarEvent/SidebarEventParentChanged.vue
@@ -27,5 +27,5 @@ const newParentPath = computed(() =>
   channelIdToPathString(props.details.after, true)
 )
 
-const newParentLink = computed(() => channelIdToLink(props.details.after))
+const newParentLink = computed(() => channelIdToLink(props.details.after) ?? '')
 </script>

--- a/src/components/Main/MainView/QallView/SubQallView.vue
+++ b/src/components/Main/MainView/QallView/SubQallView.vue
@@ -29,7 +29,7 @@ const track = computed(() =>
 )
 
 const restoreMainView = () => {
-  const channelPath = channelIdToPathString(callingChannel.value)
+  const channelPath = channelIdToPathString(callingChannel.value) as string
   router.push(constructChannelPath(channelPath))
   isSubView.value = false
 }

--- a/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
@@ -22,7 +22,7 @@
       <router-link
         v-slot="{ href, navigate }"
         custom
-        :to="channelIdToLink(props.channel.id)"
+        :to="channelIdToLink(props.channel.id) ?? ''"
       >
         <a
           :class="$style.channel"
@@ -30,7 +30,9 @@
           :aria-current="isSelected && 'page'"
           :aria-expanded="hasChildren && isOpened ? true : undefined"
           :data-is-inactive="$boolAttr(!channel.active)"
-          :aria-label="showShortenedPath ? pathTooltip : pathToShow"
+          :aria-label="
+            showShortenedPath ? pathTooltip : (pathToShow ?? undefined)
+          "
           draggable="false"
           @click="navigate"
           @mouseenter="onMouseEnter"
@@ -126,7 +128,7 @@ const onClickIcon = (e: KeyboardEvent | MouseEvent) => {
 const { openLink } = useOpenLink()
 const { channelIdToLink } = useChannelPath()
 const openChannel = (event: MouseEvent) => {
-  openLink(event, channelIdToLink(props.channel.id))
+  openLink(event, channelIdToLink(props.channel.id) as string)
 }
 
 const { pathToShow, pathTooltip } = usePath(props as TypedProps)

--- a/src/components/Main/NavigationBar/DMChannelList/DMChannelElement.vue
+++ b/src/components/Main/NavigationBar/DMChannelList/DMChannelElement.vue
@@ -56,7 +56,7 @@ const notificationState = useNotificationState(toRef(props, 'dmChannel'))
 const { openLink } = useOpenLink()
 const { channelIdToLink } = useChannelPath()
 const openChannel = (event: MouseEvent) => {
-  openLink(event, channelIdToLink(props.dmChannel.id))
+  openLink(event, channelIdToLink(props.dmChannel.id) as string)
 }
 
 const { isHovered, onMouseEnter, onMouseLeave } = useHover()

--- a/src/components/Main/NavigationBar/EphemeralNavigationContent/DraftList/DraftListDetailsPanelChannel.vue
+++ b/src/components/Main/NavigationBar/EphemeralNavigationContent/DraftList/DraftListDetailsPanelChannel.vue
@@ -31,10 +31,10 @@ const props = defineProps<{
 
 const { channelIdToShortPathString, channelIdToLink } = useChannelPath()
 
-const channelPath = computed(() =>
-  channelIdToShortPathString(props.channelId, true)
+const channelPath = computed(
+  () => channelIdToShortPathString(props.channelId, true) ?? ''
 )
-const channelLink = computed(() => channelIdToLink(props.channelId))
+const channelLink = computed(() => channelIdToLink(props.channelId) ?? '')
 const hasAttachments = computed(() => props.state.attachments.length > 0)
 
 const renderedContent = ref()

--- a/src/components/Main/NavigationBar/NavigationContent/ActivityElement.vue
+++ b/src/components/Main/NavigationBar/NavigationContent/ActivityElement.vue
@@ -26,7 +26,7 @@ const titleType = computed(() =>
 )
 const channelLink = computed(() =>
   props.type === 'channel'
-    ? channelIdToLink(props.message.channelId)
+    ? (channelIdToLink(props.message.channelId) ?? '')
     : constructMessagesPath(props.message.id)
 )
 </script>

--- a/src/components/Main/NavigationBar/NavigationContent/ChannelsTab.vue
+++ b/src/components/Main/NavigationBar/NavigationContent/ChannelsTab.vue
@@ -88,7 +88,7 @@ const staredChannels = computed(() => {
 const sortChannelTree = (tree: ChannelTreeNode[]): ChannelTreeNode[] => {
   const mapped = tree.map((node, index) => ({
     index,
-    pathString: channelIdToPathString(node.id).toUpperCase()
+    pathString: channelIdToPathString(node.id)?.toUpperCase() ?? ''
   }))
   mapped.sort((a, b) => {
     if (a.pathString > b.pathString) {

--- a/src/components/Main/NavigationBar/NavigationContent/composables/useChannelFilter.ts
+++ b/src/components/Main/NavigationBar/NavigationContent/composables/useChannelFilter.ts
@@ -13,7 +13,7 @@ const useChannelFilter = (targetChannels: Ref<readonly Channel[]>) => {
   const sortFilterdChannel = (tree: Channel[]): Channel[] => {
     const mapped = tree.map((channel, index) => ({
       index,
-      pathString: channelIdToPathString(channel.id).toUpperCase()
+      pathString: channelIdToPathString(channel.id)?.toUpperCase() ?? ''
     }))
 
     mapped.sort((a, b) => {

--- a/src/components/Modal/ChannelManageModal/ChannelManageModal.vue
+++ b/src/components/Modal/ChannelManageModal/ChannelManageModal.vue
@@ -107,7 +107,7 @@ const channel = computed((): Required<PatchChannelRequest> => {
   }
 })
 const { channelIdToPathString } = useChannelPath()
-const subtitle = computed(() => channelIdToPathString(props.id, true))
+const subtitle = computed(() => channelIdToPathString(props.id, true) ?? '')
 
 const manageState = reactive({ ...channel.value })
 const { manageChannel } = useManageChannel(props, manageState, channel)

--- a/src/components/Modal/FileModal/FileModalContentFooter.vue
+++ b/src/components/Modal/FileModal/FileModalContentFooter.vue
@@ -48,7 +48,7 @@ const { channelIdToPathString, channelIdToLink } = useChannelPath()
 const channelPath = computed(() => {
   try {
     return fileMeta.value?.channelId
-      ? channelIdToPathString(fileMeta.value?.channelId, true)
+      ? (channelIdToPathString(fileMeta.value?.channelId, true) ?? '')
       : ''
   } catch {
     return ''
@@ -65,8 +65,7 @@ const channelLink = computed(() => {
 })
 
 const onClick = async (event: MouseEvent) => {
-  if (channelLink.value === '') return
-
+  if (!channelLink.value) return
   openLinkAndClearModal(event, channelLink.value)
 }
 </script>

--- a/src/components/Modal/NotificationModal/NotificationModal.vue
+++ b/src/components/Modal/NotificationModal/NotificationModal.vue
@@ -33,8 +33,8 @@ const props = defineProps<{
 }>()
 
 const { channelIdToPathString } = useChannelPath()
-const channelPathString = computed(() =>
-  channelIdToPathString(props.channelId, true)
+const channelPathString = computed(
+  () => channelIdToPathString(props.channelId, true) ?? ''
 )
 
 const modalMounted = ref(false)

--- a/src/components/Modal/UserModal/FeatureContainer/LinkButtons.vue
+++ b/src/components/Modal/UserModal/FeatureContainer/LinkButtons.vue
@@ -44,8 +44,7 @@ const onDMClick = async (event: MouseEvent) => {
 
 const onHomeChannelClick = async (event: MouseEvent) => {
   if (!props.homeChannelId) return
-
-  openLinkAndClearModal(event, channelIdToLink(props.homeChannelId))
+  openLinkAndClearModal(event, channelIdToLink(props.homeChannelId) as string)
 }
 </script>
 

--- a/src/components/Modal/UserModal/ProfileTab/HomeChannel.vue
+++ b/src/components/Modal/UserModal/ProfileTab/HomeChannel.vue
@@ -41,6 +41,7 @@ const channelPath = computed(() =>
 
 const onClick = async (event: MouseEvent) => {
   if (!props.channelId) return
+  if (!channelPath.value) return
 
   openLinkAndClearModal(event, constructChannelPath(channelPath.value))
 }

--- a/src/components/Settings/BrowserTab/OpenMode.vue
+++ b/src/components/Settings/BrowserTab/OpenMode.vue
@@ -48,7 +48,7 @@ const toggleOpenMode = () => {
 }
 
 const { channelOptions } = useChannelOptions(undefined, channel =>
-  channel ? channelIdToPathString(channel.id) : '(unknown)'
+  channel ? (channelIdToPathString(channel.id) ?? '') : '(unknown)'
 )
 </script>
 

--- a/src/components/Settings/SessionTab/ViewStates.vue
+++ b/src/components/Settings/SessionTab/ViewStates.vue
@@ -3,8 +3,8 @@
     <h3 :class="$style.header">
       他端末/ブラウザで最新のメッセージを開いているチャンネル
     </h3>
-    <ul v-if="monitoringChanelStrings.length > 0" :class="$style.list">
-      <li v-for="channel in monitoringChanelStrings" :key="channel">
+    <ul v-if="monitoringChannelStrings.length > 0" :class="$style.list">
+      <li v-for="channel in monitoringChannelStrings" :key="channel">
         {{ channel }}
       </li>
     </ul>
@@ -26,10 +26,10 @@ fetchViewStates()
 
 const { channelIdToPathString } = useChannelPath()
 
-const monitoringChanelStrings = computed(() =>
+const monitoringChannelStrings = computed(() =>
   [...monitoringChannels.value.values()].map(cId => {
     try {
-      return channelIdToPathString(cId, true)
+      return channelIdToPathString(cId, true) ?? ''
     } catch {
       return ''
     }

--- a/src/components/UI/MessagePanel/MessagePanel.vue
+++ b/src/components/UI/MessagePanel/MessagePanel.vue
@@ -88,7 +88,7 @@ const { channelIdToShortPathString } = useChannelPath()
 
 const path = computed(() => {
   try {
-    return channelIdToShortPathString(props.message.channelId)
+    return channelIdToShortPathString(props.message.channelId) ?? 'unknown'
   } catch {
     return 'unknown'
   }

--- a/src/composables/modal/useCanCreateChildChannel.ts
+++ b/src/composables/modal/useCanCreateChildChannel.ts
@@ -9,7 +9,8 @@ const useCanCreateChildChannel = () => {
   const { channelIdToPathString } = useChannelPath()
 
   const canCreateChildChannel = (channelId: ChannelId) => {
-    const path = channelId !== nullUuid ? channelIdToPathString(channelId) : ''
+    const path =
+      channelId !== nullUuid ? (channelIdToPathString(channelId) ?? '') : ''
     const isArchived = channelsMap.value.get(channelId)?.archived ?? false
     return canCreateChildChannel_(path, isArchived)
   }

--- a/src/composables/useChannelOptions.ts
+++ b/src/composables/useChannelOptions.ts
@@ -34,7 +34,7 @@ const useChannelOptions = (
     const channels = [...channelsMap.value.values()]
       .filter(channel => containsArchivedChannels || !channel.archived)
       .map(channel => ({
-        key: channelIdToPathString(channel.id, true),
+        key: channelIdToPathString(channel.id, true) ?? '',
         value: channelToVal(channel)
       }))
       .sort((a, b) => compareStringInsensitive(a.key, b.key))

--- a/src/composables/useClose.ts
+++ b/src/composables/useClose.ts
@@ -19,7 +19,8 @@ const useClose = () => {
     switch (primaryView.value.type) {
       case 'channel': {
         try {
-          const channelPath = channelIdToPathString(primaryView.value.channelId)
+          const channelPath =
+            channelIdToPathString(primaryView.value.channelId) ?? ''
           router.push(constructChannelPath(channelPath))
         } catch {
           router.push(constructChannelPath(defaultChannelName.value))

--- a/src/store/entities/channels.ts
+++ b/src/store/entities/channels.ts
@@ -164,6 +164,7 @@ const useChannelsStorePinia = defineStore('entities/channels', () => {
     channelsMap,
     dmChannelsMap,
     userIdToDmChannelIdMap,
+    bothChannelsMapFetched,
     bothChannelsMapInitialFetchPromise,
     addChannel,
     fetchUserDMChannel,

--- a/src/store/ui/modal.ts
+++ b/src/store/ui/modal.ts
@@ -116,7 +116,9 @@ const useModalStorePinia = defineStore('ui/modal', () => {
     const primaryView = mainViewStore.primaryView.value
     if (primaryView.type === 'channel') {
       router.replace(
-        constructChannelPath(channelIdToPathString(primaryView.channelId))
+        constructChannelPath(
+          channelIdToPathString(primaryView.channelId) as string
+        )
       )
     } else if (primaryView.type === 'dm') {
       router.replace(constructUserPath(primaryView.userName))

--- a/src/views/composables/useRouteWatcher.ts
+++ b/src/views/composables/useRouteWatcher.ts
@@ -167,7 +167,7 @@ const useRouteWatcher = () => {
     let channelPath = ''
     let channelId = ''
     if (file.channelId) {
-      channelPath = channelIdToPathString(file.channelId, true)
+      channelPath = channelIdToPathString(file.channelId, true) ?? ''
       channelId = file.channelId
     } else {
       channelPath = openChannelPath.value
@@ -218,7 +218,7 @@ const useRouteWatcher = () => {
       // paramsでchannelPathを指定すると/がエンコードされてバグる
       // https://github.com/traPtitech/traQ_S-UI/issues/1611
       router.replace({
-        path: channelIdToLink(message.channelId),
+        path: channelIdToLink(message.channelId) as string,
         query: { message: message.id }
       })
     } else if (dmChannelsMap.value.has(channelId)) {

--- a/tests/unit/composables/channels/useChannelPath.spec.ts
+++ b/tests/unit/composables/channels/useChannelPath.spec.ts
@@ -7,7 +7,7 @@ describe('useChannelPath', () => {
   beforeEach(() => {
     createTestingPinia()
 
-    const { channelsMap } = useChannelsStore()
+    const { channelsMap, bothChannelsMapFetched } = useChannelsStore()
     const refinedChannels: Channel[] = channels.map(channel => ({
       ...channel,
       force: false,
@@ -17,6 +17,7 @@ describe('useChannelPath', () => {
         .map(c => c.id)
     }))
     channelsMap.value = new Map(refinedChannels.map(c => [c.id, c]))
+    bothChannelsMapFetched.value = true
   })
 
   test('channel tree', () => {


### PR DESCRIPTION
## 概要

- (fix: top level で呼び出した `useMittListener` を破棄しない)
   - #4812 が merge されれば直るはずなので消しました
- fix & refactor: [不要な style を削除](//github.com/traPtitech/traQ_S-UI/pull/4809/commits/f6ce8158ad9dd5965c66087619327376549d3772)
- fix: [`channelsMap` が fetch 済みでなければ `useChannelPath` 内のメソッドが `null` を返すようにする](//github.com/traPtitech/traQ_S-UI/pull/4809/commits/9f210533c54a1f2703f73d8fe596d80ec2a61af6)
  - fix: [既存の呼び出しをシグネチャの変更に合わせて修正する](//github.com/traPtitech/traQ_S-UI/pull/4809/commits/468e956ed818e3d921321bf54dc8805d40cfcf3f)
  
## なぜこの PR を入れたいのか
- `npm run dev` でクライアントを立ち上げると console に警告や warning がいくつか出て邪魔

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう