### PR TITLE
「ios廃止のお知らせ」を削除

### DIFF
--- a/src/components/Main/MainView/MainView.vue
+++ b/src/components/Main/MainView/MainView.vue
@@ -1,14 +1,5 @@
 <template>
   <div :class="$style.container">
-    <div v-if="iosAppFlag" :class="$style.iosAppIsDeprecated">
-      {{ iosAppDeprecatedMessage }}
-      <div v-if="iosPwaInfoLink">
-        PWA版について:
-        <a :href="iosPwaInfoLink" :class="$style.iosPwaInfoLink">{{
-          iosPwaInfoLink
-        }}</a>
-      </div>
-    </div>
     <div id="header" :class="$style.headerContainer" />
     <div :class="$style.layoutContainer" :data-layout="layout">
       <QallAudio />
@@ -23,18 +14,11 @@
 <script lang="ts" setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
-import { isIOSApp } from '/@/lib/dom/browser'
 import { useMainViewStore } from '/@/store/ui/mainView'
 
 import PrimaryViewSelector from './PrimaryViewSelector.vue'
 import QallAudio from './QallView/QallAudio.vue'
 import SecondaryViewSelector from './SecondaryViewSelector.vue'
-
-const iosAppFlag = isIOSApp(window)
-const iosAppDeprecatedMessage =
-  '現在お使いのiOSアプリ版traQは2023/04/01を以て廃止され、2023/06/01には動作しなくなります。引き続き利用するにはPWA版に移行してください。なお、PWA版は動作にiOS 16.4を要求します。'
-
-const iosPwaInfoLink = window.traQConfig.iosPwaInfoLink
 
 const { layout } = useMainViewStore()
 
@@ -51,14 +35,6 @@ onBeforeUnmount(() => {
 .container {
   display: flex;
   flex-direction: column;
-}
-
-.iosAppIsDeprecated {
-  @include color-common-text-white-primary;
-  width: 100%;
-  z-index: $z-index-header;
-  padding: 16px;
-  background-color: $theme-accent-error-default;
 }
 
 .iosPwaInfoLink {


### PR DESCRIPTION
## 概要
MainView.vue 内の iOS版 廃止のお知らせの文章に係る部分を削除。

## なぜこの PR を入れたいのか

src/components/Main/MainView/MainView.vue に iOS版 廃止のお知らせの文章があり、2023年にすでに廃止されているようだったので削除しました。


## 動作確認の手順



## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS アプリの非推奨バナーを削除し、UIをクリーンアップしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->