### PR TITLE
fix: referrerpolicy をiframeから削除

### DIFF
--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpEmbed.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpEmbed.vue
@@ -6,7 +6,6 @@
       :class="$style.content"
       allowfullscreen
       allow="fullscreen; autoplay; encrypted-media; picture-in-picture"
-      referrerpolicy="no-referrer"
     />
     <template v-else>
       <img :src="previewUrl" :class="$style.image" />


### PR DESCRIPTION
## 概要

`src/components/Main/MainView/MessageElement/Embeddings/MessageOgpEmbed.vue` にある埋め込みについて、 `referrerpolicy="no-referrer"` を削除

## なぜこの PR を入れたいのか

close #4978

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

youtubeの動画が正しく埋め込まれるようになった
<img width="1182" height="787" alt="image" src="https://github.com/user-attachments/assets/da420512-deb0-4be6-85b5-b0234c5dbdcb" />

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
 referrerpolicy をiframeから削除することで別の問題が発生しないかどうか