### PR TITLE
fix(suggestion): 補完候補リストのキーボード操作および UI の改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12259,6 +12259,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/text-field-edit/-/text-field-edit-4.1.1.tgz",
       "integrity": "sha512-bgvsU5CFdBm8YuDdpLALNqS7Th8bVaRD5cww9VMYaBYab324iN3XOXvuQxTxp9JSPhHHF6zGCDEyF08JUV2hPw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPopup.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationPopup.vue
@@ -63,6 +63,7 @@ import ATab from '/@/components/UI/ATab.vue'
 import ClickOutside from '/@/components/UI/ClickOutside'
 import useBoxSize from '/@/composables/dom/useBoxSize'
 import useRelatedChannels from '/@/composables/useRelatedChannels'
+import { safeMod } from '/@/lib/basic/arithmetic'
 import type { Point } from '/@/lib/basic/point'
 import { randomString } from '/@/lib/basic/randomString'
 
@@ -117,7 +118,7 @@ const onKeydown = (e: KeyboardEvent) => {
     return
   }
 
-  nextIndex = (nextIndex + tabNames.length) % tabNames.length
+  nextIndex = safeMod(nextIndex, tabNames.length)
 
   currentTab.value = tabNames[nextIndex] ?? currentTab.value
   tabNameRefs[currentTab.value].value?.focus()

--- a/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggester.vue
+++ b/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggester.vue
@@ -33,11 +33,8 @@
 import { type ComponentPublicInstance, computed } from 'vue'
 
 import { isIOS } from '/@/lib/dom/browser'
+import type { Candidate, WordOrConfirmedPart } from '/@/lib/suggestion/basic'
 
-import type {
-  Candidate,
-  WordOrConfirmedPart
-} from '../composables/suggestion/useWordSuggester'
 import DropdownSuggesterCandidate from './DropdownSuggesterCandidate.vue'
 
 const props = withDefaults(

--- a/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggester.vue
+++ b/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggester.vue
@@ -5,12 +5,6 @@
         mousedownイベントでやっているのはclickイベントだとフォーカスが外れるため
         preventをすることでclickイベントでフォーカスが外れるのを回避している
       -->
-      <DropdownSuggesterCandidate
-        :candidate="confirmedPartCandidate"
-        :display="confirmedPart.display"
-        :is-selected="selectedIndex === -1"
-        @mousedown.prevent="select(confirmedPartCandidate)"
-      />
       <div :class="$style.scroll">
         <div
           v-for="(candidate, index) in candidates"
@@ -33,7 +27,7 @@
 import { type ComponentPublicInstance, computed } from 'vue'
 
 import { isIOS } from '/@/lib/dom/browser'
-import type { Candidate, WordOrConfirmedPart } from '/@/lib/suggestion/basic'
+import type { Candidate, Word } from '/@/lib/suggestion/basic'
 
 import DropdownSuggesterCandidate from './DropdownSuggesterCandidate.vue'
 
@@ -44,18 +38,16 @@ const props = withDefaults(
     position?: { top: number; left: number }
     candidates?: Candidate[]
     selectedIndex: number | null
-    confirmedPart?: { text: string; display?: string }
   }>(),
   {
     isShown: false,
     position: () => ({ top: 0, left: 0 }),
-    candidates: () => [],
-    confirmedPart: () => ({ text: '', display: '' })
+    candidates: () => []
   }
 )
 
 const emit = defineEmits<{
-  (e: 'select', _word: WordOrConfirmedPart): void
+  (e: 'select', _word: Word): void
 }>()
 
 const MARGIN = 8
@@ -72,14 +64,7 @@ const styledPosition = computed(() => ({
   width: `${props.width}px`
 }))
 
-const confirmedPartCandidate = computed(
-  (): WordOrConfirmedPart => ({
-    type: 'confirmed-part',
-    text: props.confirmedPart.text
-  })
-)
-
-const select = (word: WordOrConfirmedPart) => {
+const select = (word: Word) => {
   emit('select', word)
 }
 
@@ -107,6 +92,5 @@ const scrollToSelectedCandidate = (
 .scroll {
   overflow-y: scroll;
   max-height: 32px * 4.5;
-  border-top: 2px solid $theme-background-secondary-border;
 }
 </style>

--- a/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggesterCandidate.vue
+++ b/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggesterCandidate.vue
@@ -21,8 +21,8 @@
 
 <script lang="ts" setup>
 import AStamp from '/@/components/UI/AStamp.vue'
+import type { WordOrConfirmedPart } from '/@/lib/suggestion/basic'
 
-import type { WordOrConfirmedPart } from '../composables/suggestion/useWordSuggester'
 import DropdownSuggesterStampEffect from './DropdownSuggesterStampEffect.vue'
 import DropdownSuggesterUserIcon from './DropdownSuggesterUserIcon.vue'
 

--- a/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggesterCandidate.vue
+++ b/src/components/Main/MainView/MessageInput/DropdownSuggester/DropdownSuggesterCandidate.vue
@@ -21,14 +21,14 @@
 
 <script lang="ts" setup>
 import AStamp from '/@/components/UI/AStamp.vue'
-import type { WordOrConfirmedPart } from '/@/lib/suggestion/basic'
+import type { Word } from '/@/lib/suggestion/basic'
 
 import DropdownSuggesterStampEffect from './DropdownSuggesterStampEffect.vue'
 import DropdownSuggesterUserIcon from './DropdownSuggesterUserIcon.vue'
 
 withDefaults(
   defineProps<{
-    candidate: WordOrConfirmedPart
+    candidate: Word
     display?: string
     isSelected?: boolean
   }>(),

--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -30,7 +30,6 @@
       :position="suggesterPosition"
       :candidates="suggestedCandidates"
       :selected-index="selectedIndex"
-      :confirmed-part="confirmedPart"
       @select="onSelect"
     />
   </div>
@@ -111,7 +110,6 @@ const {
   position,
   suggestedCandidates,
   selectedIndex,
-  confirmedPart,
   onSelect
 } = useSuggester(textareaRef)
 

--- a/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputTextArea.vue
@@ -29,7 +29,7 @@
       :width="suggesterWidth"
       :position="suggesterPosition"
       :candidates="suggestedCandidates"
-      :selected-index="selectedCandidateIndex"
+      :selected-index="selectedIndex"
       :confirmed-part="confirmedPart"
       @select="onSelect"
     />
@@ -110,10 +110,10 @@ const {
   suggesterWidth,
   position,
   suggestedCandidates,
-  selectedCandidateIndex,
+  selectedIndex,
   confirmedPart,
   onSelect
-} = useSuggester(textareaRef, modelValue)
+} = useSuggester(textareaRef)
 
 const {
   onBeforeInput,

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/channelSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/channelSuggestion.ts
@@ -1,25 +1,25 @@
 import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
-import type { Candidate, ConfirmedPart } from '/@/lib/suggestion/basic'
+import type { Candidate } from '/@/lib/suggestion/basic'
 
 const CHANNEL_PATH_TRIMMING_REGEXP = /^#|\/$/
 
 const channelSuggestionOverride = <
   Params extends {
     suggesterWidth: MaybeRefOrGetter<number>
-    confirmedPart: MaybeRefOrGetter<ConfirmedPart>
+    confirmedPart: MaybeRefOrGetter<string>
     suggestedCandidates: MaybeRefOrGetter<Candidate[]>
   }
 >(
   input: Params
 ) => {
   const isChannelSuggestion = computed(() =>
-    toValue(input.confirmedPart).text.startsWith('#')
+    toValue(input.confirmedPart).startsWith('#')
   )
 
   const confirmedChannelPath = computed(() => {
     return toValue(input.confirmedPart)
-      .text.replace(CHANNEL_PATH_TRIMMING_REGEXP, '')
+      .replace(CHANNEL_PATH_TRIMMING_REGEXP, '')
       .split('/')
   })
 
@@ -47,27 +47,10 @@ const channelSuggestionOverride = <
     })
   })
 
-  const confirmedPartDisplay = computed(() => {
-    const confirmedPath = [
-      confirmedChannelShortenedPathString.value,
-      confirmedChannelPath.value.at(-1)
-    ]
-      .filter(Boolean)
-      .join('/')
-
-    return `#${confirmedPath}`
-  })
-
-  const confirmedPart = computed(() => ({
-    ...toValue(input.confirmedPart),
-    display: confirmedPartDisplay.value
-  }))
-
   return {
     condition: isChannelSuggestion,
     overrides: {
       suggesterWidth: 360,
-      confirmedPart,
       suggestedCandidates
     }
   }

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/channelSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/channelSuggestion.ts
@@ -1,6 +1,6 @@
 import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
-import type { Candidate, ConfirmedPart } from '../useWordSuggester'
+import type { Candidate, ConfirmedPart } from '/@/lib/suggestion/basic'
 
 const CHANNEL_PATH_TRIMMING_REGEXP = /^#|\/$/
 

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
@@ -1,14 +1,13 @@
 import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
-import { useStampHistory } from '/@/store/domain/stampHistory'
-import { useStampRecommendations } from '/@/store/domain/stampRecommendations'
-
 import type {
   Candidate,
   ConfirmedPart,
-  WordOrConfirmedPart
-} from '../useWordSuggester'
-import type { WordWithId } from '../useWordSuggestionList'
+  WordOrConfirmedPart,
+  WordWithId
+} from '/@/lib/suggestion/basic'
+import { useStampHistory } from '/@/store/domain/stampHistory'
+import { useStampRecommendations } from '/@/store/domain/stampRecommendations'
 
 const stampSuggestionOverride = <
   Params extends {

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
@@ -1,18 +1,13 @@
 import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
-import type {
-  Candidate,
-  ConfirmedPart,
-  WordOrConfirmedPart,
-  WordWithId
-} from '/@/lib/suggestion/basic'
+import type { Candidate, Word, WordWithId } from '/@/lib/suggestion/basic'
 import { useStampHistory } from '/@/store/domain/stampHistory'
 import { useStampRecommendations } from '/@/store/domain/stampRecommendations'
 
 const stampSuggestionOverride = <
   Params extends {
-    onSelect: (word: WordOrConfirmedPart) => void
-    confirmedPart: MaybeRefOrGetter<ConfirmedPart>
+    onSelect: (word: Word) => void
+    confirmedPart: MaybeRefOrGetter<string>
     suggestedCandidates: MaybeRefOrGetter<Candidate[]>
   }
 >(
@@ -22,7 +17,7 @@ const stampSuggestionOverride = <
   const { recordStampUsage } = useStampRecommendations()
 
   const isStampSuggestion = computed(() =>
-    toValue(input.confirmedPart).text.startsWith(':')
+    toValue(input.confirmedPart).startsWith(':')
   )
 
   const suggestedCandidates = computed(() => {

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
@@ -3,7 +3,7 @@ import { computed, ref, toValue, watch } from 'vue'
 
 import useInsertText from '/@/composables/dom/useInsertText'
 import getCaretPosition from '/@/lib/dom/caretPosition'
-import type { Target, WordOrConfirmedPart } from '/@/lib/suggestion/basic'
+import type { Target, Word } from '/@/lib/suggestion/basic'
 import {
   getCurrentWord,
   getNextCandidateIndex,
@@ -11,7 +11,12 @@ import {
   getSelectedCandidateIndex
 } from '/@/lib/suggestion/basic'
 
-import useWordSuggesterList from './useWordSuggestionList'
+import useWordSuggestionList from './useWordSuggestionList'
+
+export interface Candidate {
+  word: Word
+  display?: string
+}
 
 /**
  * 補完を表示する最小の文字数
@@ -44,7 +49,7 @@ const useWordSuggester = (
    */
   const currentInputWord = ref('')
 
-  const { suggestedCandidateWords, confirmedText } = useWordSuggesterList(
+  const { suggestedCandidateWords, confirmedText } = useWordSuggestionList(
     () => target.value.word,
     MIN_LENGTH
   )
@@ -155,7 +160,7 @@ const useWordSuggester = (
     }
   }
 
-  const onSelect = (word: WordOrConfirmedPart) => {
+  const onSelect = (word: Word) => {
     insertText(word.text)
     isSuggesterShown.value = false
   }
@@ -168,9 +173,7 @@ const useWordSuggester = (
     return suggestedCandidateWords.value.map(word => ({ word }))
   })
 
-  const confirmedPart = computed(() => ({
-    text: confirmedText.value
-  }))
+  const confirmedPart = confirmedText
 
   return {
     onKeyDown,

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
@@ -1,30 +1,17 @@
-import type { ComputedRef, Ref } from 'vue'
-import { computed, ref, watch } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, ref, toValue, watch } from 'vue'
 
 import useInsertText from '/@/composables/dom/useInsertText'
 import getCaretPosition from '/@/lib/dom/caretPosition'
-import type { Target } from '/@/lib/suggestion/basic'
-import { getCurrentWord } from '/@/lib/suggestion/basic'
+import type { Target, WordOrConfirmedPart } from '/@/lib/suggestion/basic'
+import {
+  getCurrentWord,
+  getNextCandidateIndex,
+  getPrevCandidateIndex,
+  getSelectedCandidateIndex
+} from '/@/lib/suggestion/basic'
 
-import type { Word } from './useWordSuggestionList'
 import useWordSuggesterList from './useWordSuggestionList'
-
-export type WordOrConfirmedPart =
-  | Word
-  | {
-      type: 'confirmed-part'
-      text: string
-    }
-
-export interface Candidate {
-  word: Word
-  display?: string
-}
-
-export interface ConfirmedPart {
-  text: string
-  display?: string
-}
 
 /**
  * 補完を表示する最小の文字数
@@ -33,51 +20,79 @@ export interface ConfirmedPart {
 const MIN_LENGTH = 3
 
 const useWordSuggester = (
-  textareaRef: ComputedRef<HTMLTextAreaElement | undefined>,
-  value: Ref<string>
+  textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>
 ) => {
   const isSuggesterShown = ref(false)
+
   const target = ref<Target>({
     word: '',
     begin: 0,
     end: 0
   })
+
+  /**
+   * nullのときは未選択
+   * -1のときは確定部分が選択されている
+   * 0～のときは候補が選択されている
+   */
+  const selectedIndex = ref<number | null>(null)
+
   /**
    * targetは補完をしたときに更新されないがこれは更新する
    * これはtargetを更新すると候補リストが変わってしまうため
    * (補完をしたときは候補リストを変化させたくない)
    */
   const currentInputWord = ref('')
+
+  const { suggestedCandidateWords, confirmedText } = useWordSuggesterList(
+    () => target.value.word,
+    MIN_LENGTH
+  )
+
   watch(
     () => target.value.word,
     word => {
       currentInputWord.value = word
+
+      selectedIndex.value = getSelectedCandidateIndex(
+        suggestedCandidateWords.value,
+        confirmedText.value,
+        word
+      )
+    },
+    {
+      immediate: true
     }
   )
 
+  const { insertText } = useInsertText(textareaRef, target)
+
   const position = computed(() => {
-    if (!textareaRef.value) return { top: 0, left: 0 }
-    return getCaretPosition(textareaRef.value, target.value.begin)
+    const textarea = toValue(textareaRef)
+    if (!textarea) return { top: 0, left: 0 }
+    return getCaretPosition(textarea, target.value.begin)
   })
 
-  const {
-    suggestedCandidateWords,
-    confirmedText,
-    selectedCandidateIndex,
-    prevCandidateText,
-    nextCandidateText
-  } = useWordSuggesterList(target, currentInputWord, MIN_LENGTH)
+  const getCandidateTextFromIndex = (i: number) => {
+    if (i === -1) return confirmedText.value
+    return suggestedCandidateWords.value[i]?.text ?? ''
+  }
 
-  const { insertText } = useInsertText(textareaRef, target)
-  const insertTextAndMoveTarget = (text: string) => {
+  const insertTextAndMoveTarget = (index: number) => {
+    selectedIndex.value = index
+    const text = getCandidateTextFromIndex(index)
+
     insertText(text)
     target.value.end = target.value.begin + text.length
     currentInputWord.value = text
   }
 
   const updateTarget = () => {
-    if (!textareaRef.value) return
-    target.value = getCurrentWord(textareaRef.value, value.value)
+    const textarea = toValue(textareaRef)
+    if (!textarea) return
+
+    target.value = getCurrentWord(textarea)
+
     if (target.value.word.length < MIN_LENGTH) {
       isSuggesterShown.value = false
       return
@@ -90,6 +105,16 @@ const useWordSuggester = (
     if (e.isComposing) return
     if (!isSuggesterShown.value) return
 
+    const prevIndex = getPrevCandidateIndex(
+      suggestedCandidateWords.value.length,
+      selectedIndex.value
+    )
+
+    const nextIndex = getNextCandidateIndex(
+      suggestedCandidateWords.value.length,
+      selectedIndex.value
+    )
+
     // Tabによるフォーカスの移動を防止するため、長押しで連続移動できるようにするためにkeyDownで行う必要がある
     if (e.key === 'Tab') {
       e.preventDefault()
@@ -100,24 +125,25 @@ const useWordSuggester = (
 
       // 未選択状態では確定部分が補完される
       if (e.shiftKey) {
-        insertTextAndMoveTarget(prevCandidateText.value)
+        insertTextAndMoveTarget(prevIndex)
       } else {
-        insertTextAndMoveTarget(nextCandidateText.value)
+        insertTextAndMoveTarget(nextIndex)
       }
       return
     }
 
     if (e.key === 'ArrowUp') {
       e.preventDefault()
-      insertTextAndMoveTarget(prevCandidateText.value)
+      insertTextAndMoveTarget(prevIndex)
       return
     }
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      insertTextAndMoveTarget(nextCandidateText.value)
+      insertTextAndMoveTarget(nextIndex)
       return
     }
   }
+
   const onKeyUp = (e: KeyboardEvent) => {
     if (e.key === 'Tab' || e.key === 'ArrowUp' || e.key === 'ArrowDown') return
     // 文字入力後の状態をとるためkeyUpで行う必要がある
@@ -155,7 +181,7 @@ const useWordSuggester = (
     suggesterWidth: 240,
     position,
     suggestedCandidates,
-    selectedCandidateIndex,
+    selectedIndex,
     confirmedPart
   }
 }

--- a/src/components/Main/NavigationBar/ChannelList/ChannelListSelector.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelListSelector.vue
@@ -29,6 +29,7 @@
 import { type Ref, ref } from 'vue'
 
 import ATab from '/@/components/UI/ATab.vue'
+import { safeMod } from '/@/lib/basic/arithmetic'
 
 const isStarred = defineModel<boolean>('isStarred', {
   required: true
@@ -63,7 +64,7 @@ const onKeydown = (e: KeyboardEvent) => {
     return
   }
 
-  nextIndex = (nextIndex + tabNames.length) % tabNames.length
+  nextIndex = safeMod(nextIndex, tabNames.length)
 
   const nextTabName = tabNames[nextIndex] ?? tabNames[index]
   isStarred.value = tabNames[nextIndex] === 'stared'

--- a/src/components/Settings/StampTab/StampManagement.vue
+++ b/src/components/Settings/StampTab/StampManagement.vue
@@ -63,6 +63,7 @@ import { UserPermission } from '@traptitech/traq'
 import { type Ref, computed, ref } from 'vue'
 
 import ATab from '/@/components/UI/ATab.vue'
+import { safeMod } from '/@/lib/basic/arithmetic'
 import { randomString } from '/@/lib/basic/randomString'
 import { compareString } from '/@/lib/basic/string'
 import { useMeStore } from '/@/store/domain/me'
@@ -120,7 +121,7 @@ const onKeydown = (e: KeyboardEvent) => {
     return
   }
 
-  nextIndex = (nextIndex + tabNames.length) % tabNames.length
+  nextIndex = safeMod(nextIndex, tabNames.length)
 
   currentTab.value = tabNames[nextIndex] ?? currentTab.value
   tabNameRefs[currentTab.value].value?.focus()

--- a/src/composables/dom/useInsertText.ts
+++ b/src/composables/dom/useInsertText.ts
@@ -2,9 +2,6 @@ import { type MaybeRefOrGetter, type Ref, toValue } from 'vue'
 
 import { insert } from 'text-field-edit'
 
-/**
- * これを利用したときはCtrl+Zなどがきく
- */
 const useInsertText = (
   textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>,
   target?: Ref<{ begin: number; end: number }>

--- a/src/lib/basic/arithmetic.ts
+++ b/src/lib/basic/arithmetic.ts
@@ -1,0 +1,7 @@
+export function safeMod(x: number, r: number): number
+export function safeMod(x: bigint, r: bigint): bigint
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function safeMod(x: any, r: any): any {
+  return ((x % r) + r) % r
+}

--- a/src/lib/suggestion/basic.ts
+++ b/src/lib/suggestion/basic.ts
@@ -1,26 +1,61 @@
 import { lastIndexOf } from '/@/lib/basic/string'
 
+interface WordBase {
+  delimiter?: string
+  text: string
+}
+
+export interface WordWithId extends WordBase {
+  type: 'user' | 'user-group' | 'stamp' | 'channel'
+  id: string
+}
+
+export interface WordWithoutId extends WordBase {
+  type: 'stamp-effect'
+}
+
+export type Word = WordWithId | WordWithoutId
+
+export type WordOrConfirmedPart =
+  | Word
+  | {
+      type: 'confirmed-part'
+      text: string
+    }
+
+export interface Candidate {
+  word: Word
+  display?: string
+}
+
+export interface ConfirmedPart {
+  text: string
+  display?: string
+}
+
 export type Target = {
   word: string
   begin: number
   end: number
 }
 
-export const getCurrentWord = (
-  elm: { selectionStart: number; selectionEnd: number },
-  text: string
-): Target => {
-  const startIndex = elm.selectionStart
-  const nearest = lastIndexOf(text, ['@', ':', '.', '#'], startIndex - 1)
-  const prevSpaceIndex = lastIndexOf(text, [' ', '　'], startIndex - 1)
+export const getCurrentWord = ({
+  value: text,
+  selectionStart,
+  selectionEnd
+}: Pick<
+  HTMLTextAreaElement,
+  'value' | 'selectionStart' | 'selectionEnd'
+>): Target => {
+  const nearest = lastIndexOf(text, ['@', ':', '.', '#'], selectionStart - 1)
+  const prevSpaceIndex = lastIndexOf(text, [' ', '　'], selectionStart - 1)
   if (prevSpaceIndex > nearest) {
     return { word: '', begin: 0, end: 0 }
   }
 
   const begin = Math.max(nearest, 0)
-  const end = elm.selectionEnd
-  const word = text.slice(begin, end)
-  return { word, begin, end }
+  const word = text.slice(begin, selectionEnd)
+  return { word, begin, end: selectionEnd }
 }
 
 export const getDeterminedCharacters = (_candidates: string[]) => {
@@ -51,38 +86,41 @@ export const getDeterminedCharacters = (_candidates: string[]) => {
   return confirmedPart.join('')
 }
 
+export const getSelectedCandidateIndex = (
+  list: readonly Word[],
+  confirmed: string,
+  word: string | null
+) => {
+  const index = list.findIndex(c => c.text === word)
+  if (index >= 0) return index
+  if (confirmed === word) return -1
+  return null
+}
+
 export const getPrevCandidateIndex = (
-  list: readonly unknown[],
+  length: number,
   selectedIndex: number | null
 ) => {
   if (selectedIndex === null) {
     // 候補が一件のときは確定部分ではなく候補のほうを返す
-    // こうすると大文字小文字が元のものになる
-    if (list.length === 1) {
-      return 0
-    }
+    // 候補にはアイコンやスタンプが表示されている
+    if (length === 1) return 0
     return -1
   }
-  if (selectedIndex <= -1) {
-    return list.length - 1
-  }
+  if (selectedIndex < 0) return length - 1
   return selectedIndex - 1
 }
 
 export const getNextCandidateIndex = (
-  list: readonly unknown[],
+  length: number,
   selectedIndex: number | null
 ) => {
   if (selectedIndex === null) {
     // 候補が一件のときは確定部分ではなく候補のほうを返す
-    // こうすると大文字小文字が元のものになる
-    if (list.length === 1) {
-      return 0
-    }
+    // 候補にはアイコンやスタンプが表示されている
+    if (length === 1) return 0
     return -1
   }
-  if (selectedIndex >= list.length - 1) {
-    return -1
-  }
+  if (selectedIndex >= length - 1) return -1
   return selectedIndex + 1
 }

--- a/src/lib/suggestion/basic.ts
+++ b/src/lib/suggestion/basic.ts
@@ -1,3 +1,4 @@
+import { safeMod } from '/@/lib/basic/arithmetic'
 import { lastIndexOf } from '/@/lib/basic/string'
 
 interface WordBase {
@@ -107,8 +108,8 @@ export const getPrevCandidateIndex = (
     if (length === 1) return 0
     return -1
   }
-  if (selectedIndex < 0) return length - 1
-  return selectedIndex - 1
+
+  return safeMod(Math.max(0, selectedIndex) - 1, length)
 }
 
 export const getNextCandidateIndex = (
@@ -121,6 +122,6 @@ export const getNextCandidateIndex = (
     if (length === 1) return 0
     return -1
   }
-  if (selectedIndex >= length - 1) return -1
-  return selectedIndex + 1
+
+  return safeMod(selectedIndex + 1, length)
 }

--- a/tests/unit/composables/suggestions/useSuggester.spec.ts
+++ b/tests/unit/composables/suggestions/useSuggester.spec.ts
@@ -6,8 +6,6 @@ import {
   type UserGroup
 } from '@traptitech/traq'
 
-import { computed, ref } from 'vue'
-
 import { createTestingPinia } from '@pinia/testing'
 
 import useSuggesterWithoutSetup from '/@/components/Main/MainView/MessageInput/composables/suggestion/useSuggester'
@@ -61,14 +59,11 @@ describe('useSuggester', () => {
 
   test('stamps', async () => {
     const $textarea = document.createElement('textarea')
-    const textarea = computed(() => $textarea)
-    const text = ref('')
+    const [{ suggestedCandidates, onKeyUp }] = useSuggester($textarea)
 
-    const [{ suggestedCandidates, onKeyUp }] = useSuggester(textarea, text)
-
-    text.value = $textarea.textContent = 'prev :gM'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    $textarea.value = 'prev :gM'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -82,9 +77,9 @@ describe('useSuggester', () => {
       }
     ])
 
-    text.value = $textarea.textContent = 'prev :Cg'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    $textarea.value = 'prev :Cg'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -101,14 +96,11 @@ describe('useSuggester', () => {
 
   test('groups and users', async () => {
     const $textarea = document.createElement('textarea')
-    const textarea = computed(() => $textarea)
-    const text = ref('')
+    const [{ suggestedCandidates, onKeyUp }] = useSuggester($textarea)
 
-    const [{ suggestedCandidates, onKeyUp }] = useSuggester(textarea, text)
-
-    text.value = $textarea.textContent = 'prev @gM'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    $textarea.value = 'prev @gM'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -116,9 +108,9 @@ describe('useSuggester', () => {
       { word: { type: 'user-group', text: '@Gm5G9atrDx', id: 'Gm5G9atrDx' } }
     ])
 
-    text.value = $textarea.textContent = 'prev @Cg'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    $textarea.value = 'prev @Cg'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -129,14 +121,17 @@ describe('useSuggester', () => {
 
   test('channels', async () => {
     const $textarea = document.createElement('textarea')
-    const textarea = computed(() => $textarea)
-    const text = ref('')
+    // jsdom では要素が DOM に追加されていないと focus() が正しく動作しない．
+    // text-field-edit は execCommand を呼び出す前に focus() を呼び出すため，
+    // textarea を DOM に追加する必要がある
+    document.body.appendChild($textarea)
 
-    const [{ suggestedCandidates, onKeyUp }] = useSuggester(textarea, text)
+    const [{ suggestedCandidates, onKeyUp, onKeyDown }] =
+      useSuggester($textarea)
 
-    text.value = $textarea.textContent = 'prev #gp'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    $textarea.value = 'prev #gp'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -151,9 +146,14 @@ describe('useSuggester', () => {
       }
     ])
 
-    text.value = $textarea.textContent = 'prev #gps/ti'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    onKeyDown(new KeyboardEvent('keydown', { key: 'Tab' }))
+    onKeyUp(new KeyboardEvent('keyup', { key: 'Tab' }))
+
+    expect($textarea.value).toEqual('prev #gps')
+
+    $textarea.value = 'prev #gps/ti'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -177,9 +177,9 @@ describe('useSuggester', () => {
       }
     ])
 
-    text.value = $textarea.textContent = 'prev #gps/times/'
-    $textarea.selectionStart = $textarea.textContent.length
-    $textarea.selectionEnd = $textarea.textContent.length + 1
+    $textarea.value = 'prev #gps/times/'
+    $textarea.selectionStart = $textarea.value.length
+    $textarea.selectionEnd = $textarea.value.length
     onKeyUp(new KeyboardEvent('keyup'))
 
     expect(suggestedCandidates.value).toStrictEqualArrayIgnoringOrder([
@@ -229,6 +229,14 @@ describe('useSuggester', () => {
         display: '#g/t/user1'
       }
     ])
+
+    onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+    onKeyUp(new KeyboardEvent('keyup', { key: 'ArrowDown' }))
+
+    onKeyDown(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+    onKeyUp(new KeyboardEvent('keyup', { key: 'ArrowDown' }))
+
+    expect($textarea.value).toEqual('prev #gps/times/ParentLongNameMayBeCut')
   })
 })
 

--- a/tests/unit/lib/basic/arithmetic.spec.ts
+++ b/tests/unit/lib/basic/arithmetic.spec.ts
@@ -1,0 +1,107 @@
+import { safeMod } from '/@/lib/basic/arithmetic'
+
+describe('safeMod', () => {
+  describe('number', () => {
+    describe('positive dividend', () => {
+      it('can calculate basic mod', () => {
+        expect(safeMod(7, 3)).toBe(1)
+      })
+      it('can calculate when dividend is less than divisor', () => {
+        expect(safeMod(2, 5)).toBe(2)
+      })
+      it('can calculate when dividend equals divisor', () => {
+        expect(safeMod(5, 5)).toBe(0)
+      })
+      it('can calculate when dividend is multiple of divisor', () => {
+        expect(safeMod(10, 5)).toBe(0)
+      })
+      it('can calculate with large numbers', () => {
+        expect(safeMod(1000000007, 1000000)).toBe(7)
+      })
+    })
+
+    describe('zero dividend', () => {
+      it('returns zero', () => {
+        expect(safeMod(0, 5)).toBe(0)
+      })
+      it('returns zero for any positive divisor', () => {
+        expect(safeMod(0, 1)).toBe(0)
+        expect(safeMod(0, 100)).toBe(0)
+      })
+    })
+
+    describe('negative dividend', () => {
+      it('can calculate simple negative mod', () => {
+        expect(safeMod(-1, 5)).toBe(4)
+      })
+      it('can calculate negative mod with larger absolute value', () => {
+        expect(safeMod(-7, 3)).toBe(2)
+      })
+      it('can calculate when absolute value equals divisor', () => {
+        expect(safeMod(-5, 5)).toBe(0)
+      })
+      it('can calculate when absolute value is multiple of divisor', () => {
+        expect(safeMod(-10, 5)).toBe(0)
+      })
+      it('can calculate with various negative values', () => {
+        expect(safeMod(-2, 5)).toBe(3)
+        expect(safeMod(-3, 5)).toBe(2)
+        expect(safeMod(-4, 5)).toBe(1)
+      })
+    })
+
+    describe('decimal numbers', () => {
+      it('can handle decimal dividend', () => {
+        expect(safeMod(7.5, 3)).toBeCloseTo(1.5)
+      })
+      it('can handle negative decimal dividend', () => {
+        expect(safeMod(-1.5, 5)).toBeCloseTo(3.5)
+      })
+    })
+  })
+
+  describe('bigint', () => {
+    describe('positive dividend', () => {
+      it('can calculate basic mod', () => {
+        expect(safeMod(7n, 3n)).toBe(1n)
+      })
+      it('can calculate when dividend is less than divisor', () => {
+        expect(safeMod(2n, 5n)).toBe(2n)
+      })
+      it('can calculate when dividend equals divisor', () => {
+        expect(safeMod(5n, 5n)).toBe(0n)
+      })
+      it('can calculate with very large numbers', () => {
+        expect(safeMod(10000000000000000007n, 1000000000000000000n)).toBe(7n)
+      })
+    })
+
+    describe('zero dividend', () => {
+      it('returns zero', () => {
+        expect(safeMod(0n, 5n)).toBe(0n)
+      })
+    })
+
+    describe('negative dividend', () => {
+      it('can calculate simple negative mod', () => {
+        expect(safeMod(-1n, 5n)).toBe(4n)
+      })
+      it('can calculate negative mod with larger absolute value', () => {
+        expect(safeMod(-7n, 3n)).toBe(2n)
+      })
+      it('can calculate when absolute value equals divisor', () => {
+        expect(safeMod(-5n, 5n)).toBe(0n)
+      })
+      it('can calculate with various negative values', () => {
+        expect(safeMod(-2n, 5n)).toBe(3n)
+        expect(safeMod(-3n, 5n)).toBe(2n)
+        expect(safeMod(-4n, 5n)).toBe(1n)
+      })
+      it('can handle very large negative numbers', () => {
+        expect(safeMod(-10000000000000000007n, 1000000000000000000n)).toBe(
+          999999999999999993n
+        )
+      })
+    })
+  })
+})

--- a/tests/unit/lib/suggestion.spec.ts
+++ b/tests/unit/lib/suggestion.spec.ts
@@ -122,7 +122,7 @@ describe('suggestion', () => {
     })
     it('can get prev of 0', () => {
       const actual = getPrevCandidateIndex(list.length, 0)
-      expect(actual).toEqual(-1)
+      expect(actual).toEqual(3)
     })
     it('can get prev of 2', () => {
       const actual = getPrevCandidateIndex(list.length, 2)
@@ -144,7 +144,7 @@ describe('suggestion', () => {
     })
     it('can get next of 3', () => {
       const actual = getNextCandidateIndex(list.length, 3)
-      expect(actual).toEqual(-1)
+      expect(actual).toEqual(0)
     })
     it('can get next of 2', () => {
       const actual = getNextCandidateIndex(list.length, 2)

--- a/tests/unit/lib/suggestion.spec.ts
+++ b/tests/unit/lib/suggestion.spec.ts
@@ -9,10 +9,11 @@ import {
 describe('suggestion', () => {
   describe('getCurrentWord', () => {
     it('can get', () => {
-      const actual = getCurrentWord(
-        { selectionStart: 3, selectionEnd: 3 },
-        '@te'
-      )
+      const actual = getCurrentWord({
+        value: '@te',
+        selectionStart: 3,
+        selectionEnd: 3
+      })
       const expected: Target = {
         word: '@te',
         begin: 0,
@@ -21,10 +22,11 @@ describe('suggestion', () => {
       expect(actual).toEqual(expected)
     })
     it('can detect @', () => {
-      const actual = getCurrentWord(
-        { selectionStart: 18, selectionEnd: 18 },
-        'i really like@test'
-      )
+      const actual = getCurrentWord({
+        value: 'i really like@test',
+        selectionStart: 18,
+        selectionEnd: 18
+      })
       const expected: Target = {
         word: '@test',
         begin: 13,
@@ -33,10 +35,11 @@ describe('suggestion', () => {
       expect(actual).toEqual(expected)
     })
     it('can detect :', () => {
-      const actual = getCurrentWord(
-        { selectionStart: 12, selectionEnd: 12 },
-        'this: is :test'
-      )
+      const actual = getCurrentWord({
+        value: 'this: is :test',
+        selectionStart: 12,
+        selectionEnd: 12
+      })
       const expected: Target = {
         word: ':te',
         begin: 9,
@@ -45,10 +48,11 @@ describe('suggestion', () => {
       expect(actual).toEqual(expected)
     })
     it('can detect .', () => {
-      const actual = getCurrentWord(
-        { selectionStart: 8, selectionEnd: 8 },
-        'test.example.com'
-      )
+      const actual = getCurrentWord({
+        value: 'test.example.com',
+        selectionStart: 8,
+        selectionEnd: 8
+      })
       const expected: Target = {
         word: '.exa',
         begin: 4,
@@ -57,10 +61,11 @@ describe('suggestion', () => {
       expect(actual).toEqual(expected)
     })
     it('can tell if divided', () => {
-      const actual = getCurrentWord(
-        { selectionStart: 11, selectionEnd: 11 },
-        'this @is test sentence.'
-      )
+      const actual = getCurrentWord({
+        value: 'this @is test sentence.',
+        selectionStart: 11,
+        selectionEnd: 11
+      })
       const expected: Target = {
         word: '',
         begin: 0,
@@ -104,45 +109,45 @@ describe('suggestion', () => {
   const oneElementList = [0]
   describe('getPrevCandidateIndex', () => {
     it('can get prev of null', () => {
-      const actual = getPrevCandidateIndex(list, null)
+      const actual = getPrevCandidateIndex(list.length, null)
       expect(actual).toEqual(-1)
     })
     it('can get prev of null when list has only one element', () => {
-      const actual = getPrevCandidateIndex(oneElementList, null)
+      const actual = getPrevCandidateIndex(oneElementList.length, null)
       expect(actual).toBe(0)
     })
     it('can get prev of -1', () => {
-      const actual = getPrevCandidateIndex(list, -1)
+      const actual = getPrevCandidateIndex(list.length, -1)
       expect(actual).toBe(3)
     })
     it('can get prev of 0', () => {
-      const actual = getPrevCandidateIndex(list, 0)
+      const actual = getPrevCandidateIndex(list.length, 0)
       expect(actual).toEqual(-1)
     })
     it('can get prev of 2', () => {
-      const actual = getPrevCandidateIndex(list, 2)
+      const actual = getPrevCandidateIndex(list.length, 2)
       expect(actual).toBe(1)
     })
   })
   describe('getNextCandidateIndex', () => {
     it('can get next of null', () => {
-      const actual = getNextCandidateIndex(list, null)
+      const actual = getNextCandidateIndex(list.length, null)
       expect(actual).toEqual(-1)
     })
     it('can get next of null when list has only one element', () => {
-      const actual = getNextCandidateIndex(oneElementList, null)
+      const actual = getNextCandidateIndex(oneElementList.length, null)
       expect(actual).toBe(0)
     })
     it('can get next of -1', () => {
-      const actual = getNextCandidateIndex(list, -1)
+      const actual = getNextCandidateIndex(list.length, -1)
       expect(actual).toBe(0)
     })
     it('can get next of 3', () => {
-      const actual = getNextCandidateIndex(list, 3)
+      const actual = getNextCandidateIndex(list.length, 3)
       expect(actual).toEqual(-1)
     })
     it('can get next of 2', () => {
-      const actual = getNextCandidateIndex(list, 2)
+      const actual = getNextCandidateIndex(list.length, 2)
       expect(actual).toBe(3)
     })
   })

--- a/tests/unit/mocks/execCommand.ts
+++ b/tests/unit/mocks/execCommand.ts
@@ -1,0 +1,20 @@
+document.execCommand = (
+  command: string,
+  _showUI?: boolean,
+  value?: string
+): boolean => {
+  if (command === 'insertText' && document.activeElement) {
+    const el = document.activeElement as HTMLTextAreaElement | HTMLInputElement
+    if ('setRangeText' in el) {
+      el.setRangeText(
+        value ?? '',
+        el.selectionStart ?? 0,
+        el.selectionEnd ?? 0,
+        'end'
+      )
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      return true
+    }
+  }
+  return false
+}

--- a/tests/unit/mocks/index.ts
+++ b/tests/unit/mocks/index.ts
@@ -1,0 +1,1 @@
+import './execCommand'

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,3 +1,5 @@
+import './mocks'
+
 window.traQConfig = {
   firebase: {
     apiKey: '',


### PR DESCRIPTION
## 概要

既存の実装がかなり複雑だったので 1 commit あたりの差分が大きくなってしまいました．すみません．

- feat: Confirmed Part の表示を消す
- fix: 候補リストに同じ文字列が含まれる場合にキーボードによる候補の移動がおかしくなる問題を修正
  - fix & refactor: 選択候補の管理をテキストベースから index ベースに変更
    - これにより，候補リストに同じ文字列が含まれていても正しく操作できるようになった
  - refactor: `useWordSuggestionList` の役割を，候補リストの提供のみに限定
  - refactor: types の定義を `/@/lib/suggestion/base.ts` にまとめる
  - refactor: 引数の型をより汎用的にする
  - refactor: 命名や空白や宣言順序の軽微な改善


## なぜこの PR を入れたいのか
closes: #4105

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
