### PR TITLE
:wrench: traP Collectionをサービス一覧に追加

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -94,6 +94,11 @@
         label: 'rucQ',
         iconPath: 'rucq.svg',
         appLink: 'https://rucq.trap.jp/'
+      },
+      {
+        label: 'traP Collection',
+        iconPath: 'traPCollection.svg',
+        appLink: 'https://collection.trap.jp/'
       }
     ],
     ogpIgnoreHostNames: [

--- a/public/img/services/traPCollection.svg
+++ b/public/img/services/traPCollection.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="_レイヤー_2" data-name="レイヤー 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 145">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: currentColor;
+      }
+    </style>
+  </defs>
+  <g id="_レイヤー_1-2" data-name="レイヤー 1">
+    <rect class="cls-1" x="5" width="65" height="30"/>
+    <rect class="cls-1" x="80" width="65" height="30"/>
+    <polygon class="cls-1" points="80 35 80 65 120 65 120 80 150 80 150 35 80 35"/>
+    <polygon class="cls-1" points="70 65 70 35 0 35 0 85 30 85 30 65 70 65"/>
+    <polygon class="cls-1" points="0 95 0 145 70 145 70 115 30 115 30 95 0 95"/>
+    <polygon class="cls-1" points="80 115 120 115 120 100 150 100 150 145 80 145 80 115"/>
+    <rect class="cls-1" x="85" y="80" width="10" height="20"/>
+    <rect class="cls-1" x="55" y="80" width="10" height="20"/>
+  </g>
+</svg>


### PR DESCRIPTION
## 概要

traP Collectionのサービスロゴとリンクをサービス一覧に追加する

## なぜこの PR を入れたいのか

サービスロゴを作ってもらったため

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

サービス一覧を見る

## UI 変更部分のスクリーンショット

### before

<img width="540" height="389" alt="image" src="https://github.com/user-attachments/assets/1630b45c-e177-43ef-89d7-944fbfcb3c7e" />

### after

<img width="560" height="410" alt="image" src="https://github.com/user-attachments/assets/9a79f46f-4bce-4cac-8ce4-8bb2684427f1" />


## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
