### PR TITLE
docs: Volar から現在の名称の Vue (official) に合わせる

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,7 @@ $ npm i
 $ npm run gen-fonts
 ```
 
-Vetur ではなく Volar を導入することを推奨しています。
+Vetur ではなく Vue (offical) を導入することを推奨しています。
 
 ## コマンド
 


### PR DESCRIPTION
## 概要
- development.md の 「Vetur ではなく Volar を導入することを推奨しています。」を「Vetur ではなく Vue (offical) を導入することを推奨しています。」に変更した
## なぜこの PR を入れたいのか
close: #4695

## PR を出す前の確認事項

- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
