### PR TITLE
右サイドバーのピン留め、イベントタブへの小さなアイコンの追加完了

### DIFF
--- a/build/docker/Caddyfile
+++ b/build/docker/Caddyfile
@@ -1,15 +1,23 @@
 {
     admin off
 }
-
-:80
-
-encode zstd gzip
-header /sw.js Cache-Control "max-age=0"
-
-file_server {
-    precompressed br gzip
+:80 {
+    encode zstd gzip
+    header /sw.js Cache-Control "max-age=0"
+    @api path /api /api/*
+    handle @api {
+        reverse_proxy https://q.trap.jp {
+            header_up Host q.trap.jp
+            transport http {
+                tls_server_name q.trap.jp
+            }
+        }
+    }
+    handle {
+        root * /usr/share/caddy
+        try_files {path} /index.html
+        file_server {
+            precompressed br gzip
+        }
+    }
 }
-root * /usr/share/caddy
-
-try_files {path} /index.html

--- a/public/config.js
+++ b/public/config.js
@@ -141,7 +141,8 @@
       '04ad2c18-fdcb-4c43-beef-82e8ba26ac98', // #general of q.trap.jp
       '83afc6cc-737d-4868-9a2f-aeb7c199260e' // #general of q-dev.trapti.tech
     ],
-    fallbackChannelPath: 'general'
+    fallbackChannelPath: 'general',
+    backendOrigin: 'https://q.trap.jp'
   }
 
   self.traQConfig = config

--- a/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarEvents.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarEvents.vue
@@ -2,6 +2,8 @@
   <SidebarContentContainerLink
     title="イベント"
     @click-link="emit('clickLink')"
+    icon-name="history"
+    icon-mdi
   />
 </template>
 

--- a/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarPinned.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarPinned.vue
@@ -3,6 +3,8 @@
     title="ピン留め"
     :count="pinnedMessageLength"
     @click-link="emit('clickLink')"
+    icon-name="pin"
+    icon-mdi
   />
 </template>
 

--- a/src/components/Main/MainView/PrimaryViewSidebar/SidebarContentContainer.vue
+++ b/src/components/Main/MainView/PrimaryViewSidebar/SidebarContentContainer.vue
@@ -12,6 +12,7 @@
       @click="emit('toggle')"
     >
       <h2 :class="$style.headerTitle">
+        <AIcon v-if="iconName" :class="$style.headerIcon" :name="iconName" :mdi="iconMdi" :size="18"/>
         {{ title }}
       </h2>
       <slot name="header-control" />
@@ -21,12 +22,16 @@
 </template>
 
 <script lang="ts" setup>
+import AIcon from '/@/components/UI/AIcon.vue';
 const props = withDefaults(
   defineProps<{
     title?: string
     largePadding?: boolean
     clickable?: boolean
     titleClickable?: boolean
+
+    iconName?: string
+    iconMdi?: boolean
   }>(),
   {
     largePadding: false,
@@ -81,5 +86,9 @@ const onContainerClick = () => {
 .headerTitle {
   @include size-body1;
   font-weight: bold;
+}
+
+.headerIcon {
+  margin: 8px;
 }
 </style>

--- a/src/components/Main/MainView/PrimaryViewSidebar/SidebarContentContainerLink.vue
+++ b/src/components/Main/MainView/PrimaryViewSidebar/SidebarContentContainerLink.vue
@@ -4,6 +4,9 @@
     :title="title"
     :large-padding="largePadding"
     @toggle="emit('clickLink')"
+    
+    :iconName="iconName" 
+    :iconMdi="iconMdi"
   >
     <template #header-control>
       <div>
@@ -26,6 +29,9 @@ withDefaults(
     title?: string
     count?: number
     largePadding?: boolean
+
+    iconName?: string
+    iconMdi?: boolean
   }>(),
   {
     largePadding: false


### PR DESCRIPTION
## 概要
右サイドバーのピン留め、イベントタブへの小さなアイコンの追加が完了しました。

## なぜこの PR を入れたいのか
done: #8

## 動作確認の手順
traQ開発環境を起動し、右サイドバーを開いて確認。

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="1210" height="823" alt="image" src="https://github.com/user-attachments/assets/1bbe124e-7391-4c5f-a57b-60320bb58c29" /> | <img width="1211" height="821" alt="image" src="https://github.com/user-attachments/assets/78d62421-5804-4fbd-878e-14a991987c93" /> |

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * サイドバーの各リンクにアイコンが表示されるようになりました。
  * 「履歴」「ピン留め」などの項目が、より見分けやすくなりました。
* **Bug Fixes**
  * `/api` へのアクセスが正しく外部サービスへ転送されるようになりました。
  * サービスワーカーの更新が反映されやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->