### PR TITLE
fix(channel−view): `ChannelHeaderRelationButton` が `ChannelHeader` からはみ出ないようにする

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeader.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeader.vue
@@ -40,6 +40,7 @@ defineProps<{
   display: flex;
   align-items: center;
   overflow-x: auto;
+  overflow-y: hidden;
   margin-bottom: -6px;
 }
 .topic {

--- a/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationButton.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelHeader/ChannelHeaderRelationButton.vue
@@ -93,7 +93,7 @@ const focusTrigger = () => {
 
   cursor: pointer;
   overflow: hidden;
-  height: 32px;
+  height: 100%;
   width: 24px;
   margin: 0 8px;
   display: grid;


### PR DESCRIPTION
## 概要
- ブラウザのフォントサイズを「中」未満にしたとき，関連チャンネルボタンをホバーするとチャンネルヘッダーの右端に余計なスクロールバーが表示されてしまうのを改善

## なぜこの PR を入れたいのか
- :o_o_fake: に指摘された

### before
https://github.com/user-attachments/assets/5fee9c00-be54-4853-b327-c0f460e1258c

### after
https://github.com/user-attachments/assets/f997d357-d6d3-433a-8c20-cfe9762cc235


## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
