### PR TITLE
fix(stamp-list): 表示名に 0 幅スペース等が含まれる際にユーザ一覧のレイアウトが WebKit で崩れる問題を修正

### DIFF
--- a/src/components/Main/MainView/MessageElement/StampDetailElementContent.vue
+++ b/src/components/Main/MainView/MessageElement/StampDetailElementContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="$style.clickable" @click="openModal">
-    <span>{{ displayName }}</span>
+    <span>{{ removeInvisibleCharacters(displayName) }}</span>
     <span :class="$style.tails">
       <span v-if="count > 1" :class="$style.numberWrap">
         <SpinNumber :value="count" />
@@ -16,6 +16,7 @@ import type { UserId } from '/@/types/entity-ids'
 import { useUserModalOpener } from '/@/composables/modal/useUserModalOpener'
 import { useUsersStore } from '/@/store/entities/users'
 import SpinNumber from '/@/components/UI/SpinNumber.vue'
+import { makeInvisibleCharactersRemover } from '/@/lib/basic/string'
 
 const props = defineProps<{
   userId: UserId
@@ -27,6 +28,8 @@ const user = computed(() => usersMap.value.get(props.userId))
 const displayName = computed(() => user.value?.displayName ?? 'unknown')
 
 const { openModal } = useUserModalOpener(toRef(props, 'userId'))
+
+const removeInvisibleCharacters = makeInvisibleCharactersRemover()
 </script>
 
 <style lang="scss" module>

--- a/src/lib/basic/string.ts
+++ b/src/lib/basic/string.ts
@@ -66,3 +66,47 @@ export const replacePrefix = (
   if (!str.startsWith(searchValue)) return str
   return `${replaceValue}${str.slice(searchValue.length)}`
 }
+
+const INVISIBLE_CHARACTERS = {
+  basic: [
+    0x000b, // VERTICAL_TABULATION
+    0x200b, // ZERO_WIDTH_SPACE
+    0x2028, // LINE_SEPARATOR
+    0x2029, // PARAGRAPH_SEPARATOR
+    0x2061, // FUNCTION_APPLICATION
+    0x2062, // INVISIBLE_TIMES
+    0x2063, // INVISIBLE_SEPARATOR
+    0xfeff // ZERO_WIDTH_NO_BREAK_SPACE
+  ],
+  joiner: [
+    0x034f, // COMBINING_GRAPHEME_JOINER
+    0x200c, // ZERO_WIDTH_NON_JOINER
+    0x200d // ZERO_WIDTH_JOINER
+  ],
+  directional: [
+    0x200e, // LEFT_TO_RIGHT_MARK
+    0x200f, // RIGHT_TO_LEFT_MARK
+    0x202a, // LEFT_TO_RIGHT_EMBEDDING
+    0x202b, // RIGHT_TO_LEFT_EMBEDDING
+    0x202c, // POP_DIRECTIONAL_FORMATTING
+    0x202d, // LEFT_TO_RIGHT_OVERRIDE
+    0x202e // RIGHT_TO_LEFT_OVERRIDE
+  ]
+} as const
+
+export const makeInvisibleCharactersRemover = (
+  options: Partial<Record<keyof typeof INVISIBLE_CHARACTERS, boolean>> = {}
+) => {
+  type Keys = keyof typeof INVISIBLE_CHARACTERS
+  const defaultOptions = { basic: true }
+
+  const targets = Object.entries({ ...defaultOptions, ...options })
+    .filter(([_, value]) => value)
+    .map(([key]) => INVISIBLE_CHARACTERS[key as Keys])
+    .flat() as number[]
+
+  return (text: string) =>
+    [...text]
+      .filter(c => !targets.includes(c.codePointAt(0) as number))
+      .join('')
+}


### PR DESCRIPTION
## 概要

- 愚直に特殊文字を filter して取り除きます．
- CSS の `white-space` プロパティでは直りませんでした．

## なぜこの PR を入れたいのか

https://q.trap.jp/channels/team/SysAd/traQ/Client?message=0199718f-8c43-75bf-a120-96a3b5243b2e

## PR を出す前の確認事項
- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている (praywright)
   - できれば実機で検証したい
- [x] 自分で一度コードを眺めて自分的に問題はなさそう