### PR TITLE
dependabot で `workbox-* の pattern を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
       patches:
         update-types:
           - 'patch'
+        exclude-patterns:
+          - '@types/*'
+          - '*eslint*'
+          - '*prettier*'
+          - 'workbox-*'
   - package-ecosystem: docker
     directory: '/'
     schedule:


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

- `workbox-*` 関連の dependabot PR が別々に立っていたこと
- これらの パッケージが別ではなく、同一のバージョンで管理されていること

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

CI の pass

## UI 変更部分のスクリーンショット

なし

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Dependabot設定を更新し、依存関係の自動グループ化と特定パターンのパッチアップデート除外設定を追加しました。これにより、依存関係の管理プロセスがより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->