### PR TITLE
feat(image-viewer): 同メッセージ内の複数画像を連続して閲覧できるようにする

### DIFF
--- a/src/components/Modal/FileModal/FileModalImage.vue
+++ b/src/components/Modal/FileModal/FileModalImage.vue
@@ -3,11 +3,29 @@
     <div :class="$style.header">
       <FileModalContentHeader :file-id="fileMeta?.id ?? ''" is-white />
     </div>
+
+    <div
+      v-if="siblingImageIds.length > 1"
+      :class="[$style.navButton, $style.navLeft]"
+      @click.stop="prevFile"
+    >
+      <AIcon name="chevron-left" mdi :size="32" />
+    </div>
+
     <ImageViewer
       :class="$style.img"
       :src="fileRawPath"
       :alt="fileMeta?.name ?? 'unknown'"
     />
+
+    <div
+      v-if="siblingImageIds.length > 1"
+      :class="[$style.navButton, $style.navRight]"
+      @click.stop="nextFile"
+    >
+      <AIcon name="chevron-right" mdi :size="32" />
+    </div>
+
     <div :class="$style.footer">
       <FileModalContentFooter :file-id="fileMeta?.id ?? ''" is-white />
     </div>
@@ -15,16 +33,90 @@
 </template>
 
 <script lang="ts" setup>
+import { computed, watchEffect } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { useEventListener } from '@vueuse/core'
+
 import FileModalContentFooter from '/@/components/Modal/FileModal/FileModalContentFooter.vue'
 import FileModalContentHeader from '/@/components/Modal/FileModal/FileModalContentHeader.vue'
+import AIcon from '/@/components/UI/AIcon.vue'
 import ImageViewer from '/@/components/UI/ImageViewer.vue'
 import useFileMeta from '/@/composables/files/useFileMeta'
+import { buildFilePath } from '/@/lib/apis'
+import { safeMod } from '/@/lib/basic/arithmetic'
+import { isImage } from '/@/lib/basic/file'
+import { isFile } from '/@/lib/guard/embeddingOrUrl'
+import { constructFilesPath } from '/@/router'
+import { useMessagesView } from '/@/store/domain/messagesView'
+import { useMessagesStore } from '/@/store/entities/messages'
 
 const props = defineProps<{
   fileId: string
 }>()
 
 const { fileMeta, fileRawPath } = useFileMeta(props)
+
+const router = useRouter()
+const { embeddingsMap } = useMessagesView()
+const { fileMetaDataMap } = useMessagesStore()
+
+const siblingImageIds = computed(() => {
+  for (const embeddings of embeddingsMap.value.values()) {
+    const fileIds = embeddings.filter(isFile).map(e => e.id)
+    if (fileIds.includes(props.fileId)) {
+      return fileIds.filter(id => {
+        const meta = fileMetaDataMap.value.get(id)
+        return meta && isImage(meta.mime)
+      })
+    }
+  }
+  return [props.fileId]
+})
+
+watchEffect(() => {
+  siblingImageIds.value.forEach(id => {
+    if (id !== props.fileId) {
+      // Preload
+      const img = new Image()
+      img.src = buildFilePath(id)
+    }
+  })
+})
+
+const currentIndex = computed(() => siblingImageIds.value.indexOf(props.fileId))
+
+const moveFile = (index: number) => {
+  if (currentIndex.value === -1 || siblingImageIds.value.length <= 1) return
+
+  router.replace(
+    constructFilesPath(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      siblingImageIds.value[
+        safeMod(currentIndex.value + index, siblingImageIds.value.length)
+      ]!
+    )
+  )
+}
+
+const nextFile = () => moveFile(1)
+const prevFile = () => moveFile(-1)
+
+const onKeyDown = (e: KeyboardEvent) => {
+  if (
+    e.target instanceof HTMLInputElement ||
+    e.target instanceof HTMLTextAreaElement
+  ) {
+    return
+  }
+  if (e.key === 'ArrowRight') {
+    nextFile()
+  } else if (e.key === 'ArrowLeft') {
+    prevFile()
+  }
+}
+
+useEventListener('keydown', onKeyDown)
 </script>
 
 <style lang="scss" module>
@@ -53,6 +145,37 @@ const { fileMeta, fileRawPath } = useFileMeta(props)
 .img {
   height: 100%;
   width: 100%;
+}
+.navButton {
+  @include color-ui-secondary;
+
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: $z-index-file-modal-header;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  opacity: 0;
+
+  .container:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.6);
+  }
+}
+.navLeft {
+  left: 4px;
+}
+.navRight {
+  right: 4px;
 }
 .footer {
   position: absolute;

--- a/src/components/Modal/FileModal/FileModalImage.vue
+++ b/src/components/Modal/FileModal/FileModalImage.vue
@@ -12,11 +12,23 @@
       <AIcon name="chevron-left" mdi :size="32" />
     </div>
 
-    <ImageViewer
-      :class="$style.img"
-      :src="fileRawPath"
-      :alt="fileMeta?.name ?? 'unknown'"
-    />
+    <transition
+      :enter-active-class="$style.transitionActive"
+      :leave-active-class="$style.transitionActive"
+      :enter-from-class="
+        direction === 'next' ? $style.nextEnterFrom : $style.prevEnterFrom
+      "
+      :leave-to-class="
+        direction === 'next' ? $style.nextLeaveTo : $style.prevLeaveTo
+      "
+    >
+      <ImageViewer
+        :key="fileRawPath"
+        :class="$style.img"
+        :src="fileRawPath"
+        :alt="fileMeta?.name ?? 'unknown'"
+      />
+    </transition>
 
     <div
       v-if="siblingImageIds.length > 1"
@@ -33,7 +45,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watchEffect } from 'vue'
+import { computed, ref, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { useEventListener } from '@vueuse/core'
@@ -86,8 +98,13 @@ watchEffect(() => {
 
 const currentIndex = computed(() => siblingImageIds.value.indexOf(props.fileId))
 
+type Direction = 'next' | 'prev'
+const direction = ref<Direction>('next')
+
 const moveFile = (index: number) => {
   if (currentIndex.value === -1 || siblingImageIds.value.length <= 1) return
+
+  direction.value = index > 0 ? 'next' : 'prev'
 
   router.replace(
     constructFilesPath(
@@ -143,9 +160,35 @@ useEventListener('keydown', onKeyDown)
   }
 }
 .img {
+  position: absolute;
+  top: 0;
+  left: 0;
   height: 100%;
   width: 100%;
 }
+
+.transitionActive {
+  transition:
+    transform 150ms ease-in-out,
+    opacity 150ms ease;
+}
+.nextEnterFrom {
+  transform: translateX(30%);
+  opacity: 0;
+}
+.nextLeaveTo {
+  transform: translateX(-30%);
+  opacity: 0;
+}
+.prevEnterFrom {
+  transform: translateX(-30%);
+  opacity: 0;
+}
+.prevLeaveTo {
+  transform: translateX(30%);
+  opacity: 0;
+}
+
 .navButton {
   @include color-ui-secondary;
 


### PR DESCRIPTION
## 概要

画像を動かせる機能と競合するのでスワイプは実装してないです

## なぜこの PR を入れたいのか

- closes: https://github.com/traPtitech/traQ_S-UI/issues/5041

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="1236" height="915" alt="image" src="https://github.com/user-attachments/assets/f45daa3f-cfd6-45f0-8e01-e71bd9717bc3" /> | <img width="1262" height="915" alt="image" src="https://github.com/user-attachments/assets/bf338cde-39f8-47b8-a350-5eb35ee27f0b" /> |

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **New Features**
  * 画像ビューアに前後の画像へ移動できるナビゲーション機能を追加しました。矢印キーとボタンで操作可能です。
  * 関連画像を自動的にプリロード表示するようになりました。
  * スムーズなスライド効果を含むトランジション動作を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->