### PR TITLE
chore: PR templateのbefore/afterをtableにする

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/en.md
+++ b/.github/PULL_REQUEST_TEMPLATE/en.md
@@ -8,9 +8,9 @@
 
 ## ScreenShots of UI Changes
 
-|Before|After|
-|------|-----|
-|<!-- Paste image -->|<!-- Paste image -->|
+| Before               | After                |
+| -------------------- | -------------------- |
+| <!-- Paste image --> | <!-- Paste image --> |
 
 ## Pre-PR Check-List
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,9 @@
 
 ## UI 変更部分のスクリーンショット
 
-|Before|After|
-|------|-----|
-|<!-- Paste image -->|<!-- Paste image -->|
+| Before               | After                |
+| -------------------- | -------------------- |
+| <!-- Paste image --> | <!-- Paste image --> |
 
 ## PR を出す前の確認事項
 


### PR DESCRIPTION
## 概要

画像をそのまま貼ると幅いっぱいに広がって見にくいためテーブルにして左右分割して見れるようにする

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

### before

### after

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * プルリクエストテンプレートのUIスクリーンショットセクションを改善しました。従来の「Before」「After」見出しと個別プレースホルダーを廃止し、Before／Afterを並べて表示するマークダウン表形式に変更。表示が整理され、比較が分かりやすくなります（機能変更なし、テンプレートの書式調整のみ）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->