### PR TITLE
fix: ファイルサマリー付き引用を持つメッセージが存在した場合のレイアウトシフトを抑制

### DIFF
--- a/src/components/Main/MainView/MessageElement/composables/useElementRenderObserver.ts
+++ b/src/components/Main/MainView/MessageElement/composables/useElementRenderObserver.ts
@@ -18,6 +18,7 @@ const useElementRenderObserver = (
   isEntryMessage: Ref<boolean> | boolean,
   messageId: Ref<string>,
   embeddingsState: Readonly<{
+    quoteMessageIds: readonly MessageId[]
     fileIds: readonly FileId[]
     externalUrls: readonly ExternalUrl[]
   }>,
@@ -65,12 +66,13 @@ const useElementRenderObserver = (
     () => {
       if (
         (unref(isEntryMessage) ||
+          embeddingsState.quoteMessageIds.length > 0 ||
           embeddingsState.fileIds.length > 0 ||
           embeddingsState.externalUrls.length > 0) &&
         bodyRef.value
       ) {
         /*
-          添付ファイル/外部URLがある場合か
+          引用 / 添付ファイル / 外部URL がある場合か
           エントリーメッセージは
           高さ監視をする
         */


### PR DESCRIPTION
## 概要

- メッセージの高さが変更されても changeHeight イベントが emit されない場合があったので，emit するようにした (発生確率小)
- 引用メッセージの高さが変化しうるようになった (引用の詳細を fetch する必要があるため) が，ResizeObserver に登録されない場合があったので，「引用を一件以上持つ」ことをサイズ監視の条件に加えた (発生確率大)

## なぜこの PR を入れたいのか
- https://q.trap.jp/channels/services/feedback?message=019a70a2-175c-72db-b75b-25bf9d095f59

## 動作確認の手順
- [#gps/mikke](https://q.trap.jp/channels/gps/mikke) あたりがわかりやすい

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
