### PR TITLE
chore(localhost-certs): `localhost-certs` の権限問題を解決

### DIFF
--- a/build/gen-localhost-certs.sh
+++ b/build/gen-localhost-certs.sh
@@ -3,6 +3,8 @@
 SCRIPT_DIR=$(dirname "$0")
 cd "$SCRIPT_DIR/.."
 
+mkdir -p .certs
+
 docker run --rm \
     --mount type=bind,source=./.certs,target=/certs \
     alpine/mkcert@sha256:a8f4f5af61908b4c79c2e9d1e5f23e747f29de174649209ebafcab03d4f6d5fd \


### PR DESCRIPTION
## 概要
- root 権限で生成されてしまっていた

## なぜこの PR を入れたいのか
- 環境によっては `npm run dev` や `npm run localhost-certs:rem` で `Permission denied` となる

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
