### PR TITLE
Reapply #4894, #4988

### DIFF
--- a/src/composables/dom/useInsertText.ts
+++ b/src/composables/dom/useInsertText.ts
@@ -1,29 +1,22 @@
-import { type MaybeRefOrGetter, type Ref, toValue } from 'vue'
+import { type MaybeRefOrGetter, toValue } from 'vue'
 
-import { insert } from 'text-field-edit'
+import useResponsive from '/@/composables/useResponsive'
+import { insertText } from '/@/lib/dom/insertText'
 
 const useInsertText = (
   textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>,
-  target?: Ref<{ begin: number; end: number }>
+  targetRef?: MaybeRefOrGetter<{ begin: number; end: number }>
 ) => {
-  const insertText = (text: string) => {
-    const textarea = toValue(textareaRef)
+  const { isMobile } = useResponsive()
 
-    if (!textarea) return
+  return {
+    insertText: (text: string) => {
+      const textarea = toValue(textareaRef)
+      if (!textarea) return
 
-    if (target) {
-      textarea.selectionStart = target.value.begin
-      textarea.selectionEnd = target.value.end
+      insertText(textarea, text, toValue(targetRef), isMobile.value)
     }
-
-    // Windowsでの\r\nを含む文字列を貼り付けた後に
-    // Ctrl+Zでアンドゥすると、キャレットの位置がずれるので
-    // ずれないように\nに統一しておく
-    const normalizedText = text.replaceAll('\r\n', '\n')
-    insert(textarea, normalizedText)
   }
-
-  return { insertText }
 }
 
 export default useInsertText

--- a/src/lib/dom/insertText.ts
+++ b/src/lib/dom/insertText.ts
@@ -1,0 +1,32 @@
+import { insert } from 'text-field-edit'
+
+import { isDefined } from '/@/lib/basic/array'
+
+export const insertText = (
+  textarea: HTMLTextAreaElement,
+  text: string,
+  target: {
+    begin?: number
+    end?: number
+  } = {},
+  isMobile = false
+) => {
+  // `execCommand` は deprecated だが，`setRangeText` は undo できなくなってしまうので，PC の場合は `execCommand` を用いる．
+  // `execCommand` は主にモバイル端末での挙動が怪しいので，それを改善するためのワークアラウンド．
+  if (isMobile) {
+    textarea.setRangeText(
+      text,
+      target?.begin ?? textarea.selectionStart,
+      target?.end ?? textarea.selectionEnd,
+      'end'
+    )
+  } else {
+    if (isDefined(target?.begin)) textarea.selectionStart = target.begin
+    if (isDefined(target?.end)) textarea.selectionEnd = target.end
+
+    // Windowsでの\r\nを含む文字列を貼り付けた後に
+    // Ctrl+Zでアンドゥすると、キャレットの位置がずれるので
+    // ずれないように\nに統一しておく
+    insert(textarea, text.replaceAll('\r\n', '\n'))
+  }
+}

--- a/src/lib/dom/insertText.ts
+++ b/src/lib/dom/insertText.ts
@@ -20,6 +20,8 @@ export const insertText = (
       target?.end ?? textarea.selectionEnd,
       'end'
     )
+
+    textarea.dispatchEvent(new Event('input'))
   } else {
     if (isDefined(target?.begin)) textarea.selectionStart = target.begin
     if (isDefined(target?.end)) textarea.selectionEnd = target.end

--- a/tests/unit/composables/dom/useInsertText.spec.ts
+++ b/tests/unit/composables/dom/useInsertText.spec.ts
@@ -1,0 +1,44 @@
+import useInsertTextWithoutSetup from '/@/composables/dom/useInsertText'
+
+import { setupMatchMedia } from '../../mocks/matchMedia'
+import { withSetup } from '../../testUtils'
+
+const useInsertText = withSetup(useInsertTextWithoutSetup)
+
+describe('useInsertText', () => {
+  it('uses the non-mobile insertText path when matchMedia does not match', () => {
+    setupMatchMedia(false)
+    const textarea = document.createElement('textarea')
+    textarea.value = 'before after'
+    textarea.setSelectionRange(7, 12)
+    document.body.appendChild(textarea)
+    textarea.focus()
+    const execCommand = vi.spyOn(document, 'execCommand')
+    const [{ insertText }, { unmount }] = useInsertText(textarea)
+
+    insertText('new')
+
+    expect(execCommand).toHaveBeenCalledWith('insertText', false, 'new')
+    expect(textarea.value).toBe('before new')
+    unmount()
+    textarea.remove()
+  })
+
+  it('uses the mobile insertText path when matchMedia matches', () => {
+    setupMatchMedia(true)
+    const textarea = document.createElement('textarea')
+    textarea.value = 'before after'
+    textarea.setSelectionRange(7, 12)
+    const setRangeText = vi.spyOn(textarea, 'setRangeText')
+    const onInput = vi.fn()
+    textarea.addEventListener('input', onInput)
+    const [{ insertText }, { unmount }] = useInsertText(textarea)
+
+    insertText('new')
+
+    expect(setRangeText).toHaveBeenCalledWith('new', 7, 12, 'end')
+    expect(onInput).toHaveBeenCalledOnce()
+    unmount()
+    setupMatchMedia()
+  })
+})

--- a/tests/unit/lib/dom/insertText.spec.ts
+++ b/tests/unit/lib/dom/insertText.spec.ts
@@ -1,0 +1,44 @@
+import { insertText } from '/@/lib/dom/insertText'
+
+describe('insertText', () => {
+  let textarea: HTMLTextAreaElement
+
+  beforeEach(() => {
+    textarea = document.createElement('textarea')
+    textarea.value = 'before after'
+  })
+
+  afterEach(() => {
+    textarea.remove()
+  })
+
+  it('uses setRangeText with the current selection and dispatches input on mobile', () => {
+    textarea.setSelectionRange(7, 12)
+    const setRangeText = vi.spyOn(textarea, 'setRangeText')
+    const onInput = vi.fn()
+    textarea.addEventListener('input', onInput)
+
+    insertText(textarea, 'new', undefined, true)
+
+    expect(setRangeText).toHaveBeenCalledWith('new', 7, 12, 'end')
+    expect(onInput).toHaveBeenCalledOnce()
+  })
+
+  it('keeps using the non-mobile insertion path by default', () => {
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    insertText(textarea, 'new', { begin: 7, end: 12 })
+
+    expect(textarea.value).toBe('before new')
+  })
+
+  it('normalizes \\r\\n to \\n on the non-mobile insertion path', () => {
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    insertText(textarea, 'line1\r\nline2', { begin: 7, end: 12 })
+
+    expect(textarea.value).toBe('before line1\nline2')
+  })
+})

--- a/tests/unit/mocks/index.ts
+++ b/tests/unit/mocks/index.ts
@@ -1,1 +1,2 @@
 import './execCommand'
+import './matchMedia'

--- a/tests/unit/mocks/matchMedia.ts
+++ b/tests/unit/mocks/matchMedia.ts
@@ -1,0 +1,11 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vitest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vitest.fn(),
+    removeEventListener: vitest.fn(),
+    dispatchEvent: vitest.fn()
+  }))
+})

--- a/tests/unit/mocks/matchMedia.ts
+++ b/tests/unit/mocks/matchMedia.ts
@@ -1,11 +1,16 @@
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vitest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addEventListener: vitest.fn(),
-    removeEventListener: vitest.fn(),
-    dispatchEvent: vitest.fn()
-  }))
-})
+export const setupMatchMedia = (matches = false) => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vitest.fn().mockImplementation(query => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vitest.fn(),
+      removeEventListener: vitest.fn(),
+      dispatchEvent: vitest.fn()
+    }))
+  })
+}
+
+setupMatchMedia()


### PR DESCRIPTION
## 概要
`setRangeText` を呼んだときも `input` イベントが発火するようにした

## なぜこの PR を入れたいのか

文脈: 
- https://q.trap.jp/channels/team/SysAd/traQ/Client?message=019b598a-67c8-7474-9464-02952474031f
- https://q.trap.jp/channels/services/feedback?message=019b5975-6e6e-7445-b6fc-edf48a982594

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * テキスト挿入が端末に応じて最適化され、より自然に動作するようになりました。
* **Bug Fixes**
  * 改行を含む貼り付け後のカーソル位置ずれや挙動の不安定さを抑制しました。
  * 選択範囲を指定した挿入の反映が安定し、入力位置の扱いが改善されました。
* **Tests**
  * モバイル/非モバイルの挿入挙動をユニットテストで検証できるよう、差し替え用モックを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->