### PR TITLE
feat(messages): コンテキストメニューやスタンプピッカーが表示されている `MessageElement` も背景色を強調する

### DIFF
--- a/src/components/Main/MainView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MainView/MessageElement/MessageElement.vue
@@ -8,6 +8,7 @@
       :data-is-pinned="$boolAttr(message.pinned)"
       :data-is-entry="$boolAttr(isEntryMessage)"
       :data-is-editing="$boolAttr(isEditing)"
+      :data-is-active="$boolAttr(isActive)"
       @pointerenter="onPointerEnter"
       @click="onClick"
       @mouseleave="onMouseLeave"
@@ -18,6 +19,7 @@
         :class="$style.pinned"
       />
       <MessageTools
+        v-model:is-active="isActive"
         :show="showMessageTools"
         :class="$style.tools"
         :message-id="messageId"
@@ -38,7 +40,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, shallowRef, toRef } from 'vue'
+import { computed, ref, shallowRef, toRef } from 'vue'
 import type { ChangeHeightData } from './composables/useElementRenderObserver'
 import useElementRenderObserver from './composables/useElementRenderObserver'
 import MessageContents from './MessageContents.vue'
@@ -72,6 +74,8 @@ const emit = defineEmits<{
   (e: 'changeHeight', _data: ChangeHeightData): void
 }>()
 
+const isActive = ref(false)
+
 const bodyRef = shallowRef<HTMLDivElement | null>(null)
 const { isMobile } = useResponsiveStore()
 const { messagesMap } = useMessagesStore()
@@ -92,7 +96,9 @@ useElementRenderObserver(
 
 const { isHovered, onPointerEnter, onClick, onMouseLeave, onClickOutside } =
   useMessageToolsHover()
-const showMessageTools = computed(() => isHovered.value && !isEditing.value)
+const showMessageTools = computed(
+  () => (isHovered.value && !isEditing.value) || isActive.value
+)
 </script>
 
 <style lang="scss" module>
@@ -116,8 +122,11 @@ $messagePaddingMobile: 16px;
     // TODO: 色を正しくする
     background: $common-background-pin;
   }
-  &:not([data-is-editing]):not([data-is-pinned]):not([data-is-entry]):hover {
-    background: var(--specific-message-hover-background);
+  &:not([data-is-editing]):not([data-is-pinned]):not([data-is-entry]) {
+    &[data-is-active],
+    &:hover {
+      background: var(--specific-message-hover-background);
+    }
   }
 }
 

--- a/src/components/Main/MainView/MessageElement/MessageTools.vue
+++ b/src/components/Main/MainView/MessageElement/MessageTools.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="show || isStampPickerOpen || contextMenuPosition"
+    v-if="show"
     ref="containerEle"
     :class="$style.container"
     :data-is-mobile="$boolAttr(isMobile)"
@@ -85,7 +85,7 @@
 
 <script lang="ts" setup>
 import type { Stamp } from '@traptitech/traq'
-import { computed, ref, toRef } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import MessageContextMenu from './MessageContextMenu.vue'
 import AIcon from '/@/components/UI/AIcon.vue'
 import AStamp from '/@/components/UI/AStamp.vue'
@@ -101,6 +101,7 @@ import { useMessageEditingStateStore } from '/@/store/ui/messageEditingStateStor
 import { useResponsiveStore } from '/@/store/ui/responsive'
 import { useStampPickerInvoker } from '/@/store/ui/stampPicker'
 import type { MessageId, StampId } from '/@/types/entity-ids'
+import { isDefined } from '/@/lib/basic/array'
 
 const props = withDefaults(
   defineProps<{
@@ -113,6 +114,8 @@ const props = withDefaults(
     show: false
   }
 )
+
+const isActive = defineModel<boolean>('isActive', { default: false })
 
 const { recentStampIds } = useStampHistory()
 const { addStampOptimistically } = useStampUpdater()
@@ -174,6 +177,14 @@ const onDotsClick = (e: MouseEvent) => {
     y: e.pageY
   })
 }
+
+watch(
+  () => isStampPickerOpen.value || isDefined(contextMenuPosition.value),
+  value => {
+    isActive.value = value
+  },
+  { immediate: true }
+)
 
 const { isMobile } = useResponsiveStore()
 


### PR DESCRIPTION
## 概要
- コンテキストメニューやスタンプピッカーが表示されている `MessageElement` も背景色を強調する
  - Discord もこの仕様

## なぜこの PR を入れたいのか
close: #3981

## UI 変更部分のスクリーンショット
<img width="749" height="170" alt="image" src="https://github.com/user-attachments/assets/4160b6dd-56da-4a2b-ac56-a5cf549bd932" />


## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう