### PR TITLE
feat(settings): shift + enter での送信をデフォルトで無効に

### DIFF
--- a/src/store/app/browserSettings.ts
+++ b/src/store/app/browserSettings.ts
@@ -58,7 +58,7 @@ const useBrowserSettingsPinia = defineStore('app/browserSettings', () => {
     lastOpenChannelName: 'general',
     openChannelName: 'general',
     sendWithModifierKey: 'modifier',
-    modifierKey: { alt: true, ctrl: true, shift: true, macCtrl: true },
+    modifierKey: { alt: true, ctrl: true, shift: false, macCtrl: true },
     ecoMode: false,
     prioritizeStarredChannel: true,
     prioritizeNotifiedChannel: true,


### PR DESCRIPTION
## 概要

As titled

## なぜこの PR を入れたいのか

一般的に shift + enter には改行が割り当てられているサービスが多いため、traQがデフォルトで shift + enter を送信にしていると他のサービスに慣れたユーザーが誤送信しやすくなる

## 動作確認の手順

## UI 変更部分のスクリーンショット

なし

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
