### PR TITLE
debug: /api/v3/files/:id へのすべての通信に ?dl=1 を付与

### DIFF
--- a/src/composables/files/useFileLink.ts
+++ b/src/composables/files/useFileLink.ts
@@ -7,7 +7,7 @@ import type { FileId } from '/@/types/entity-ids'
 const useFileLink = (props: { fileId: FileId }) => {
   const fileLink = computed(() => constructFilesPath(props.fileId))
   const onFileDownloadLinkClick = () => {
-    location.href = buildFilePath(props.fileId, true)
+    location.href = buildFilePath(props.fileId)
   }
   return { fileLink, onFileDownloadLinkClick }
 }

--- a/src/lib/apis.ts
+++ b/src/lib/apis.ts
@@ -33,11 +33,11 @@ const apis = new Apis(
 
 export default apis
 
-export const buildFilePath = (fileId: FileId, withDlParam = false) =>
-  `${BASE_PATH}/files/${fileId}${withDlParam ? '?dl=1' : ''}`
+export const buildFilePath = (fileId: FileId) =>
+  `${BASE_PATH}/files/${fileId}?dl=1`
 
 export const buildUserIconPath = (userIconFileId: FileId) =>
-  `${BASE_PATH}/files/${userIconFileId}`
+  `${BASE_PATH}/files/${userIconFileId}?dl=1`
 
 export const buildFileThumbnailPath = (fileId: FileId) =>
   `${BASE_PATH}/files/${fileId}/thumbnail`

--- a/src/sw/notification.ts
+++ b/src/sw/notification.ts
@@ -84,7 +84,7 @@ export const setupNotification = async () => {
       if (store?.detail) {
         const me = store.detail
         data.body = `${me.displayName}: ${event.reply}`
-        data.icon = `/api/v3/files/${me.iconFileId}`
+        data.icon = `/api/v3/files/${me.iconFileId}?dl=1`
       } else {
         // eslint-disable-next-line no-console
         console.warn('[sw] no store or me.detail found')

--- a/src/sw/workbox.ts
+++ b/src/sw/workbox.ts
@@ -68,7 +68,7 @@ export const setupWorkbox = () => {
 
   // ファイルAPIのキャッシュ設定
   registerRoute(
-    new RegExp('/api/v3/files/[0-9a-fA-F-]{36}$'),
+    new RegExp('/api/v3/files/[0-9a-fA-F-]{36}(\\?dl=1)?$'),
     new CacheFirst({
       cacheName: 'files-cache',
       plugins: [


### PR DESCRIPTION
バックエンドの動作変更時の挙動確認用。
- buildFilePath / buildUserIconPath を常に ?dl=1 付きに変更
- 通知アイコンURLにも付与
- SWの files-cache 正規表現を ?dl=1 付きでもマッチするよう修正

## 概要

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <!-- Paste image --> | <!-- Paste image --> |

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [ ] 動作確認ができている
- [ ] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
