### PR TITLE
引用メッセージの画像やファイルをクリック遷移対応にする

### DIFF
--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageFileSummaryFile.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageFileSummaryFile.vue
@@ -1,12 +1,12 @@
 <template>
-  <div :class="$style.container">
+  <RouterLink :to="fileLink" :class="$style.container" @click.stop>
     <FileTypeIcon
       :type="fileType"
       :size="24"
       :is-animated-image="isAnimatedImage"
     />
     <div>{{ fileMeta?.name ?? 'unknown' }}</div>
-  </div>
+  </RouterLink>
 </template>
 
 <script lang="ts" setup>
@@ -18,7 +18,7 @@ const props = defineProps<{
   fileId: FileId
 }>()
 
-const { fileType, fileMeta, isAnimatedImage } = useFileMeta(props)
+const { fileType, fileMeta, fileLink, isAnimatedImage } = useFileMeta(props)
 </script>
 
 <style lang="scss" module>

--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageFileSummaryImage.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageFileSummaryImage.vue
@@ -1,7 +1,12 @@
 <template>
-  <div :class="$style.container" :style="containerStyle">
+  <RouterLink
+    :to="fileLink"
+    :class="$style.container"
+    :style="containerStyle"
+    @click.stop
+  >
     <PlayIcon v-if="isAnimatedImage" :class="$style.playIcon" />
-  </div>
+  </RouterLink>
 </template>
 
 <script lang="ts" setup>
@@ -15,7 +20,7 @@ const props = defineProps<{
   fileId: FileId
 }>()
 
-const { fileThumbnailPath, isAnimatedImage } = useFileThumbnail(props)
+const { fileLink, fileThumbnailPath, isAnimatedImage } = useFileThumbnail(props)
 const containerStyle = computed(() => ({
   backgroundImage: `url(${fileThumbnailPath.value})`
 }))


### PR DESCRIPTION
## 概要

ファイルサマリー（ファイル/画像）の外枠を RouterLink 化してファイル詳細へ遷移できるように

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

- 任意のメッセージでファイルサマリーをクリックし、ファイル詳細画面へ遷移できる
- メッセージ検索でファイルをクリックしたときに、正常にファイル詳細画面へ遷移できる

## UI 変更部分のスクリーンショット

なし

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
    - 本番環境以外で検索のファイルの動作確認ができない
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
