### PR TITLE
fix(markdown): render 前に正しく initialFetchPromise が待機されないバグを修正

### DIFF
--- a/src/lib/markdown/markdown.ts
+++ b/src/lib/markdown/markdown.ts
@@ -53,17 +53,17 @@ const loadMd = async () => {
   md = new traQMarkdownIt(storeProvider, [], embeddingOrigin)
 }
 
-const waitForInitialFetch = async () => {
+const waitForInitialFetch = () => {
   const { usersMapInitialFetchPromise } = useUsersStore()
   const { userGroupsMapInitialFetchPromise } = useGroupsStore()
   const { bothChannelsMapInitialFetchPromise } = useChannelsStore()
   const { stampsMapInitialFetchPromise } = useStampsStore()
 
-  await Promise.all([
-    usersMapInitialFetchPromise,
-    userGroupsMapInitialFetchPromise,
-    bothChannelsMapInitialFetchPromise,
-    stampsMapInitialFetchPromise,
+  return Promise.all([
+    usersMapInitialFetchPromise.value,
+    userGroupsMapInitialFetchPromise.value,
+    bothChannelsMapInitialFetchPromise.value,
+    stampsMapInitialFetchPromise.value,
     loadMd()
   ])
 }


### PR DESCRIPTION
## 概要

- `*MapInitialFetchPromise` を await する際に `.value` が抜けていたので追加

あとでやりたい
- https://github.com/traPtitech/traQ_S-UI/issues/4848

## なぜこの PR を入れたいのか
closes: #4669

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
