### PR TITLE
fix(message-scroller): スタンプ取得完了前に表示されたチャンネルのスクロール位置が上にずれる問題を修正

### DIFF
--- a/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
+++ b/src/components/Main/MainView/MessagesScroller/MessagesScroller.vue
@@ -178,16 +178,23 @@ onMounted(() => {
     state.height = rootRef.value?.scrollHeight ?? 0
   }
 })
+
 // マウント後にstampの取得が完了した場合
-watch(stampsMapFetched, async fetched => {
-  if (fetched && rootRef.value) {
+watch(
+  stampsMapFetched,
+  async fetched => {
+    if (!fetched || !rootRef.value) return
+
     await nextTick()
     const scrollHeight = rootRef.value.scrollHeight
     rootRef.value.scrollTop = scrollHeight
     state.height = scrollHeight
     state.scrollTop = scrollHeight
+  },
+  {
+    flush: 'post'
   }
-})
+)
 
 watch(
   () => props.messageIds,


### PR DESCRIPTION
## 概要
- ウォッチャーに `flush: 'post'` を与えた

## なぜこの PR を入れたいのか
- feedback: https://q.trap.jp/channels/services/feedback?message=019a70a2-175c-72db-b75b-25bf9d095f59 (一部)

## 動作確認の手順
- いろんなチャンネルにアクセスしてみて，最下部までスクロールされることを確認する (画像付き引用があるとズレるので，これは別途修正する必要がある)

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
