### PR TITLE
feat(modal): `UserModal` の開いていたタブを保存・復元できるようにする

### DIFF
--- a/src/components/Modal/ModalContainer.vue
+++ b/src/components/Modal/ModalContainer.vue
@@ -50,6 +50,9 @@
             ? currentState.file
             : undefined
         "
+        :navigation="
+          currentState.type === 'user' ? currentState.navigation : undefined
+        "
       />
     </div>
   </transition>

--- a/src/components/Modal/UserModal/NavigationContent.vue
+++ b/src/components/Modal/UserModal/NavigationContent.vue
@@ -15,11 +15,11 @@ import ProfileTab from './ProfileTab/ProfileTab.vue'
 import GroupsTab from './GroupsTab.vue'
 import TagsTab from './TagsTab.vue'
 import type { User, UserDetail } from '@traptitech/traq'
-import type { NavigationItemType } from './composables/useNavigation'
+import type { UserModalNavigationItemType } from '/@/store/ui/modal/states'
 
 withDefaults(
   defineProps<{
-    currentNavigation?: NavigationItemType
+    currentNavigation?: UserModalNavigationItemType
     user: User
     detail?: UserDetail
   }>(),

--- a/src/components/Modal/UserModal/NavigationSelector.vue
+++ b/src/components/Modal/UserModal/NavigationSelector.vue
@@ -6,19 +6,18 @@
       :icon-name="item.iconName"
       :icon-mdi="item.iconMdi"
       :is-selected="currentNavigation === item.type"
-      @click="onNavigationItemClick(item.type)"
+      @click="emit('navigationChange', item.type)"
     />
   </section>
 </template>
 
 <script lang="ts" setup>
 import NavigationSelectorItem from '/@/components/Modal/UserModal/NavigationSelectorItem.vue'
-import type { NavigationItemType } from './composables/useNavigation'
-import { useNavigationSelectorItem } from './composables/useNavigation'
+import type { UserModalNavigationItemType } from '/@/store/ui/modal/states'
 
 withDefaults(
   defineProps<{
-    currentNavigation?: NavigationItemType
+    currentNavigation?: UserModalNavigationItemType
   }>(),
   {
     currentNavigation: 'profile' as const
@@ -26,11 +25,11 @@ withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'navigationChange', _type: NavigationItemType): void
+  (e: 'navigationChange', _type: UserModalNavigationItemType): void
 }>()
 
 const items: {
-  type: NavigationItemType
+  type: UserModalNavigationItemType
   iconName: string
   iconMdi?: true
 }[] = [
@@ -48,7 +47,6 @@ const items: {
     iconMdi: true
   }
 ]
-const { onNavigationItemClick } = useNavigationSelectorItem(emit)
 </script>
 
 <style lang="scss" module>

--- a/src/components/Modal/UserModal/UserModal.vue
+++ b/src/components/Modal/UserModal/UserModal.vue
@@ -32,7 +32,6 @@
 <script lang="ts" setup>
 import { computed, reactive } from 'vue'
 import type { UserId } from '/@/types/entity-ids'
-import { type NavigationItemType } from './composables/useNavigation'
 import useUserDetail from './composables/useUserDetail'
 import { useModalStore } from '/@/store/ui/modal'
 import { useResponsiveStore } from '/@/store/ui/responsive'
@@ -43,10 +42,11 @@ import FeatureContainer from './FeatureContainer/FeatureContainer.vue'
 import NavigationSelector from './NavigationSelector.vue'
 import NavigationContent from './NavigationContent.vue'
 import CloseButton from '/@/components/UI/CloseButton.vue'
+import type { UserModalNavigationItemType } from '/@/store/ui/modal/states'
 
 const props = defineProps<{
   id: UserId
-  navigation?: NavigationItemType
+  navigation?: UserModalNavigationItemType
 }>()
 
 const { clearModal, replaceModal } = useModalStore()
@@ -65,7 +65,7 @@ const styles = reactive({
   }))
 })
 
-const onNavigationChange = (type: NavigationItemType) => {
+const onNavigationChange = (type: UserModalNavigationItemType) => {
   replaceModal({
     type: 'user',
     id: props.id,

--- a/src/components/Modal/UserModal/UserModal.vue
+++ b/src/components/Modal/UserModal/UserModal.vue
@@ -16,11 +16,11 @@
       <div :class="$style.content" :style="styles.content">
         <FeatureContainer :user="user" :detail="userDetail" />
         <NavigationSelector
-          :current-navigation="currentNavigation"
+          :current-navigation="navigation"
           @navigation-change="onNavigationChange"
         />
         <NavigationContent
-          :current-navigation="currentNavigation"
+          :current-navigation="navigation"
           :user="user"
           :detail="userDetail"
         />
@@ -30,9 +30,9 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive, toRef } from 'vue'
+import { computed, reactive } from 'vue'
 import type { UserId } from '/@/types/entity-ids'
-import { useNavigation } from './composables/useNavigation'
+import { type NavigationItemType } from './composables/useNavigation'
 import useUserDetail from './composables/useUserDetail'
 import { useModalStore } from '/@/store/ui/modal'
 import { useResponsiveStore } from '/@/store/ui/responsive'
@@ -46,9 +46,10 @@ import CloseButton from '/@/components/UI/CloseButton.vue'
 
 const props = defineProps<{
   id: UserId
+  navigation?: NavigationItemType
 }>()
 
-const { clearModal } = useModalStore()
+const { clearModal, replaceModal } = useModalStore()
 const { isMobile } = useResponsiveStore()
 const { usersMap } = useUsersStore()
 
@@ -64,8 +65,13 @@ const styles = reactive({
   }))
 })
 
-const { navigationSelectorState, onNavigationChange } = useNavigation()
-const currentNavigation = toRef(navigationSelectorState, 'currentNavigation')
+const onNavigationChange = (type: NavigationItemType) => {
+  replaceModal({
+    type: 'user',
+    id: props.id,
+    navigation: type
+  })
+}
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const user = computed(() => usersMap.value.get(props.id)!)

--- a/src/components/Modal/UserModal/composables/useNavigation.ts
+++ b/src/components/Modal/UserModal/composables/useNavigation.ts
@@ -1,8 +1,0 @@
-import createNavigation from '/@/composables/useAbstractNavigation'
-
-export type NavigationItemType = 'profile' | 'groups' | 'tags'
-
-export const { useNavigation, useNavigationSelectorItem } = createNavigation<
-  NavigationItemType,
-  'navigationChange'
->('profile', 'navigationChange')

--- a/src/store/ui/modal.ts
+++ b/src/store/ui/modal.ts
@@ -59,7 +59,7 @@ const useModalStorePinia = defineStore('ui/modal', () => {
       {
         ...history.state,
         // historyのstateにはproxyされたobjectは入らないのでtoRawする
-        modalState: [...toRaw(modalState.value), newModalState]
+        modalState: [...toRaw(modalState.value).slice(0, -1), newModalState]
       },
       ''
     )

--- a/src/store/ui/modal/states.ts
+++ b/src/store/ui/modal/states.ts
@@ -1,3 +1,4 @@
+import type { NavigationItemType as UserModalNavigationItemType } from '/@/components/Modal/UserModal/composables/useNavigation'
 import type { RouteName } from '/@/router'
 import type {
   UserId,
@@ -62,6 +63,7 @@ interface BaseModalState {
 interface UserModalState extends BaseModalState {
   type: 'user'
   id: UserId
+  navigation?: UserModalNavigationItemType
 }
 
 interface NotificationModalState extends BaseModalState {

--- a/src/store/ui/modal/states.ts
+++ b/src/store/ui/modal/states.ts
@@ -1,4 +1,3 @@
-import type { NavigationItemType as UserModalNavigationItemType } from '/@/components/Modal/UserModal/composables/useNavigation'
 import type { RouteName } from '/@/router'
 import type {
   UserId,
@@ -9,6 +8,8 @@ import type {
   MessageId,
   StampId
 } from '/@/types/entity-ids'
+
+export type UserModalNavigationItemType = 'profile' | 'groups' | 'tags'
 
 export type ModalStateType =
   | 'user'


### PR DESCRIPTION
## 概要
- feat: `UserModal` のナビゲーションの状態管理を `useNavigation` から `modalState` へ移行する
  - fix: `replaceModal` で既に閉じられた modal が `modalState` に残るバグを修正

closes: #4846

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう