### PR TITLE
feat: MessageQuoteListItemHeaderにnameの表示を追加

### DIFF
--- a/src/components/Main/MainView/MessageElement/Embeddings/MessageQuoteListItemHeader.vue
+++ b/src/components/Main/MainView/MessageElement/Embeddings/MessageQuoteListItemHeader.vue
@@ -1,6 +1,7 @@
 <template>
   <div :class="$style.header">
     <span :class="$style.displayName">{{ displayName }}</span>
+    <span :class="$style.name">{{ name }}</span>
   </div>
 </template>
 
@@ -17,6 +18,7 @@ const props = defineProps<{
 const { usersMap, fetchUser } = useUsersStore()
 
 const user = computed(() => usersMap.value.get(props.userId))
+const name = computed(() => '@' + (user.value?.name ?? 'unknown'))
 const displayName = computed(() => user.value?.displayName ?? 'unknown')
 if (user.value === undefined) {
   fetchUser({ userId: props.userId })
@@ -33,6 +35,22 @@ if (user.value === undefined) {
 .displayName {
   @include size-body2;
   font-weight: bold;
+  flex: 2;
+  max-width: min-content;
+
+  word-break: keep-all;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.name {
+  @include size-body2;
+  @include color-ui-secondary;
+  margin-left: 4px;
+  flex: 1;
+  max-width: min-content;
+
   word-break: keep-all;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
## 概要

## なぜこの PR を入れたいのか

close #5178 

## 動作確認の手順

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="740" height="136" alt="image" src="https://github.com/user-attachments/assets/c25a5b62-7116-42db-a586-7e662b1f48e6" /> | <img width="744" height="131" alt="image" src="https://github.com/user-attachments/assets/1b398cfd-b372-4da5-b520-47734af4f45a" /> |
| <img width="464" height="137" alt="image" src="https://github.com/user-attachments/assets/5495b8cd-b172-4029-ad28-a23a708509eb" /> | <img width="463" height="135" alt="image" src="https://github.com/user-attachments/assets/da965342-5ede-4399-a3c7-c1269622b354" /> |

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

flex周りの実装
デザインはこれで大丈夫か

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メッセージ引用ヘッダーにユーザー名を表示するようになりました。ユーザー名が不明な場合は「unknown」と表示されます。

* **改善**
  * テキストの折返しと省略表示に対応するよう、ヘッダーの表示スタイルを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->