### PR TITLE
fix: featureFlag のサンプルの提供終了日を9999年に変更

### DIFF
--- a/src/store/app/featureFlagSettings.ts
+++ b/src/store/app/featureFlagSettings.ts
@@ -25,7 +25,7 @@ export const featureFlagDescriptions = {
     title: 'フラグテスト・サンプル用',
     description: '「提供終了日」の表記がひらがなになります。',
     defaultValue: false,
-    endAt: new Date('2025-07-31T23:59:59+09:00')
+    endAt: new Date('9999-12-31T00:00')
   },
   contain_strict_alternate: {
     title: 'contain: strict の代替',


### PR DESCRIPTION
## 概要
- featureFlag のサンプルの提供終了日を9999年に変更
## なぜこの PR を入れたいのか
close: #4708

## PR を出す前の確認事項

- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
