### PR TITLE
fix: ドラッグの終了判定を緩和する

### DIFF
--- a/src/components/Main/NavigationBar/DesktopNavigationBar.vue
+++ b/src/components/Main/NavigationBar/DesktopNavigationBar.vue
@@ -42,6 +42,7 @@
       @pointerdown="onDragStart"
       @pointermove="onDragging"
       @pointerup="onDragEnd"
+      @pointercancel="onDragEnd"
       @dblclick="initializeNavigationWidth"
     />
   </div>

--- a/src/composables/dom/useDragging.ts
+++ b/src/composables/dom/useDragging.ts
@@ -1,0 +1,81 @@
+import { type MaybeRefOrGetter, onBeforeUnmount, ref, toValue } from 'vue'
+
+import { useEventListener } from '@vueuse/core'
+
+interface UseDraggingOptions {
+  targetRef: MaybeRefOrGetter<HTMLElement | null | undefined>
+  onDragStart?: (e: PointerEvent) => void
+  onDragging?: (e: PointerEvent) => void
+  onDragEnd?: () => void
+}
+
+const useDragging = ({
+  targetRef,
+  onDragStart,
+  onDragging,
+  onDragEnd
+}: UseDraggingOptions) => {
+  const isDragging = ref(false)
+  let pointerId: null | number = null
+
+  const handleDragStart = (e: PointerEvent) => {
+    const target = toValue(targetRef)
+
+    isDragging.value = true
+
+    pointerId = e.pointerId
+    target?.setPointerCapture(pointerId)
+
+    onDragStart?.(e)
+    e.preventDefault()
+  }
+
+  const handleDragging = (e: PointerEvent) => {
+    if (!isDragging.value) return
+
+    onDragging?.(e)
+    e.preventDefault()
+  }
+
+  const handleDragEnd = () => {
+    if (!isDragging.value) return
+    isDragging.value = false
+
+    const target = toValue(targetRef)
+
+    if (pointerId && target?.hasPointerCapture(pointerId)) {
+      target?.releasePointerCapture(pointerId)
+    }
+
+    pointerId = null
+
+    onDragEnd?.()
+  }
+
+  const handleVisibilityChange = () => {
+    if (document.hidden) {
+      handleDragEnd()
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      handleDragEnd()
+    }
+  }
+
+  useEventListener(['blur', 'pagehide'], handleDragEnd)
+  useEventListener(document, 'contextmenu', handleDragEnd)
+  useEventListener(document, 'visibilitychange', handleVisibilityChange)
+  useEventListener(document, 'keydown', handleKeyDown)
+  onBeforeUnmount(handleDragEnd)
+
+  return {
+    isDragging,
+    onDragStart: handleDragStart,
+    onDragging: handleDragging,
+    onDragEnd: handleDragEnd
+  }
+}
+
+export default useDragging


### PR DESCRIPTION
## 概要
- ドラッグ中，pointerup が発火する前にキーボード操作等でフォーカスが切り替わるとドラッグの継続判定が残り続ける不具合があったのを修正．
  - 以下の場合にもドラッグが終了したと判定する：
    - Escape キーが押下されたとき
    - `pointercancel` イベントが発火したとき
    - `document` の `contextmenu` イベントが発火したとき
    - `document` の `changevisivility` イベントが発火し， hidden となったとき
    - `window` の `blur` イベントが発火したとき
- https://github.com/traPtitech/traQ_S-UI/pull/4890 に依存しています

## なぜこの PR を入れたいのか
- このへん：https://q.trap.jp/messages/019b695e-8649-7f22-a59b-cdfe7b47a531

## PR を出す前の確認事項
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう
