### PR TITLE
OGPカードのリンク先を投稿されたURLに変更する

### DIFF
--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
@@ -13,6 +13,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 
+import { isDefined } from '/@/lib/basic/array'
 import { useMessagesStore } from '/@/store/entities/messages'
 
 import MessageOgpListItem from './MessageOgpListItem.vue'
@@ -29,13 +30,13 @@ const props = withDefaults(
 const { ogpDataMap } = useMessagesStore()
 
 const ogpItems = computed(() =>
-  props.externalUrls.flatMap(url => {
-    const ogpData = ogpDataMap.value.get(url)
-    if (!ogpData?.title) {
-      return []
-    }
-    return [{ url, ogpData }]
-  })
+  props.externalUrls
+    .map((url: string) => {
+      const ogpData = ogpDataMap.value.get(url)
+      return isDefined(ogpData) ? { url, ogpData } : undefined
+    })
+    .filter(isDefined)
+    .filter(({ ogpData }: { ogpData: { title?: string } }) => ogpData.title)
 )
 </script>
 

--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
@@ -1,8 +1,8 @@
 <template>
   <div :class="$style.container">
     <MessageOgpListItem
-      v-for="item in ogpItems"
-      :key="item.url"
+      v-for="(item, index) in ogpItems"
+      :key="`${item.url}-${index}`"
       :class="$style.item"
       :url="item.url"
       :ogp-data="item.ogpData"

--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
@@ -1,10 +1,11 @@
 <template>
   <div :class="$style.container">
     <MessageOgpListItem
-      v-for="(data, i) in ogpData"
-      :key="i"
+      v-for="item in ogpItems"
+      :key="item.url"
       :class="$style.item"
-      :ogp-data="data"
+      :url="item.url"
+      :ogp-data="item.ogpData"
     />
   </div>
 </template>
@@ -12,7 +13,6 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 
-import { isDefined } from '/@/lib/basic/array'
 import { useMessagesStore } from '/@/store/entities/messages'
 
 import MessageOgpListItem from './MessageOgpListItem.vue'
@@ -28,11 +28,14 @@ const props = withDefaults(
 
 const { ogpDataMap } = useMessagesStore()
 
-const ogpData = computed(() =>
-  props.externalUrls
-    .map(url => ogpDataMap.value.get(url))
-    .filter(isDefined)
-    .filter(o => o.title)
+const ogpItems = computed(() =>
+  props.externalUrls.flatMap(url => {
+    const ogpData = ogpDataMap.value.get(url)
+    if (!ogpData?.title) {
+      return []
+    }
+    return [{ url, ogpData }]
+  })
 )
 </script>
 

--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpList.vue
@@ -36,7 +36,7 @@ const ogpItems = computed(() =>
       return isDefined(ogpData) ? { url, ogpData } : undefined
     })
     .filter(isDefined)
-    .filter(({ ogpData }: { ogpData: { title?: string } }) => ogpData.title)
+    .filter(({ ogpData }) => ogpData.title)
 )
 </script>
 

--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpListItem.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageOgpListItem.vue
@@ -2,7 +2,7 @@
   <div :class="$style.container">
     <MessageOgpContentVideo
       v-if="isVideoType && imageUrl && videoUrl"
-      :url="ogpData.url"
+      :url="url"
       :title="ogpData.title"
       :description="ogpData.description"
       :preview-url="imageUrl"
@@ -10,7 +10,7 @@
     />
     <MessageOgpContentWebsite
       v-else
-      :url="ogpData.url"
+      :url="url"
       :title="ogpData.title"
       :description="ogpData.description"
       :image-url="imageUrl"
@@ -29,6 +29,7 @@ import MessageOgpContentVideo from './MessageOgpContentVideo.vue'
 import MessageOgpContentWebsite from './MessageOgpContentWebsite.vue'
 
 const props = defineProps<{
+  url: string
   ogpData: Ogp
 }>()
 


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

OGPカードのリンク先としてog:urlを使うのは間違っていると思われる
主な文脈：https://q.trap.jp/messages/019d1988-4202-75bc-beed-a9c09b16ee95

## 動作確認の手順

https://cover-corp.com/news/detail/c2026032201 などのOGPカードを踏む

## UI 変更部分のスクリーンショット

（UI変更なし）

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - clientを変更すべきかは要議論です
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OGPプレビューの生成ロジックを整理し、一覧表示用データをURL付きの形に変更しました。
  * 各プレビュー項目へURLとOGPデータを個別に渡すよう更新しました。
  * タイトル未設定のプレビューは一覧から除外されるよう安定化しました。
  * 表示キーを見直し、描画の安定性を向上しました。
  * 見た目や操作感は変更ありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->