### PR TITLE
fix: `MessagesScroller` のスクロール位置が正しく記録されないバグを修正

### DIFF
--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -36,7 +36,6 @@
 import { throttle } from 'throttle-debounce'
 import type { Ref } from 'vue'
 import {
-  computed,
   nextTick,
   onMounted,
   onUnmounted,
@@ -114,11 +113,12 @@ const useScrollRestoration = (
   const { lastScrollPosition } = useMainViewStore()
   const route = useRoute()
   watch(
-    computed(() => route.name),
+    () => route.name,
     async (to, from) => {
       if (isMessageScrollerRoute(from)) {
-        lastScrollPosition.value = rootRef.value?.scrollTop ?? 0
+        lastScrollPosition.value = state.scrollTop
       }
+
       if (isMessageScrollerRoute(to)) {
         state.scrollTop = lastScrollPosition.value
         await nextTick()


### PR DESCRIPTION
## 概要

- `rootRef.value.scrollTop` ではなく `state.scrollTop` を参照するようにした
  - `state.scrollTop` は `handleScroll` によってスクロールの度に値が更新される

## なぜこの PR を入れたいのか

- closes: #4600

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
