### PR TITLE
perf: messagesMap に shallowRef を使うように

### DIFF
--- a/src/store/entities/messages.ts
+++ b/src/store/entities/messages.ts
@@ -1,6 +1,6 @@
 import type { FileInfo, Message, MessageStamp, Ogp } from '@traptitech/traq'
 
-import { ref } from 'vue'
+import { computed, ref, shallowRef, triggerRef } from 'vue'
 
 import type { AxiosError } from 'axios'
 import mitt from 'mitt'
@@ -46,14 +46,19 @@ const useMessagesStorePinia = defineStore('entities/messages', () => {
    * ここでは内容が更新されることのみを保障する
    * それぞれの方でメッセージIDの追加、削除の更新はする必要がある
    */
-  const messagesMap = ref(new Map<MessageId, Message>())
+  const internalMessagesMap = shallowRef(new Map<MessageId, Message>())
+  const messagesMap = computed<ReadonlyMap<MessageId, Message>>(
+    () => internalMessagesMap.value
+  )
   const extendMessagesMap = (messages: Message[]) => {
     for (const message of messages) {
-      messagesMap.value.set(message.id, message)
+      internalMessagesMap.value.set(message.id, message)
     }
+    triggerRef(internalMessagesMap)
   }
   const deleteMessage = (messageId: MessageId) => {
-    messagesMap.value.delete(messageId)
+    internalMessagesMap.value.delete(messageId)
+    triggerRef(internalMessagesMap)
 
     messageMitt.emit('deleteMessage', messageId)
   }
@@ -71,7 +76,7 @@ const useMessagesStorePinia = defineStore('entities/messages', () => {
 
     const [{ data: message }, shared] = await getMessage(messageId)
     if (!shared) {
-      messagesMap.value.set(message.id, message)
+      internalMessagesMap.value.set(message.id, message)
     }
     return message
   }

--- a/src/store/entities/messages.ts
+++ b/src/store/entities/messages.ts
@@ -77,6 +77,7 @@ const useMessagesStorePinia = defineStore('entities/messages', () => {
     const [{ data: message }, shared] = await getMessage(messageId)
     if (!shared) {
       internalMessagesMap.value.set(message.id, message)
+      triggerRef(internalMessagesMap)
     }
     return message
   }


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

過去のメッセージを遡る際のパフォーマンス向上

## 実装について

`messagesMap` では `ref()` が使われているが、これだと `messagesMap.value.set()` した際に毎回関連する処理が走って重くなってしまう
メッセージが多いときに手元で計測して 25～35ms 程度要した。過去のメッセージを遡る際にはこの処理を1回の読み込みにつき20メッセージ分行うので相当遅い

`shallowRef()` を使うことで値のトラッキングを避け、不要な更新処理を省けている。更新した後に手動で `triggerRef()` し、基本は `ReadonlyMap` を読み取らせることで意図せぬ更新 (による reactivity の喪失) を避けている

## 動作確認の手順

適当にメッセージがたくさんあるチャンネルをたくさん遡る (500メッセージぐらい遡ると差が分かりやすいかも)

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## メモ

このPRを適用してもメッセージを遡るのは依然として遅いが、これは仮想スクロールしてないことによるDOMサイズの肥大化が主な原因だと推測している
