### PR TITLE
feat: 引用と画像を同時に貼ったときに、メッセージのリンクとの間に空行を入れないようにする

### DIFF
--- a/src/components/Main/MainView/MessageInput/composables/usePostMessage.ts
+++ b/src/components/Main/MainView/MessageInput/composables/usePostMessage.ts
@@ -17,6 +17,7 @@ import { useChannelsStore } from '/@/store/entities/channels'
 import { useUsersStore } from '/@/store/entities/users'
 import { useGroupsStore } from '/@/store/entities/groups'
 import type { AxiosProgressEvent } from 'axios'
+import { isEmbeddedLink } from '/@/lib/markdown/markdown'
 
 /**
  * @param progress アップロード進行状況 0～1
@@ -45,9 +46,30 @@ const uploadAttachments = async (
   return responses.map(res => buildFilePathForPost(res.data.id))
 }
 
-const createContent = (embededText: string, fileUrls: string[]) => {
-  const embededUrls = fileUrls.join('\n')
-  return embededText + (embededText && embededUrls ? '\n\n' : '') + embededUrls
+const createContent = async (
+  embeddedText: string,
+  fileUrls: string[]
+) => {
+  const joinContents = (delimiter: string, contents: string[]) =>
+    contents.filter(Boolean).join(delimiter)
+
+  const embeddedUrls = fileUrls.join('\n')
+  const trimmedEmbeddedText = embeddedText.trimEnd()
+
+  if (trimmedEmbeddedText === '') {
+    return joinContents('\n', [embeddedText, embeddedUrls])
+  }
+
+  const trimmedEmbeddedTextLines = trimmedEmbeddedText.split(`\n`)
+
+  if (
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await isEmbeddedLink(trimmedEmbeddedTextLines.at(-1)!)
+  ) {
+    return joinContents('\n', [trimmedEmbeddedText, embeddedUrls])
+  }
+
+  return joinContents('\n\n', [embeddedText, embeddedUrls])
 }
 
 const usePostMessage = (
@@ -110,7 +132,7 @@ const usePostMessage = (
     const dummyFileUrls = state.attachments.map(() =>
       buildFilePathForPost(nullUuid)
     )
-    const dummyText = createContent(embededText, dummyFileUrls)
+    const dummyText = await createContent(embededText, dummyFileUrls)
     if (countLength(dummyText) > MESSAGE_MAX_LENGTH) {
       addErrorToast('メッセージが長すぎます')
       return
@@ -125,7 +147,7 @@ const usePostMessage = (
       })
 
       await apis.postMessage(cId, {
-        content: createContent(embededText, fileUrls)
+        content: await createContent(embededText, fileUrls)
       })
 
       clearState()

--- a/src/components/Main/MainView/MessageInput/composables/usePostMessage.ts
+++ b/src/components/Main/MainView/MessageInput/composables/usePostMessage.ts
@@ -46,7 +46,7 @@ const uploadAttachments = async (
   return responses.map(res => buildFilePathForPost(res.data.id))
 }
 
-const createContent = async (
+export const createContent = async (
   embeddedText: string,
   fileUrls: string[]
 ) => {

--- a/src/lib/markdown/markdown.ts
+++ b/src/lib/markdown/markdown.ts
@@ -6,6 +6,7 @@ import { useUsersStore } from '/@/store/entities/users'
 import { useChannelsStore } from '/@/store/entities/channels'
 import { useGroupsStore } from '/@/store/entities/groups'
 import { useStampsStore } from '/@/store/entities/stamps'
+import { isDefined } from '../basic/array'
 
 const storeProvider: Store = {
   getUser(id) {
@@ -81,4 +82,9 @@ export const renderInline = async (text: string) => {
 export const parse = async (text: string) => {
   await waitForInitialFetch()
   return md.md.parse(text, {})
+}
+
+export const isEmbeddedLink = async (text: string) => {
+  await waitForInitialFetch()
+  return isDefined(md.embeddingExtractor.urlToEmbeddingData(text))
 }

--- a/tests/unit/components/Main/MainView/MessageInput/composables/usePostMessage.spec.ts
+++ b/tests/unit/components/Main/MainView/MessageInput/composables/usePostMessage.spec.ts
@@ -1,0 +1,177 @@
+import { createTestingPinia } from '@pinia/testing'
+import { createContent } from '/@/components/Main/MainView/MessageInput/composables/usePostMessage'
+import { nullUuid } from '/@/lib/basic/uuid'
+import { buildFilePathForPost, embeddingOrigin } from '/@/lib/apis'
+import { vi } from 'vitest'
+
+vi.mock('/@/lib/markdown/markdown', () => ({
+  isEmbeddedLink: vi.fn((text: string) => text.startsWith(embeddingOrigin))
+}))
+
+describe('usePostMessage', () => {
+  describe('createContent', () => {
+    beforeAll(() => {
+      createTestingPinia()
+    })
+
+    it.each(TEST_CASES)('$description', async ({ input, files, expected }) => {
+      const content = await createContent(input, files ?? [])
+      expect(content).toBe(expected)
+    })
+  })
+})
+
+const FILES = ['fileUrl1', 'fileUrl2']
+const FILE_LINKS = FILES.join('\n')
+const LINK = buildFilePathForPost(nullUuid)
+const LINE_BREAKS = '\n\n\n\n\n'
+const SPACES = '     '
+
+interface TestCase {
+  description: string
+  input: string
+  files?: string[]
+  expected: string
+}
+
+const TEST_CASES: TestCase[] = [
+  {
+    description: 'empty',
+    input: '',
+    expected: ''
+  },
+  {
+    description: 'text',
+    input: 'test text',
+    expected: 'test text'
+  },
+  {
+    description: 'link',
+    input: LINK,
+    expected: LINK
+  },
+  {
+    description: 'text + link',
+    input: `test text\n${LINK}`,
+    expected: `test text\n${LINK}`
+  },
+  {
+    description: 'line breaks',
+    input: LINE_BREAKS,
+    expected: LINE_BREAKS
+  },
+  {
+    description: 'text + line breaks',
+    input: `test text${LINE_BREAKS}`,
+    expected: `test text${LINE_BREAKS}`
+  },
+  {
+    description: 'link + line breaks',
+    input: `${LINK}${LINE_BREAKS}`,
+    expected: `${LINK}`
+  },
+  {
+    description: 'text + link + line breaks',
+    input: `test text\n${LINK}${LINE_BREAKS}`,
+    expected: `test text\n${LINK}`
+  },
+  {
+    description: 'empty + files',
+    input: '',
+    files: FILES,
+    expected: FILE_LINKS
+  },
+  {
+    description: 'text + files',
+    input: 'test text',
+    files: FILES,
+    expected: `test text\n\n${FILE_LINKS}`
+  },
+  {
+    description: 'link + files',
+    input: LINK,
+    files: FILES,
+    expected: `${LINK}\n${FILE_LINKS}`
+  },
+  {
+    description: 'text + link + files',
+    input: `test text\n${LINK}`,
+    files: FILES,
+    expected: `test text\n${LINK}\n${FILE_LINKS}`
+  },
+  {
+    description: 'line breaks + files',
+    input: LINE_BREAKS,
+    files: FILES,
+    expected: `${LINE_BREAKS}\n${FILE_LINKS}`
+  },
+  {
+    description: 'text + line breaks + files',
+    input: `test text${LINE_BREAKS}`,
+    files: FILES,
+    expected: `test text${LINE_BREAKS}\n\n${FILE_LINKS}`
+  },
+  {
+    description: 'link + line breaks + files',
+    input: `${LINK}${LINE_BREAKS}`,
+    files: FILES,
+    expected: `${LINK}\n${FILE_LINKS}`
+  },
+  {
+    description: 'text + link + line breaks + files',
+    input: `test text\n${LINK}${LINE_BREAKS}`,
+    files: FILES,
+    expected: `test text\n${LINK}\n${FILE_LINKS}`
+  },
+  {
+    description: 'bullet point link + files',
+    input: `- ${LINK}`,
+    files: FILES,
+    expected: `- ${LINK}\n\n${FILE_LINKS}`
+  },
+  {
+    description: 'bullet point link + line breaks + files',
+    input: `- ${LINK}${LINE_BREAKS}`,
+    files: FILES,
+    expected: `- ${LINK}${LINE_BREAKS}\n\n${FILE_LINKS}`
+  },
+  {
+    description: 'spaces + files',
+    input: SPACES,
+    files: FILES,
+    expected: `${SPACES}\n${FILE_LINKS}`
+  },
+  {
+    description: 'text ending with space',
+    input: 'test text ',
+    expected: 'test text '
+  },
+  {
+    description: 'mixed whitespace',
+    input: ' \t\n ',
+    expected: ' \t\n '
+  },
+  {
+    description: 'mixed whitespace + files',
+    input: ' \t\n ',
+    files: FILES,
+    expected: ` \t\n \n${FILE_LINKS}`
+  },
+  {
+    description: 'text ending with newline',
+    input: 'test text\n',
+    expected: 'test text\n'
+  },
+  {
+    description: 'text ending with newline + files',
+    input: 'test text\n',
+    files: FILES,
+    expected: `test text\n\n\n${FILE_LINKS}`
+  },
+  {
+    description: 'link ending with newline + files',
+    input: `${LINK}\n`,
+    files: FILES,
+    expected: `${LINK}\n${FILE_LINKS}`
+  }
+]


### PR DESCRIPTION
## 概要
- 改行を除いた一番最後の行が埋め込みリンク かつ 添付ファイルがある ときには、改行の個数は一つにする
- https://github.com/traPtitech/traQ_S-UI/pull/1316 にあるように、改行を除いた最後の行がリンクではなく かつ 添付ファイルがある ときには改行の個数は二つにする
## なぜこの PR を入れたいのか
close: #3979

## 動作確認の手順
- テストを書いた

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう