### PR TITLE
fix: テンプレートリテラル中の null-handling を追加

### DIFF
--- a/src/components/Main/MainView/MessageInput/composables/usePostMessage.ts
+++ b/src/components/Main/MainView/MessageInput/composables/usePostMessage.ts
@@ -66,8 +66,9 @@ const usePostMessage = (
   const isForce = computed(() => channelsMap.value.get(unref(channelId))?.force)
   const confirmString = computed(
     () =>
-      `#${channelIdToShortPathString(
-        unref(channelId)
+      `${channelIdToShortPathString(
+        unref(channelId),
+        true
       )}に投稿されたメッセージは全員に通知されます。メッセージを投稿しますか？\n注) このチャンネルは重要な連絡以外には使用しないでください。`
   )
 

--- a/src/components/Main/NavigationBar/ChannelList/composables/usePath.ts
+++ b/src/components/Main/NavigationBar/ChannelList/composables/usePath.ts
@@ -31,7 +31,7 @@ export const usePath = (typedProps: TypedProps) => {
   )
   const pathTooltip = computed(() =>
     typedProps.showShortenedPath
-      ? `#${channelIdToPathString(typedProps.channel.id)}`
+      ? `${channelIdToPathString(typedProps.channel.id, true) ?? ''}`
       : undefined
   )
 

--- a/src/components/Modal/ChannelCreateModal/ChannelCreateModal.vue
+++ b/src/components/Modal/ChannelCreateModal/ChannelCreateModal.vue
@@ -154,7 +154,7 @@ const title = computed(
 )
 const subtitle = computed(() =>
   props.parentChannelId
-    ? `${channelIdToPathString(props.parentChannelId, true)}/`
+    ? `${channelIdToPathString(props.parentChannelId, true) ?? ''}/`
     : ''
 )
 const newChannelPath = computed(() => {

--- a/src/composables/document/useDocumentTitle.ts
+++ b/src/composables/document/useDocumentTitle.ts
@@ -14,12 +14,19 @@ const useDocumentTitle = () => {
     switch (primaryView.value.type) {
       case 'channel':
         try {
-          return `#${channelIdToShortPathString(primaryView.value.channelId)}`
+          const channel = channelIdToShortPathString(
+            primaryView.value.channelId,
+            true
+          )
+          if (channel) return channel
+          return ''
         } catch {
           return ''
         }
+
       case 'dm':
         return `@${primaryView.value.userName}`
+
       case 'clips':
         return (
           clipFoldersMap.value.get(primaryView.value.clipFolderId)?.name ??

--- a/src/lib/markdown/markdown.ts
+++ b/src/lib/markdown/markdown.ts
@@ -34,7 +34,7 @@ const storeProvider: Store = {
   },
   generateChannelHref(id) {
     const { channelIdToLink } = useChannelPath()
-    return `${embeddingOrigin}${channelIdToLink(id)}`
+    return `${embeddingOrigin}${channelIdToLink(id) as string}`
   },
   generateUserHref(id) {
     return `javascript:openUserModal(${encodeURIComponent(JSON.stringify(id))})`


### PR DESCRIPTION
ESlint の `@typescript-eslint/restrict-template-expressions` を有効にできないかと思って試したのですが、型情報の生成に時間が掛かりすぎていたので断念しました

## なぜこの PR を入れたいのか

- closes #4868

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
