### PR TITLE
Feature Flagの期限を暫定的に延ばす

### DIFF
--- a/src/store/app/featureFlagSettings.ts
+++ b/src/store/app/featureFlagSettings.ts
@@ -17,7 +17,7 @@ export type FeatureFlag = FeatureFlagDescription & { enabled: boolean }
 
 /*
   *** FeatureFlag の利用仮ルール ***
-  - 日時の指定は最大一ヶ月先まで （FeatureFlag の利用を前提とした・FeatureFlag を乱用した運用を避けるため。期間後に本実装するかを検討する）
+  - 日時の指定を不必要に長くしない （FeatureFlag の利用を前提とした・FeatureFlag を乱用した運用を避けるため。期間中に本実装するかを検討する）
   - 利用しなくなった FeatureFlag は削除する
   - 仮ルールなので必要に応じて変えてほしいです
 */
@@ -42,14 +42,14 @@ export const featureFlagDescriptions = {
     description:
       'お気に入りチャンネル一覧を、お気に入りに登録されたチャンネルのみの木構造で表示します。',
     defaultValue: false,
-    endAt: new Date('2025-12-31T23:59')
+    endAt: new Date('2026-09-30T23:59')
   },
   stamp_recommendation: {
     title: 'スタンプのレコメンド機能',
     description:
       'スタンプのレコメンド機能を有効にします。スタンプ履歴が用いられている部分をレコメンドで置き換えます。',
     defaultValue: false,
-    endAt: new Date('2026-01-31T23:59')
+    endAt: new Date('2026-09-30T23:59')
   }
 } as const satisfies Record<string, FeatureFlagDescription>
 


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

<img width="255" height="196" alt="image" src="https://github.com/user-attachments/assets/2bfb5799-e02c-411c-8fc3-00dbef6192fc" />

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * 機能フラグの有効期限を延長しました。これにより、該当フラグの無効化時期が2026年9月30日に延期されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->