### PR TITLE
ui: モバイルで画像が小さくなりがちな問題を修正

### DIFF
--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageFileListImage.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageFileListImage.vue
@@ -86,11 +86,9 @@ const {
   }
   max-width: 100%;
   img {
-    height: 100%;
-    width: auto;
+    width: clamp(100px, 100%, 600px);
+    height: auto;
     max-height: 450px;
-    max-width: min(600px, 100%);
-    min-width: 100px;
     object-fit: contain;
     cursor: pointer;
   }


### PR DESCRIPTION
## 概要

サイズの主導をheight: 100%からwidth: 100%に変更

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

モバイル端末の場合min-width: 100pxが尊重されて画像サイズが極端に小さくなる

## 動作確認の手順

## UI 変更部分のスクリーンショット

|Before|After|
|-|-|
![image](https://github.com/user-attachments/assets/bfc36ca8-66c9-4adc-acf8-ba1814cd9bd0)|![image](https://github.com/user-attachments/assets/6c277e6b-dcc9-4a2e-a87a-bbea48c6ee51)|

また、PCではサイズが変わらないことを確認

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

最小幅は100pxのままで良いか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 画像表示のサイズ計算ロジックを改善し、より適切なレスポンシブ表示を実現しました。画像は画面サイズに応じて最適な大きさで表示されるようになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->