### PR TITLE
feat(search): DM 内メッセージ検索

### DIFF
--- a/src/composables/searchMessage/useQueryParser.ts
+++ b/src/composables/searchMessage/useQueryParser.ts
@@ -5,7 +5,7 @@ import type { Ref } from 'vue'
 import { setFallbackForNullishOrOnError } from '/@/lib/basic/fallback'
 import { channelIdToPathString } from '/@/lib/channel'
 import type { ChannelTree } from '/@/lib/channelTree'
-import { channelPathToId } from '/@/lib/channelTree'
+import { channelPathToId as channelPathToIdImpl } from '/@/lib/channelTree'
 import type { StoreForParser } from '/@/lib/searchMessage/parserBase'
 import {
   createQueryParser,
@@ -37,27 +37,45 @@ const getStoreForParser = ({
   usersMap: Ref<ReadonlyMap<UserId, User>>
   me: Ref<User | undefined>
   fetchUserByName: (param: { username: string }) => Promise<User | undefined>
-}): StoreForParser => ({
-  channelPathToId: path =>
-    setFallbackForNullishOrOnError(undefined).exec(() =>
-      channelPathToId(path.split('/'), channelTree.value)
-    ),
-  usernameToDmChannelId: async username => {
-    const user = await fetchUserByName({ username })
-    return userIdToDmChannelIdMap.value.get(user?.id ?? '')
-  },
-  usernameToId: async username => {
+}): StoreForParser => {
+  const getMyUsername = () => `@${me.value?.name}`
+  const getMyUserId = () => me.value?.id
+
+  const userIdToDmChannelId = (userId: UserId): DMChannelId | undefined => {
+    return userIdToDmChannelIdMap.value.get(userId)
+  }
+
+  const channelIdToPath = (channelId: ChannelId): string | undefined => {
+    return channelIdToPathString(channelId, channelsMap.value)
+  }
+
+  const usernameToId = async (
+    username: string
+  ): Promise<UserId | undefined> => {
     const user = await fetchUserByName({ username })
     return user?.id
-  },
-  getCurrentChannelPathOrUsername: () => {
-    const channelId =
-      primaryView.value.type === 'channel' || primaryView.value.type === 'dm'
-        ? primaryView.value.channelId
-        : undefined
+  }
+
+  const getCurrentChannelId = () => {
+    return primaryView.value.type === 'channel' ||
+      primaryView.value.type === 'dm'
+      ? primaryView.value.channelId
+      : undefined
+  }
+
+  const usernameToDmChannelId = async (
+    username: string
+  ): Promise<DMChannelId | undefined> => {
+    const id = await usernameToId(username)
+    if (!id) return undefined
+    return userIdToDmChannelId(id)
+  }
+
+  const getCurrentChannelPathOrUsername = () => {
+    const channelId = getCurrentChannelId()
     if (!channelId) return undefined
 
-    const path = channelIdToPathString(channelId, channelsMap.value)
+    const path = channelIdToPath(channelId)
     if (path) return `#${path}`
 
     const userId = dmChannelsMap.value.get(channelId)?.userId
@@ -65,21 +83,30 @@ const getStoreForParser = ({
 
     const username = usersMap.value.get(userId)?.name
     if (username) return `@${username}`
-  },
-  getCurrentChannelId: () => {
-    return primaryView.value.type === 'channel' ||
-      primaryView.value.type === 'dm'
-      ? primaryView.value.channelId
-      : undefined
-  },
-  getMyDmChannelId: () => {
-    const myUserId = me.value?.id
+  }
+
+  const getMyDmChannelId = () => {
+    const myUserId = getMyUserId()
     if (!myUserId) return undefined
-    return userIdToDmChannelIdMap.value.get(myUserId)
-  },
-  getMyUsername: () => `@${me.value?.name}`,
-  getMyUserId: () => me.value?.id
-})
+    return userIdToDmChannelId(myUserId)
+  }
+
+  const channelPathToId = (path: string): ChannelId | undefined =>
+    setFallbackForNullishOrOnError(undefined).exec(() =>
+      channelPathToIdImpl(path.split('/'), channelTree.value)
+    )
+
+  return {
+    channelPathToId,
+    usernameToDmChannelId,
+    usernameToId,
+    getCurrentChannelPathOrUsername,
+    getCurrentChannelId,
+    getMyDmChannelId,
+    getMyUsername,
+    getMyUserId
+  }
+}
 
 const useQueryParser = () => {
   const { channelsMap, dmChannelsMap, userIdToDmChannelIdMap } =

--- a/src/composables/searchMessage/useQueryParser.ts
+++ b/src/composables/searchMessage/useQueryParser.ts
@@ -72,6 +72,11 @@ const getStoreForParser = ({
       ? primaryView.value.channelId
       : undefined
   },
+  getMyDmChannelId: () => {
+    const myUserId = me.value?.id
+    if (!myUserId) return undefined
+    return userIdToDmChannelIdMap.value.get(myUserId)
+  },
   getMyUsername: () => `@${me.value?.name}`,
   getMyUserId: () => me.value?.id
 })

--- a/src/composables/searchMessage/useQueryParser.ts
+++ b/src/composables/searchMessage/useQueryParser.ts
@@ -1,7 +1,6 @@
-import type { Channel, User } from '@traptitech/traq'
+import type { Channel, DMChannel, User } from '@traptitech/traq'
 
-import type { ComputedRef, Ref } from 'vue'
-import { computed } from 'vue'
+import type { Ref } from 'vue'
 
 import { setFallbackForNullishOrOnError } from '/@/lib/basic/fallback'
 import { channelIdToPathString } from '/@/lib/channel'
@@ -18,53 +17,81 @@ import { useChannelsStore } from '/@/store/entities/channels'
 import { useUsersStore } from '/@/store/entities/users'
 import type { PrimaryViewInformation } from '/@/store/ui/mainView'
 import { useMainViewStore } from '/@/store/ui/mainView'
-import type { ChannelId } from '/@/types/entity-ids'
+import type { ChannelId, DMChannelId, UserId } from '/@/types/entity-ids'
 
 const getStoreForParser = ({
   primaryView,
   channelsMap,
+  dmChannelsMap,
+  userIdToDmChannelIdMap,
   channelTree,
-  myUsername,
+  usersMap,
+  me,
   fetchUserByName
 }: {
   primaryView: Ref<PrimaryViewInformation>
   channelsMap: Ref<ReadonlyMap<ChannelId, Channel>>
+  dmChannelsMap: Ref<ReadonlyMap<DMChannelId, DMChannel>>
+  userIdToDmChannelIdMap: Ref<ReadonlyMap<UserId, DMChannelId>>
   channelTree: Ref<ChannelTree>
-  myUsername: ComputedRef<string | undefined>
+  usersMap: Ref<ReadonlyMap<UserId, User>>
+  me: Ref<User | undefined>
   fetchUserByName: (param: { username: string }) => Promise<User | undefined>
 }): StoreForParser => ({
   channelPathToId: path =>
     setFallbackForNullishOrOnError(undefined).exec(() =>
       channelPathToId(path.split('/'), channelTree.value)
     ),
+  usernameToDmChannelId: async username => {
+    const user = await fetchUserByName({ username })
+    return userIdToDmChannelIdMap.value.get(user?.id ?? '')
+  },
   usernameToId: async username => {
     const user = await fetchUserByName({ username })
     return user?.id
   },
-  getCurrentChannelPath: () => {
+  getCurrentChannelPathOrUsername: () => {
     const channelId =
       primaryView.value.type === 'channel' || primaryView.value.type === 'dm'
         ? primaryView.value.channelId
         : undefined
-    return channelId
-      ? channelIdToPathString(channelId, channelsMap.value)
+    if (!channelId) return undefined
+
+    const path = channelIdToPathString(channelId, channelsMap.value)
+    if (path) return `#${path}`
+
+    const userId = dmChannelsMap.value.get(channelId)?.userId
+    if (!userId) return undefined
+
+    const username = usersMap.value.get(userId)?.name
+    if (username) return `@${username}`
+  },
+  getCurrentChannelId: () => {
+    return primaryView.value.type === 'channel' ||
+      primaryView.value.type === 'dm'
+      ? primaryView.value.channelId
       : undefined
   },
-  getMyUsername: () => myUsername.value
+  getMyUsername: () => `@${me.value?.name}`,
+  getMyUserId: () => me.value?.id
 })
 
 const useQueryParser = () => {
-  const { channelsMap } = useChannelsStore()
+  const { channelsMap, dmChannelsMap, userIdToDmChannelIdMap } =
+    useChannelsStore()
   const { channelTree } = useChannelTree()
   const { primaryView } = useMainViewStore()
-  const { fetchUserByName } = useUsersStore()
+  const { fetchUserByName, usersMap } = useUsersStore()
   const { detail: me } = useMeStore()
   const parseQuery = createQueryParser(
     getStoreForParser({
       primaryView,
       channelsMap,
+      dmChannelsMap,
+      userIdToDmChannelIdMap,
       channelTree,
-      myUsername: computed(() => me.value?.name),
+      usersMap,
+      me,
       fetchUserByName
     })
   )

--- a/src/lib/searchMessage/parserBase.ts
+++ b/src/lib/searchMessage/parserBase.ts
@@ -166,8 +166,7 @@ export const HereToken = Symbol('in:here')
 export const MeToken = Symbol('in:me / from:me / to:me')
 
 export const channelOrDmChannelParser = async <T extends string>(
-  channelPathToId: ChannelPathToId,
-  usernameToDmChannelId: UsernameToDmChannelId,
+  { channelPathToId, usernameToDmChannelId }: StoreForParser,
   extracted: ExtractedFilter<T>
 ): Promise<ChannelId | typeof HereToken | typeof MeToken | undefined> => {
   const body = extracted.prefix === '#' ? `#${extracted.body}` : extracted.body

--- a/src/lib/searchMessage/parserBase.ts
+++ b/src/lib/searchMessage/parserBase.ts
@@ -186,13 +186,11 @@ export const userParser = async <T extends string>(
   usernameToId: UsernameToId,
   extracted: ExtractedFilter<T>
 ): Promise<UserId | typeof MeToken | undefined> => {
+  if (extracted.body === 'me') return MeToken
+
   const username = extracted.body.startsWith('@')
     ? extracted.body.slice(1)
     : extracted.body
-
-  if (username === 'me') {
-    return MeToken
-  }
 
   return usernameToId(username)
 }

--- a/src/lib/searchMessage/parserBase.ts
+++ b/src/lib/searchMessage/parserBase.ts
@@ -1,5 +1,10 @@
 // 実際のフィルタに依存しない関数群
-import type { ChannelId, MessageId, UserId } from '/@/types/entity-ids'
+import type {
+  ChannelId,
+  DMChannelId,
+  MessageId,
+  UserId
+} from '/@/types/entity-ids'
 
 const dateOnlyFormRegex = /^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$/
 
@@ -87,6 +92,7 @@ export type StoreForParser = {
   usernameToId: UsernameToId
   getCurrentChannelPathOrUsername: () => string | undefined
   getCurrentChannelId: () => ChannelId | undefined
+  getMyDmChannelId: () => DMChannelId | undefined
   getMyUsername: () => string | undefined
   getMyUserId: () => UserId | undefined
 }
@@ -156,16 +162,17 @@ export const dateParser = <T extends string>(
   return date
 }
 
-export const InHereToken = Symbol('in:here')
-export const FromToMeToken = Symbol('from:me / to:me')
+export const HereToken = Symbol('in:here')
+export const MeToken = Symbol('in:me / from:me / to:me')
 
 export const channelOrDmChannelParser = async <T extends string>(
   channelPathToId: ChannelPathToId,
   usernameToDmChannelId: UsernameToDmChannelId,
   extracted: ExtractedFilter<T>
-): Promise<ChannelId | typeof InHereToken | undefined> => {
+): Promise<ChannelId | typeof HereToken | typeof MeToken | undefined> => {
   const body = extracted.prefix === '#' ? `#${extracted.body}` : extracted.body
-  if (body === 'here') return InHereToken
+  if (body === 'here') return HereToken
+  if (body === 'me') return MeToken
 
   const channelName = body.startsWith('#') ? body.slice(1) : body
   const channelPath = channelPathToId(channelName)
@@ -178,13 +185,13 @@ export const channelOrDmChannelParser = async <T extends string>(
 export const userParser = async <T extends string>(
   usernameToId: UsernameToId,
   extracted: ExtractedFilter<T>
-): Promise<UserId | typeof FromToMeToken | undefined> => {
+): Promise<UserId | typeof MeToken | undefined> => {
   const username = extracted.body.startsWith('@')
     ? extracted.body.slice(1)
     : extracted.body
 
   if (username === 'me') {
-    return FromToMeToken
+    return MeToken
   }
 
   return usernameToId(username)

--- a/src/lib/searchMessage/queryParser.ts
+++ b/src/lib/searchMessage/queryParser.ts
@@ -8,9 +8,9 @@ import type {
   FilterParser,
   StoreForParser
 } from './parserBase'
-import { FromToMeToken } from './parserBase'
+import { MeToken } from './parserBase'
 import {
-  InHereToken,
+  HereToken,
   channelOrDmChannelParser,
   dateParser,
   makePrefixedFilterExtractor,
@@ -53,9 +53,13 @@ type MediaFlagFilterKey = 'attachments' | 'image' | 'audio' | 'video'
 export type Filter =
   | { type: 'after'; raw: string; value: Date }
   | { type: 'before'; raw: string; value: Date }
-  | { type: 'in'; raw: string; value: typeof InHereToken | ChannelId }
-  | { type: 'to'; raw: string; value: typeof FromToMeToken | UserId }
-  | { type: 'from'; raw: string; value: typeof FromToMeToken | UserId }
+  | {
+      type: 'in'
+      raw: string
+      value: typeof HereToken | typeof MeToken | ChannelId
+    }
+  | { type: 'to'; raw: string; value: typeof MeToken | UserId }
+  | { type: 'from'; raw: string; value: typeof MeToken | UserId }
   | { type: 'citation'; raw: string; value: MessageId }
   | { type: 'attrFlag'; raw: string; value: AttrFlagFilterKey; negate: boolean }
   | {
@@ -192,6 +196,7 @@ const parseQueryFragmentToFilterWithoutStore = parseToFilterBase(
 /** 実際のクエリに対応するオブジェクトへの変換 */
 const filterOrStringToSearchMessageQuery = (
   currentChannelId: string | undefined,
+  myDmChannelId: string | undefined,
   myUserId: string | undefined,
   f: Filter | string
 ): SearchMessageQueryObject => {
@@ -206,12 +211,13 @@ const filterOrStringToSearchMessageQuery = (
         [f.type]: f.value.toISOString()
       }
     case 'in': {
-      if (f.value === InHereToken) return { in: currentChannelId }
+      if (f.value === HereToken) return { in: currentChannelId }
+      if (f.value === MeToken) return { in: myDmChannelId }
       return { in: f.value }
     }
     case 'to':
     case 'from': {
-      const user = f.value === FromToMeToken ? myUserId : f.value
+      const user = f.value === MeToken ? myUserId : f.value
       return { [f.type]: user }
     }
     case 'citation':
@@ -248,6 +254,7 @@ export const createQueryParser = (store: StoreForParser) => {
 
     const currentChannelPathOrUsername = store.getCurrentChannelPathOrUsername()
     const currentChannelId = store.getCurrentChannelId()
+    const myDmChannelId = store.getMyDmChannelId()
     const myUsername = store.getMyUsername()
     const myUserId = store.getMyUserId()
 
@@ -263,7 +270,12 @@ export const createQueryParser = (store: StoreForParser) => {
 
     const queryObject = parseds
       .map(f =>
-        filterOrStringToSearchMessageQuery(currentChannelId, myUserId, f)
+        filterOrStringToSearchMessageQuery(
+          currentChannelId,
+          myDmChannelId,
+          myUserId,
+          f
+        )
       )
       .reduce(mergeSearchMessageQueryObject, emptySearchMessageQueryObject)
 
@@ -278,11 +290,12 @@ const parsedFilterToNormalizedString = (
 ) => {
   if (typeof f === 'string') return f
 
-  if (f.type === 'in' && f.value === InHereToken) {
-    return `in:${currentChannelPathOrUsername}`
+  if (f.type === 'in') {
+    if (f.value === HereToken) return `in:${currentChannelPathOrUsername}`
+    if (f.value === MeToken) return `in:${myUsername}`
   }
 
-  if ((f.type === 'from' || f.type === 'to') && f.value === FromToMeToken) {
+  if ((f.type === 'from' || f.type === 'to') && f.value === MeToken) {
     return `${f.type}:${myUsername}`
   }
   return f.raw

--- a/src/lib/searchMessage/queryParser.ts
+++ b/src/lib/searchMessage/queryParser.ts
@@ -139,11 +139,7 @@ const parser = async (
         : undefined
     }
     case 'in': {
-      const result = await channelOrDmChannelParser(
-        store.channelPathToId,
-        store.usernameToDmChannelId,
-        extracted
-      )
+      const result = await channelOrDmChannelParser(store, extracted)
       return result
         ? { type, raw: rawQuery(extracted), value: result }
         : undefined

--- a/tests/unit/lib/searchMessage/queryParser.spec.ts
+++ b/tests/unit/lib/searchMessage/queryParser.spec.ts
@@ -20,6 +20,193 @@ const mockMyDmChannelId = 'my-dm-channel-id'
 const mockMyUsername = 'myUsername'
 
 describe('parseQuery', () => {
+  const TEST_CASES = [
+    {
+      description: 'plain',
+      query: 'lorem       ipsum',
+      expectedNormalizedQuery: 'lorem ipsum',
+      expectedQueryObject: { word: 'lorem ipsum' }
+    },
+    {
+      description: 'with date-filter',
+      query: 'lorem ipsum after:2021-01-23',
+      expectedNormalizedQuery: 'lorem ipsum after:2021-01-23',
+      expectedQueryObject: {
+        word: 'lorem ipsum',
+        after: '2021-01-23T00:00:00.000Z'
+      }
+    },
+    {
+      description: 'with in-filter (prefix: `in:`, channel)',
+      query: `lorem ipsum in:${mockChannelName}`,
+      expectedNormalizedQuery: `lorem ipsum in:${mockChannelName}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockChannelId }
+    },
+    {
+      description: 'with in-filter (prefix: `in:`, user)',
+      query: `lorem ipsum in:${mockUserName}`,
+      expectedNormalizedQuery: `lorem ipsum in:${mockUserName}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockDmChannelId }
+    },
+    {
+      description: 'with in-filter (prefix: `#`, channel)',
+      query: `lorem ipsum #${mockChannelName}`,
+      expectedNormalizedQuery: `lorem ipsum #${mockChannelName}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockChannelId }
+    },
+    {
+      description: 'with in-filter (prefix: `#`, user)',
+      query: `lorem ipsum #${mockUserName}`,
+      expectedNormalizedQuery: `lorem ipsum #${mockUserName}`,
+      expectedQueryObject: {
+        word: `lorem ipsum #${mockUserName}`,
+        in: undefined
+      }
+    },
+    {
+      description: 'with in-filter (prefix: `in:#`, channel)',
+      query: `lorem ipsum in:#${mockChannelName}`,
+      expectedNormalizedQuery: `lorem ipsum in:#${mockChannelName}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockChannelId }
+    },
+    {
+      description: 'with in-filter (prefix: `in:#`, user)',
+      query: `lorem ipsum in:#${mockUserName}`,
+      expectedNormalizedQuery: `lorem ipsum in:#${mockUserName}`,
+      expectedQueryObject: {
+        word: `lorem ipsum in:#${mockUserName}`,
+        in: undefined
+      }
+    },
+    {
+      description: 'with in-filter (prefix: `in:@`, channel)',
+      query: `lorem ipsum in:@${mockChannelName}`,
+      expectedNormalizedQuery: `lorem ipsum in:@${mockChannelName}`,
+      expectedQueryObject: {
+        word: `lorem ipsum in:@${mockChannelName}`,
+        in: undefined
+      }
+    },
+    {
+      description: 'with in-filter (prefix: `in:@`, user)',
+      query: `lorem ipsum in:@${mockUserName}`,
+      expectedNormalizedQuery: `lorem ipsum in:@${mockUserName}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockDmChannelId }
+    },
+    {
+      description: 'with in:here',
+      query: 'lorem ipsum in:here',
+      expectedNormalizedQuery: `lorem ipsum in:${mockCurrentChannelPath}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockCurrentChannelId }
+    },
+    {
+      description: 'with in:me',
+      query: 'lorem ipsum in:me',
+      expectedNormalizedQuery: `lorem ipsum in:${mockMyUsername}`,
+      expectedQueryObject: { word: 'lorem ipsum', in: mockMyDmChannelId }
+    },
+    {
+      description: 'with user-filter without @',
+      query: `lorem ipsum from:${mockUserName}`,
+      expectedNormalizedQuery: `lorem ipsum from:${mockUserName}`,
+      expectedQueryObject: { word: 'lorem ipsum', from: mockUserId }
+    },
+    {
+      description: 'with user-filter with @',
+      query: `lorem ipsum from:@${mockUserName}`,
+      expectedNormalizedQuery: `lorem ipsum from:@${mockUserName}`,
+      expectedQueryObject: { word: 'lorem ipsum', from: mockUserId }
+    },
+    {
+      description: 'with me',
+      query: 'lorem ipsum to:me',
+      expectedNormalizedQuery: `lorem ipsum to:${mockMyUsername}`,
+      expectedQueryObject: { word: 'lorem ipsum', to: mockMyUserId }
+    },
+    {
+      description: 'with an invalid prefix',
+      query: 'invalid:',
+      expectedNormalizedQuery: 'invalid:',
+      expectedQueryObject: { word: 'invalid:' }
+    },
+    {
+      description: 'with empty prefixes (1)',
+      query: 'after: in: cite: from:',
+      expectedNormalizedQuery: 'after: in: cite: from:',
+      expectedQueryObject: {
+        after: undefined,
+        in: undefined,
+        from: undefined
+      }
+    },
+    {
+      description: 'with empty prefixes (2)',
+      query: '# @',
+      expectedNormalizedQuery: '# @',
+      expectedQueryObject: { in: undefined, from: undefined }
+    },
+    {
+      description: 'with message-filter (url)',
+      query: `lorem ipsum cite:${mockMessageUrl}`,
+      expectedNormalizedQuery: `lorem ipsum cite:${mockMessageUrl}`,
+      expectedQueryObject: { word: 'lorem ipsum', citation: mockMessageId }
+    },
+    {
+      description: 'with message-filter (not a message url)',
+      query: 'lorem ipsum cite:https://example.com/a',
+      expectedNormalizedQuery: 'lorem ipsum cite:https://example.com/a',
+      expectedQueryObject: {
+        word: 'lorem ipsum cite:https://example.com/a',
+        citation: undefined
+      }
+    },
+    {
+      description: 'with message-filter (id)',
+      query: `lorem ipsum cite:${mockMessageId}`,
+      expectedNormalizedQuery: `lorem ipsum cite:${mockMessageId}`,
+      expectedQueryObject: { word: 'lorem ipsum', citation: mockMessageId }
+    },
+    {
+      description: 'with media-flag-filter',
+      query: 'lorem has:image ipsum',
+      expectedNormalizedQuery: 'lorem has:image ipsum',
+      expectedQueryObject: { word: 'lorem ipsum', hasImage: true }
+    },
+    {
+      description: 'with invalid media-flag-filter',
+      query: 'lorem has:ipsum',
+      expectedNormalizedQuery: 'lorem has:ipsum',
+      expectedQueryObject: { word: 'lorem has:ipsum', hasImage: undefined }
+    },
+    {
+      description: 'with invalid attr-flag-filter',
+      query: 'lorem ipsum is:bott',
+      expectedNormalizedQuery: 'lorem ipsum is:bott',
+      expectedQueryObject: { word: 'lorem ipsum is:bott', bot: undefined }
+    },
+    {
+      description: 'with negated flag-filter (not-style)',
+      query: 'lorem ipsum not:bot',
+      expectedNormalizedQuery: 'lorem ipsum not:bot',
+      expectedQueryObject: { word: 'lorem ipsum', bot: false }
+    },
+    {
+      description: 'with negated flag-filter (negation-style)',
+      query: 'lorem ipsum -is:bot',
+      expectedNormalizedQuery: 'lorem ipsum -is:bot',
+      expectedQueryObject: { word: 'lorem ipsum', bot: false }
+    },
+    {
+      description: 'with wrong valued-filter',
+      query: 'lorem ipsum from:@phantom',
+      expectedNormalizedQuery: 'lorem ipsum from:@phantom',
+      expectedQueryObject: {
+        word: 'lorem ipsum from:@phantom',
+        from: undefined
+      }
+    }
+  ]
+
   const store: StoreForParser = {
     channelPathToId: channelPath => {
       if (channelPath === mockChannelName) {
@@ -56,195 +243,18 @@ describe('parseQuery', () => {
   }
   const parseQuery = createQueryParser(store)
 
-  it('can parse query without filter', async () => {
-    const query = 'lorem       ipsum'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe('lorem ipsum')
-    expect(queryObject.word).toBe('lorem ipsum')
-  })
-  it('can parse query with date-filter', async () => {
-    const query = 'lorem ipsum after:2021-01-23'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.after).toBe('2021-01-23T00:00:00.000Z')
-  })
-  it('can parse query with in-filter (prefix: `in:`, channel)', async () => {
-    const query = `lorem ipsum in:${mockChannelName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockChannelId)
-  })
-  it('can parse query with in-filter (prefix: `in:`, user)', async () => {
-    const query = `lorem ipsum in:${mockUserName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockDmChannelId)
-  })
-  it('can parse query with in-filter (prefix: `#`, channel)', async () => {
-    const query = `lorem ipsum #${mockChannelName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockChannelId)
-  })
-  it('can parse query with in-filter (prefix: `#`, user)', async () => {
-    const query = `lorem ipsum #${mockUserName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe(query)
-    expect(queryObject.in).toBeUndefined()
-  })
-  it('can parse query with in-filter (prefix: `in:#`, channel)', async () => {
-    const query = `lorem ipsum in:#${mockChannelName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockChannelId)
-  })
-  it('can parse query with in-filter (prefix: `in:#`, user)', async () => {
-    const query = `lorem ipsum in:#${mockUserName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe(query)
-    expect(queryObject.in).toBeUndefined()
-  })
-  it('can parse query with in-filter (prefix: `in:@`, channel)', async () => {
-    const query = `lorem ipsum in:@${mockChannelName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe(query)
-    expect(queryObject.in).toBeUndefined()
-  })
-  it('can parse query with in-filter (prefix: `in:@`, user)', async () => {
-    const query = `lorem ipsum in:@${mockUserName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockDmChannelId)
-  })
-  it('can parse query with in:here', async () => {
-    const query = 'lorem ipsum in:here'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(`lorem ipsum in:${mockCurrentChannelPath}`)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockCurrentChannelId)
-  })
-  it('can parse query with in:me', async () => {
-    const query = 'lorem ipsum in:me'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(`lorem ipsum in:${mockMyUsername}`)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.in).toEqual(mockMyDmChannelId)
-  })
-  it('can parse query with user-filter without @', async () => {
-    const query = `lorem ipsum from:${mockUserName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.from).toEqual(mockUserId)
-  })
-  it('can parse query with user-filter with @', async () => {
-    const query = `lorem ipsum from:@${mockUserName}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.from).toEqual(mockUserId)
-  })
-  it('can parse query with me', async () => {
-    const query = 'lorem ipsum to:me'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(`lorem ipsum to:${mockMyUsername}`)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.to).toEqual(mockMyUserId)
-  })
-  it('can parse query with an invalid prefix', async () => {
-    const query = 'invalid:'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('invalid:')
-  })
-  it('can parse query with empty prefixes (1)', async () => {
-    const query = 'after: in: cite: from:'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.after).toBeUndefined()
-    expect(queryObject.in).toBeUndefined()
-    expect(queryObject.from).toBeUndefined()
-  })
-  it('can parse query with empty prefixes (2)', async () => {
-    const query = '# @'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.in).toBeUndefined()
-    expect(queryObject.from).toBeUndefined()
-  })
-  it('can parse query with message-filter (url)', async () => {
-    const query = `lorem ipsum cite:${mockMessageUrl}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.citation).toEqual(mockMessageId)
-  })
-  it('can parse query with message-filter (not a message url)', async () => {
-    const query = 'lorem ipsum cite:https://example.com/a'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum cite:https://example.com/a')
-    expect(queryObject.citation).toBeUndefined()
-  })
-  it('can parse query with message-filter (id)', async () => {
-    const query = `lorem ipsum cite:${mockMessageId}`
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.citation).toEqual(mockMessageId)
-  })
-  it('can parse query with media-flag-filter', async () => {
-    const query = 'lorem has:image ipsum'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.hasImage).toBe(true)
-  })
-  it('can parse query with invalid media-flag-filter', async () => {
-    const query = 'lorem has:ipsum'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem has:ipsum')
-    expect(queryObject.hasImage).toBeUndefined()
-  })
-  it('can parse query with invalid attr-flag-filter', async () => {
-    const query = 'lorem ipsum is:bott'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum is:bott')
-    expect(queryObject.bot).toBeUndefined()
-  })
-  it('can parse query with negated flag-filter (not-style)', async () => {
-    const query = 'lorem ipsum not:bot'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.bot).toBe(false)
-  })
-  it('can parse query with negated flag-filter (negation-style)', async () => {
-    const query = 'lorem ipsum -is:bot'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe('lorem ipsum')
-    expect(queryObject.bot).toBe(false)
-  })
-  it('can parse query with wrong valued-filter', async () => {
-    // @phantomさんは存在しないのでこのクエリはwordに入る
-    const query = 'lorem ipsum from:@phantom'
-    const { normalizedQuery, queryObject } = await parseQuery(query)
-    expect(normalizedQuery).toBe(query)
-    expect(queryObject.word).toBe(query)
-    expect(queryObject.from).toBeUndefined()
-  })
+  test.each(TEST_CASES)(
+    '$description',
+    async ({ query, expectedNormalizedQuery, expectedQueryObject }) => {
+      const { normalizedQuery, queryObject } = await parseQuery(query)
+
+      expect(normalizedQuery).toBe(expectedNormalizedQuery)
+
+      Object.entries(expectedQueryObject).forEach(([key, value]) => {
+        expect(queryObject[key as keyof typeof queryObject]).toEqual(value)
+      })
+    }
+  )
 })
 
 describe('toSearchMessageParam', () => {


### PR DESCRIPTION
## 概要

### やったこと・変更点
- feat: `in:user_name`, `in:@user_name` クエリのサポートを追加
  - 現在の仕様との互換性のため，チャンネル名が優先される．すなわち，`general` という名前のチャンネルとユーザーが同時に存在した場合，`in:general` は `in:#general` と同値になる．
- feat: `in:me` (自分宛て DM を対象とした検索) クエリのサポートを追加
- fix: `from:@me` や `to:@me` が `from:me`, `to:me` として解釈される不具合を修正．
  - 現在は `me` という名前のユーザーが存在した場合であっても，そのユーザを `from` や `to` の引数として取ることができない．

また，軽微な変更として，`in:here` や `in:me` の自動置換が `#` や `@` を付加するようになる．
すなわち，現在 `in:here` が `in:current/channel/path` と展開されるのが，`in:#current/channel/path` と展開されるようになる．`in:me` や `from:me`, `to:me` に関しても同様に，それぞれ `in:@my_user_name`, `from:@my_user_name`, `to:@my_user_name` と展開される．

### やってないこと
- DMView にチェンネル内検索ボタンを置く

## なぜこの PR を入れたいのか

- closes: #3853
- 現時点でも API を叩けば検索は可能であるにもかかわらずクライアント側の実装がないのは些か不自然

## PR を出す前の確認事項
- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう