### PR TITLE
fix: 一部の環境でテキスト置換の挙動がおかしくなる問題を修正

### DIFF
--- a/src/composables/dom/useInsertText.ts
+++ b/src/composables/dom/useInsertText.ts
@@ -1,27 +1,22 @@
-import { toValue, type MaybeRefOrGetter } from 'vue'
+import { type MaybeRefOrGetter, toValue } from 'vue'
 
-/**
- * これを利用したときはCtrl+Zなどがきく
- */
+import { insertText } from '/@/lib/dom/insertText'
+import { useResponsiveStore } from '/@/store/ui/responsive'
+
 const useInsertText = (
   textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>,
   targetRef?: MaybeRefOrGetter<{ begin: number; end: number }>
 ) => {
-  const insertText = (text: string) => {
-    const textarea = toValue(textareaRef)
-    if (!textarea) return
+  const { isMobile } = useResponsiveStore()
 
-    const target = toValue(targetRef)
+  return {
+    insertText: (text: string) => {
+      const textarea = toValue(textareaRef)
+      if (!textarea) return
 
-    textarea.setRangeText(
-      text,
-      target?.begin ?? textarea.selectionStart,
-      target?.end ?? textarea.selectionEnd,
-      'end'
-    )
+      insertText(textarea, text, toValue(targetRef), isMobile.value)
+    }
   }
-
-  return { insertText }
 }
 
 export default useInsertText

--- a/src/composables/dom/useInsertText.ts
+++ b/src/composables/dom/useInsertText.ts
@@ -1,27 +1,24 @@
-import type { Ref } from 'vue'
-
-import { insert } from 'text-field-edit'
+import { toValue, type MaybeRefOrGetter } from 'vue'
 
 /**
  * これを利用したときはCtrl+Zなどがきく
  */
 const useInsertText = (
-  textareaRef: Ref<HTMLTextAreaElement | undefined>,
-  target?: Ref<{ begin: number; end: number }>
+  textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>,
+  targetRef?: MaybeRefOrGetter<{ begin: number; end: number }>
 ) => {
   const insertText = (text: string) => {
-    if (!textareaRef.value) return
+    const textarea = toValue(textareaRef)
+    if (!textarea) return
 
-    if (target) {
-      textareaRef.value.selectionStart = target.value.begin
-      textareaRef.value.selectionEnd = target.value.end
-    }
+    const target = toValue(targetRef)
 
-    // Windowsでの\r\nを含む文字列を貼り付けた後に
-    // Ctrl+Zでアンドゥすると、キャレットの位置がずれるので
-    // ずれないように\nに統一しておく
-    const normalizedText = text.replaceAll('\r\n', '\n')
-    insert(textareaRef.value, normalizedText)
+    textarea.setRangeText(
+      text,
+      target?.begin ?? textarea.selectionStart,
+      target?.end ?? textarea.selectionEnd,
+      'end'
+    )
   }
 
   return { insertText }

--- a/src/lib/dom/insertText.ts
+++ b/src/lib/dom/insertText.ts
@@ -1,0 +1,28 @@
+export const insertText = (
+  textarea: HTMLTextAreaElement,
+  text: string,
+  target: {
+    begin?: number
+    end?: number
+  } = {},
+  isMobile = false
+) => {
+  // `execCommand` は deprecated だが，`setRangeText` は undo できなくなってしまうので，PC の場合は `execCommand` を用いる．
+  // `execCommand` は主にモバイル端末での挙動が怪しいので，それを改善するためのワークアラウンド．
+  if (isMobile) {
+    textarea.setRangeText(
+      text,
+      target?.begin ?? textarea.selectionStart,
+      target?.end ?? textarea.selectionEnd,
+      'end'
+    )
+  } else {
+    if (target?.begin) textarea.selectionStart = target.begin
+    if (target?.end) textarea.selectionEnd = target.end
+
+    // Windowsでの\r\nを含む文字列を貼り付けた後に
+    // Ctrl+Zでアンドゥすると、キャレットの位置がずれるので
+    // ずれないように\nに統一しておく
+    document.execCommand('insertText', false, text.replaceAll('\r\n', '\n'))
+  }
+}

--- a/src/store/ui/responsive.ts
+++ b/src/store/ui/responsive.ts
@@ -6,10 +6,8 @@ import { mobileMinBreakpoint } from '/@/lib/media'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 
 const useResponsiveStorePinia = defineStore('ui/responsive', () => {
-  const queryList = window.matchMedia(`(max-width: ${mobileMinBreakpoint}px)`)
-  const isHoverSupported = window.matchMedia(
-    '(hover: hover) and (pointer: fine)'
-  )
+  const queryList = matchMedia(`(max-width: ${mobileMinBreakpoint}px)`)
+  const isHoverSupported = matchMedia('(hover: hover) and (pointer: fine)')
 
   const isMobile = ref(queryList.matches)
   const isTouchDevice = ref(!isHoverSupported.matches)

--- a/tests/unit/mocks/index.ts
+++ b/tests/unit/mocks/index.ts
@@ -1,0 +1,1 @@
+import './matchMedia'

--- a/tests/unit/mocks/matchMedia.ts
+++ b/tests/unit/mocks/matchMedia.ts
@@ -1,0 +1,11 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vitest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vitest.fn(),
+    removeEventListener: vitest.fn(),
+    dispatchEvent: vitest.fn()
+  }))
+})

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,3 +1,5 @@
+import './mocks'
+
 window.traQConfig = {
   firebase: {
     apiKey: '',


### PR DESCRIPTION
## 概要
- fix: 非推奨の insert API の代わりに setRangeText を利用する
- https://github.com/traPtitech/traQ_S-UI/pull/4836 から切り出しました

文脈: https://q.trap.jp/messages/0199cb80-5c7d-7b3c-8d87-1833ed050b24

## なぜこの PR を入れたいのか
- 非推奨で，挙動も怪しいため

## 動作確認の手順
- 実際に補完等のテキスト置換が行われる操作をしてみて、現在と変わらないか、あるいはヘンな挙動が改善されているかを確認する

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう