### PR TITLE
fix(stamp-element): スタンプホバー時の表示が残り続ける問題を修正

### DIFF
--- a/src/composables/dom/useHover.ts
+++ b/src/composables/dom/useHover.ts
@@ -3,18 +3,32 @@ import useToggle from '/@/composables/utils/useToggle'
 const useHover = (delay: number = 0) => {
   const { value, open, close } = useToggle()
   let timeoutId: NodeJS.Timeout | null = null
+  let hoverTarget: EventTarget | null = null
 
-  const onMouseEnter = () => {
+  const onMouseEnter = (e?: MouseEvent) => {
+    hoverTarget = e?.currentTarget ?? null
+
     if (delay <= 0) {
       open()
     } else {
+      if (timeoutId) clearTimeout(timeoutId)
+
       timeoutId = setTimeout(() => {
+        timeoutId = null
+
+        // 実際にまだホバー中かどうかを確認（要素がある場合のみ）
+        if (hoverTarget instanceof Element && !hoverTarget.matches(':hover')) {
+          return
+        }
+
         open()
       }, delay)
     }
   }
 
   const onMouseLeave = () => {
+    hoverTarget = null
+
     if (timeoutId) {
       clearTimeout(timeoutId)
       timeoutId = null


### PR DESCRIPTION
## 概要

- 「『ホバーした後に一度クリックしてから離す』を 500ms 以内に行う」が再現の条件

## なぜこの PR を入れたいのか

- https://q.trap.jp/messages/019a7236-ef5a-76bf-87ae-151d92dd64eb
- https://q.trap.jp/messages/019a7577-ea4e-7ee2-8c8b-48fb15dc21ab

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
