### PR TITLE
deps: bump `@traptitech/traq` to 3.25.1 and apply patchs for the type mismatch bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mdi/js": "^7.4.47",
         "@sapphi-red/web-noise-suppressor": "^0.3.5",
         "@shiguredo/virtual-background": "^2023.2.0",
-        "@traptitech/traq": "^3.24.4-0",
+        "@traptitech/traq": "^3.25.1-4",
         "@traptitech/traq-markdown-it": "^7.0.2",
         "autosize": "^6.0.1",
         "browser-image-compression": "^2.0.2",
@@ -4281,11 +4281,12 @@
       "integrity": "sha512-tH/Fk1WMsnSuLpuRsXw8iHtdivoCEI5V08hQ7doVm6WmzAnBf/cUzyH9+GbOldPq9Hwv9v9tuy5t/MxmdNAGXg=="
     },
     "node_modules/@traptitech/traq": {
-      "version": "3.24.4-0",
-      "resolved": "https://registry.npmjs.org/@traptitech/traq/-/traq-3.24.4-0.tgz",
-      "integrity": "sha512-XUGZwRlMtZ+a1+j7o0NaES2JXlx+LoBjNllGWEGyJzfvYFy/kO2nHBjag7tCvd6NquXCuQU5w+Lkn75BdCRvmQ==",
+      "version": "3.25.1-4",
+      "resolved": "https://registry.npmjs.org/@traptitech/traq/-/traq-3.25.1-4.tgz",
+      "integrity": "sha512-pvCxOtO9KnsWcJ511sQMHwU0rDB05u9oMLSuUq5ZI/a+ZUrF9xXjoHnEi0CkwrRev1tGA0beC7h2J6T5H8U93g==",
+      "license": "MIT",
       "dependencies": {
-        "axios": "^1.8.4"
+        "axios": "^1.12.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@mdi/js": "^7.4.47",
     "@sapphi-red/web-noise-suppressor": "^0.3.5",
     "@shiguredo/virtual-background": "^2023.2.0",
-    "@traptitech/traq": "^3.24.4-0",
+    "@traptitech/traq": "^3.25.1-4",
     "@traptitech/traq-markdown-it": "^7.0.2",
     "autosize": "^6.0.1",
     "browser-image-compression": "^2.0.2",

--- a/src/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import { computed } from 'vue'
 import { isStampPaletteValid } from './utils'
 import FormButton from '/@/components/UI/FormButton.vue'

--- a/src/components/Settings/StampPaletteTab/StampPaletteEditor.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteEditor.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import { computed } from 'vue'
 import StampPaletteEditorAddStamp from './StampPaletteEditorAddableStampList.vue'
 import StampPaletteEditorBasicInfo from './StampPaletteEditorBasicInfo.vue'

--- a/src/components/Settings/StampPaletteTab/StampPaletteListItem.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteListItem.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import { computed } from 'vue'
 import StampPaletteListItemHeader from './StampPaletteListItemHeader.vue'
 import StampPaletteListItemStampList from './StampPaletteListItemStampList.vue'

--- a/src/components/Settings/StampPaletteTab/StampPaletteListItemHeader.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteListItemHeader.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import AIcon from '/@/components/UI/AIcon.vue'
 import IconButton from '/@/components/UI/IconButton.vue'
 import useExecWithToast from '/@/composables/toast/useExecWithToast'

--- a/src/components/Settings/StampPaletteTab/utils.ts
+++ b/src/components/Settings/StampPaletteTab/utils.ts
@@ -1,4 +1,4 @@
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import router from '/@/router'
 import { settingsStampPaletteRouteName } from '/@/router/settings'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'

--- a/src/store/entities/stampPalettes.ts
+++ b/src/store/entities/stampPalettes.ts
@@ -1,8 +1,8 @@
 import type {
   PatchStampPaletteRequest,
-  PostStampPaletteRequest,
-  StampPalette
+  PostStampPaletteRequest
 } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { CacheStrategy } from './utils'
@@ -14,15 +14,36 @@ import { wsListener } from '/@/lib/websocket'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import { useTrueChangedPromise } from '/@/store/utils/promise'
 import type { StampPaletteId } from '/@/types/entity-ids'
+import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 
-const getStampPalette = createSingleflight(apis.getStampPalette.bind(apis))
-const getStampPalettes = createSingleflight(apis.getStampPalettes.bind(apis))
-const createStampPaletteSingleflight = createSingleflight(
-  apis.createStampPalette.bind(apis)
+// FIXME: 型定義では `StampPalette['stamps']` は `Set<string>` だが，実際には `Array<string>` が返る
+// openapi-generator のバグだが，どのように修正されるかわからないので一旦型の上書きによって対応する
+// https://github.com/traPtitech/traQ_S-UI/issues/4612
+
+const getStampPalette = createSingleflight(
+  apis.getStampPalette.bind(apis) as unknown as (
+    paletteId?: StampPaletteId,
+    options?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<StampPalette>>
 )
+
+const getStampPalettes = createSingleflight(
+  apis.getStampPalettes.bind(apis) as unknown as (
+    options?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<StampPalette[]>>
+)
+
+const createStampPaletteSingleflight = createSingleflight(
+  apis.createStampPalette.bind(apis) as unknown as (
+    postStampPaletteRequest?: PostStampPaletteRequest,
+    options?: AxiosRequestConfig
+  ) => Promise<AxiosResponse<StampPalette>>
+)
+
 const editStampPaletteSingleflight = createSingleflight(
   apis.editStampPalette.bind(apis)
 )
+
 const deleteStampPaletteSingleflight = createSingleflight(
   apis.deleteStampPalette.bind(apis)
 )

--- a/src/types/entity.d.ts
+++ b/src/types/entity.d.ts
@@ -4,6 +4,8 @@ import type { StampId } from './entity-ids'
 // FIXME: 型定義では `StampPalette['stamps']` は `Set<string>` だが，実際には `Array<string>` が返る
 // openapi-generator のバグだが，どのように修正されるかわからないので一旦型の上書きによって対応する
 // https://github.com/traPtitech/traQ_S-UI/issues/4612
-export type StampPalette = Omit<StampPalette_, 'stamps'> & {
-  stamps: StampId[]
-}
+
+export type StampPalette =
+  StampPalette_['stamps'] extends Set<StampId>
+    ? Omit<StampPalette_, 'stamps'> & { stamps: StampId[] }
+    : never // 元々の型が `Set<string>` 以外をになったら type-check で検出できるように `never` 型を返す

--- a/src/types/entity.d.ts
+++ b/src/types/entity.d.ts
@@ -1,0 +1,9 @@
+import type { StampPalette as StampPalette_ } from '@traptitech/traq'
+import type { StampId } from './entity-ids'
+
+// FIXME: 型定義では `StampPalette['stamps']` は `Set<string>` だが，実際には `Array<string>` が返る
+// openapi-generator のバグだが，どのように修正されるかわからないので一旦型の上書きによって対応する
+// https://github.com/traPtitech/traQ_S-UI/issues/4612
+export type StampPalette = Omit<StampPalette_, 'stamps'> & {
+  stamps: StampId[]
+}

--- a/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteCreateTab.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import { computed, onBeforeUnmount, ref } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'
 import StampPaletteDescription from '/@/components/Settings/StampPaletteTab/StampPaletteDescription.vue'

--- a/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteDetailTab.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { StampPalette } from '@traptitech/traq'
+import type { StampPalette } from '/@/types/entity'
 import { isAxiosError } from 'axios'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRaw } from 'vue'
 import StampPaletteActionButtons from '/@/components/Settings/StampPaletteTab/StampPaletteActionButtons.vue'


### PR DESCRIPTION
## 概要

openapi-generator のバグによって，`StampPallet['stamps']` が `Set<string>` になったにもかかわらず実際に返される値は `Array<string>` となってしまうので，それに対する patch をあてる．
- まだどのような方向で修正されるか定かではないので，差分が少なくて済むように型定義の上書きによって一時的に対処する．


関連
- https://github.com/traPtitech/traQ/pull/2783
- https://github.com/traPtitech/traQ_S-UI/issues/4612
- https://github.com/OpenAPITools/openapi-generator/issues/11746

## なぜこの PR を入れたいのか

required by #4842 

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう