### PR TITLE
fix: WebKit 系ブラウザでレイアウトが崩れる不具合を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,17 @@
       }
     </style>
 
+    <style>
+      /*
+        WebKit で発生する contain: strict による不具合の回避策
+        WebKit の場合は App.vue にて "inline-size layout paint style" を指定する
+        cf. https://bugs.webkit.org/show_bug.cgi?id=297186
+      */
+      body {
+        --contain-strict: strict;
+      }
+    </style>
+
     <link href="/fonts/fonts.css" rel="stylesheet" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,14 +21,16 @@ import { useBrowserSettings } from '/@/store/app/browserSettings'
 import { useTts } from '/@/store/app/tts'
 import { useThemeSettings } from '/@/store/app/themeSettings'
 import useDocumentTitle from '/@/composables/document/useDocumentTitle'
-import { isWebKit } from './lib/dom/browser'
+import { isWebKit } from '/@/lib/dom/browser'
 
-if (isWebKit()) {
+const alternateContainStrict = () => {
   document.body.style.setProperty(
     '--contain-strict',
     'inline-size layout paint style'
   )
 }
+
+if (isWebKit()) alternateContainStrict()
 
 const useQallConfirmer = () => {
   window.addEventListener('beforeunload', event => {
@@ -96,6 +98,15 @@ ${Object.entries(style.value)
 import ToastContainer from '/@/components/Toast/ToastContainer.vue'
 import ModalContainer from '/@/components/Modal/ModalContainer.vue'
 import StampPickerContainer from '/@/components/Main/StampPicker/StampPickerContainer.vue'
+import { useFeatureFlagSettings } from '/@/store/app/featureFlagSettings'
+
+const { featureFlags } = useFeatureFlagSettings()
+
+watchEffect(() => {
+  if (featureFlags.value.contain_strict_alternate.enabled) {
+    alternateContainStrict()
+  }
+})
 
 useTts()
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,14 @@ import { useBrowserSettings } from '/@/store/app/browserSettings'
 import { useTts } from '/@/store/app/tts'
 import { useThemeSettings } from '/@/store/app/themeSettings'
 import useDocumentTitle from '/@/composables/document/useDocumentTitle'
+import { isWebKit } from './lib/dom/browser'
+
+if (isWebKit()) {
+  document.body.style.setProperty(
+    '--contain-strict',
+    'inline-size layout paint style'
+  )
+}
 
 const useQallConfirmer = () => {
   window.addEventListener('beforeunload', event => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import type { Ref } from 'vue'
-import { computed, watchEffect } from 'vue'
+import { computed, watch, watchEffect } from 'vue'
 import useHtmlDataset from '/@/composables/document/useHtmlDataset'
 import { useThemeVariables } from '/@/composables/document/useThemeVariables'
 import { useResponsiveStore } from '/@/store/ui/responsive'
@@ -21,16 +21,6 @@ import { useBrowserSettings } from '/@/store/app/browserSettings'
 import { useTts } from '/@/store/app/tts'
 import { useThemeSettings } from '/@/store/app/themeSettings'
 import useDocumentTitle from '/@/composables/document/useDocumentTitle'
-import { isWebKit } from '/@/lib/dom/browser'
-
-const alternateContainStrict = () => {
-  document.body.style.setProperty(
-    '--contain-strict',
-    'inline-size layout paint style'
-  )
-}
-
-if (isWebKit()) alternateContainStrict()
 
 const useQallConfirmer = () => {
   window.addEventListener('beforeunload', event => {
@@ -102,11 +92,16 @@ import { useFeatureFlagSettings } from '/@/store/app/featureFlagSettings'
 
 const { featureFlags } = useFeatureFlagSettings()
 
-watchEffect(() => {
-  if (featureFlags.value.contain_strict_alternate.enabled) {
-    alternateContainStrict()
-  }
-})
+watch(
+  () => featureFlags.value.contain_strict_alternate.enabled,
+  enabled => {
+    document.body.style.setProperty(
+      '--contain-strict',
+      enabled ? 'inline-size layout paint style' : 'strict'
+    )
+  },
+  { immediate: true }
+)
 
 useTts()
 

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationListItem.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationListItem.vue
@@ -49,7 +49,7 @@ defineExpose({ focus })
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  contain: strict;
+  contain: var(--contain-strict);
   height: 1.5rem;
   line-height: 1.5rem;
 }

--- a/src/components/Main/MainView/MainViewFrame.vue
+++ b/src/components/Main/MainView/MainViewFrame.vue
@@ -35,7 +35,7 @@ $paddingSize: 16px;
   min-width: 0;
   padding: $paddingSize 0;
   transition: opacity 0.3s ease;
-  contain: strict;
+  contain: var(--contain-strict);
 }
 .body {
   height: calc(100% + #{$paddingSize * 2});

--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -279,7 +279,7 @@ useScrollRestoration(rootRef, state)
   overflow-y: scroll;
   padding: 12px 0;
   backface-visibility: hidden;
-  contain: strict;
+  contain: var(--contain-strict);
   // overflow-anchorはデフォルトでautoだが、Safariが対応していないので、
   // 手動で調節しているため明示的に無効化する
   overflow-anchor: none;

--- a/src/components/Main/MainView/MessagesScroller/MessagesScrollerSeparator.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScrollerSeparator.vue
@@ -19,7 +19,7 @@ $margin: 30px;
   width: 100%;
   height: 32px;
   padding: 4px 12px;
-  contain: strict;
+  contain: var(--contain-strict);
 }
 .title {
   display: flex;

--- a/src/components/Main/NavigationBar/NavigationContent.vue
+++ b/src/components/Main/NavigationBar/NavigationContent.vue
@@ -51,7 +51,7 @@ withDefaults(
     left: 8px;
   }
   backface-visibility: hidden;
-  contain: strict;
+  contain: var(--contain-strict);
 }
 .content {
   margin: 24px 0;

--- a/src/components/Main/StampPicker/StampPickerContainer.vue
+++ b/src/components/Main/StampPicker/StampPickerContainer.vue
@@ -60,6 +60,6 @@ const style = computed(() => {
 .positionAbsolute {
   position: fixed;
   z-index: $z-index-stamp-picker;
-  contain: strict;
+  contain: var(--contain-strict);
 }
 </style>

--- a/src/components/Modal/ModalContainer.vue
+++ b/src/components/Modal/ModalContainer.vue
@@ -127,6 +127,6 @@ const component = computed(() => {
   background-color: rgba(0, 0, 0, 0.15);
   transition: background-color 0.1s;
   z-index: $z-index-modal-container;
-  contain: strict;
+  contain: var(--contain-strict);
 }
 </style>

--- a/src/components/UI/AIcon.vue
+++ b/src/components/UI/AIcon.vue
@@ -89,6 +89,6 @@ const path = computed(() => mdiPaths[props.name])
 
 <style lang="scss" module>
 .icon {
-  contain: strict;
+  contain: var(--contain-strict);
 }
 </style>

--- a/src/lib/dom/browser.ts
+++ b/src/lib/dom/browser.ts
@@ -1,5 +1,13 @@
 export const isMac = () => navigator.platform.includes('Mac')
 
+/**
+ *  ほとんどのブラウザの UA には `applewebkit` が含まれるので
+ *  WebKit 特有の処理を用いて判定する
+ */
+export const isWebKit = () => {
+  return Date.parse('1969-12-31T23:59:59.9991Z') === 0
+}
+
 const ua = navigator.userAgent.toLowerCase()
 
 export const isSafari = () => {

--- a/src/store/app/featureFlagSettings.ts
+++ b/src/store/app/featureFlagSettings.ts
@@ -25,6 +25,14 @@ export const featureFlagDescriptions = {
     description: '「提供終了日」の表記がひらがなになります。',
     defaultValue: false,
     endAt: new Date('2025-07-31T23:59:59+09:00')
+  },
+  contain_strict_alternate: {
+    title: 'contain: strict の代替',
+    description:
+      '「contain: strict」を「contain: inline-size layout paint style」で代替します。 ' +
+      'WebKit 系ブラウザ (Safari など）でレイアウトが崩れる場合に有効にすることで不具合が解消される可能性があります。',
+    defaultValue: false,
+    endAt: new Date('9999-12-31T00:00')
   }
 } as const satisfies Record<string, FeatureFlagDescription>
 

--- a/src/store/app/featureFlagSettings.ts
+++ b/src/store/app/featureFlagSettings.ts
@@ -2,6 +2,7 @@ import { defineStore, acceptHMRUpdate } from 'pinia'
 import { computed } from 'vue'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import useIndexedDbValue from '/@/composables/utils/useIndexedDbValue'
+import { isWebKit } from '/@/lib/dom/browser'
 
 type FeatureFlagDescription = {
   title: string
@@ -31,7 +32,7 @@ export const featureFlagDescriptions = {
     description:
       '「contain: strict」を「contain: inline-size layout paint style」で代替します。 ' +
       'WebKit 系ブラウザ (Safari など）でレイアウトが崩れる場合に有効にすることで不具合が解消される可能性があります。',
-    defaultValue: false,
+    defaultValue: isWebKit(),
     endAt: new Date('9999-12-31T00:00')
   }
 } as const satisfies Record<string, FeatureFlagDescription>

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -224,7 +224,7 @@ $nav-width-ratio: math.div($nav-width-diff, $nav-width-display-width-diff);
     y: auto;
   }
   scrollbar-gutter: stable;
-  contain: strict;
+  contain: var(--contain-strict);
   z-index: $z-index-sidebar-wrapper;
 }
 .sidebarPortal {


### PR DESCRIPTION
## 概要

WebKit の場合に `contain: strict` を `contain: inline-size layout paint style` で代替します．

thanks to: https://q.trap.jp/channels/team/SysAd/random?message=01995d67-b74e-7997-b9dd-e0096849782c

## なぜこの PR を入れたいのか
feedback: https://q.trap.jp/channels/services/feedback?message=019937ac-7d04-701d-b2c2-0f06a0d182d2

## PR を出す前の確認事項
- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 疑問点
- 実験的機能ではなく別な部分に差し込んだ方が良い気もする