### PR TITLE
config.jsでバックエンドのoriginを設定できるようにする

### DIFF
--- a/src/lib/apis.ts
+++ b/src/lib/apis.ts
@@ -48,7 +48,8 @@ export const buildFileWaveformPath = (fileId: FileId) =>
 export const embeddingOrigin =
   DEV_SERVER !== '' && import.meta.env.MODE === 'development'
     ? DEV_SERVER
-    : (self.traQConfig.backendOrigin ?? `${location.protocol}//${location.host}`)
+    : (self.traQConfig.backendOrigin ??
+      `${location.protocol}//${location.host}`)
 
 export const buildFilePathForPost = (fileId: FileId) =>
   `${embeddingOrigin}${constructFilesPath(fileId)}`

--- a/src/lib/apis.ts
+++ b/src/lib/apis.ts
@@ -48,7 +48,7 @@ export const buildFileWaveformPath = (fileId: FileId) =>
 export const embeddingOrigin =
   DEV_SERVER !== '' && import.meta.env.MODE === 'development'
     ? DEV_SERVER
-    : `${location.protocol}//${location.host}`
+    : (self.traQConfig.backendOrigin ?? `${location.protocol}//${location.host}`)
 
 export const buildFilePathForPost = (fileId: FileId) =>
   `${embeddingOrigin}${constructFilesPath(fileId)}`

--- a/src/lib/markdown/markdown.ts
+++ b/src/lib/markdown/markdown.ts
@@ -54,17 +54,6 @@ const loadMd = async () => {
   if (md) return
   const { traQMarkdownIt } = await import('./traq-markdown-it')
   md = new traQMarkdownIt(storeProvider, [], embeddingOrigin)
-
-  // q.trap.jp のURLも内部リンクとして認識する
-  // メッセージ内の添付ファイル・引用リンクは https://q.trap.jp/files/... や
-  // https://q.trap.jp/messages/... の形式で保存されているが、
-  // embeddingOrigin が q.ramdos.net なので外部URL扱いされてしまう。
-  // urlToEmbeddingData を上書きして q.trap.jp を embeddingOrigin に正規化してから渡す。
-  const upstreamOrigin = 'https://q.trap.jp'
-  const orig = md.embeddingExtractor.urlToEmbeddingData.bind(md.embeddingExtractor)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(md.embeddingExtractor as any).urlToEmbeddingData = (url: string) =>
-    orig(url.replace(upstreamOrigin, embeddingOrigin))
 }
 
 const waitForInitialFetch = () => {

--- a/src/lib/markdown/markdown.ts
+++ b/src/lib/markdown/markdown.ts
@@ -54,6 +54,17 @@ const loadMd = async () => {
   if (md) return
   const { traQMarkdownIt } = await import('./traq-markdown-it')
   md = new traQMarkdownIt(storeProvider, [], embeddingOrigin)
+
+  // q.trap.jp のURLも内部リンクとして認識する
+  // メッセージ内の添付ファイル・引用リンクは https://q.trap.jp/files/... や
+  // https://q.trap.jp/messages/... の形式で保存されているが、
+  // embeddingOrigin が q.ramdos.net なので外部URL扱いされてしまう。
+  // urlToEmbeddingData を上書きして q.trap.jp を embeddingOrigin に正規化してから渡す。
+  const upstreamOrigin = 'https://q.trap.jp'
+  const orig = md.embeddingExtractor.urlToEmbeddingData.bind(md.embeddingExtractor)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(md.embeddingExtractor as any).urlToEmbeddingData = (url: string) =>
+    orig(url.replace(upstreamOrigin, embeddingOrigin))
 }
 
 const waitForInitialFetch = () => {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -127,6 +127,15 @@ export type Config = Readonly<{
    * @example 'general'
    */
   fallbackChannelPath?: string
+
+  /**
+   * traQバックエンドのオリジン
+   * フロントエンドとは異なるドメインでホストする場合に指定する
+   * 省略時は `location.origin` を使用
+   *
+   * @example 'https://q.trap.jp'
+   */
+  backendOrigin?: string
 }>
 
 declare global {


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

preview環境や、オレオレフロントエンドで引用リンクやファイル埋め込みが壊れて辛いので、`config.js`でオリジンを設定できるようにする

## 動作確認の手順

- [x] env.MODEがdevelopmentでない環境を用意し、public/config.jsに適当なオリジンを設定して引用リンクやファイル埋め込みがOGP埋め込みとして扱われないことを確認する

## UI 変更部分のスクリーンショット

（UI変更なし）

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

`public/config.js`に`backendOrigin: 'https://q.trap.jp'`って書くかは少し迷ったのですが、既存の環境を壊しそうなので書かないことにしました

## その他

preview環境の問題を修正するためには、マージ後にmanifestに手を加える必要があります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フロントエンド設定にバックエンド起点を指定できるオプション（backendOrigin）を追加しました。別ドメインでホストする構成で明示的にバックエンドの起点を設定できます。

* **バグ修正**
  * 起点解決ロジックを改善しました。設定値がある場合はそれを優先して使用し、未設定時は従来の既定の起点を使用します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->