### PR TITLE
chore(formatting): `.prettierrc` から `filepath: none` を取り除く

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -23,7 +23,6 @@
   "bracketSameLine": false,
   "arrowParens": "avoid",
   "rangeStart": 0,
-  "filepath": "none",
   "requirePragma": false,
   "insertPragma": false,
   "proseWrap": "preserve",


### PR DESCRIPTION
## 概要

cf. https://prettier.io/docs/options#file-path:~:text=This%20option%20is%20only%20useful%20in%20the%20CLI%20and%20API.%20It%20doesn%E2%80%99t%20make%20sense%20to%20use%20it%20in%20a%20configuration%20file

## なぜこの PR を入れたいのか
- しばしば VS Code の Prettier プラグインと `npm run format` が競合する

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう