### PR TITLE
2文字のチャンネルまではそのまま表示するように

### DIFF
--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -171,11 +171,13 @@ const useChannelPath = () => {
 
     const channelIds = simpleChannels.map(c => c.id)
     const channelNames = simpleChannels.map(c => c.name)
-    const channelInitials = channelNames.map(c => c[0] ?? '')
+    const channelShortenedNames = channelNames.map(name =>
+      name.length <= 2 ? name : (name[0] ?? '')
+    )
 
     // r/g/p/child
     const primitiveChannels = [
-      ...channelInitials.slice(0, -1),
+      ...channelShortenedNames.slice(0, -1),
       channelNames[channelsLength - 1] ?? ''
     ]
     if (primitiveChannels.join('/').length >= MAX_SHORT_PATH_LENGTH) {
@@ -240,7 +242,7 @@ const useChannelPath = () => {
         replaceInitialChannels.join('/').length > MAX_SHORT_PATH_LENGTH &&
         replaceInitialIndex < channelsLength - 2
       ) {
-        const indexinitial = channelInitials[replaceInitialIndex]
+        const indexinitial = channelShortenedNames[replaceInitialIndex]
         if (indexinitial !== undefined) {
           replaceInitialChannels[replaceInitialIndex] = indexinitial
         }


### PR DESCRIPTION
## 概要

title のとおり

## なぜこの PR を入れたいのか

times チャンネル移行によって times/22/... となってるが、アクティビティや通知上だと非常に見づらいので2文字までは許容することにする

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

<img width="255" height="129" alt="image" src="https://github.com/user-attachments/assets/5e4669bd-3d9f-4359-a265-f882be6c8d49" />


| Before               | After                |
| -------------------- | -------------------- |
| <!-- Paste image --> | <!-- Paste image --> |

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * チャネル名の短縮表示ルールを改善しました。2文字以下の名前はそのまま表示され、それより長い名前は先頭1文字のみで表示されます。
  * チャネルパスや関連する表示領域でこの短縮ルールが一貫して適用され、表示の統一性と可読性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->