### PR TITLE
fix/5170 show group edit button only if admin

### DIFF
--- a/src/components/Modal/GroupModal/GroupModal.vue
+++ b/src/components/Modal/GroupModal/GroupModal.vue
@@ -4,7 +4,7 @@
     :subtitle="name"
     icon-name="group"
     return-button
-    edit-button
+    :edit-button="isAdmin"
     @edit="onGroupEdit"
   >
     <UserListItem
@@ -29,6 +29,7 @@ import type { UserGroupMember } from '@traptitech/traq'
 
 import { computed } from 'vue'
 
+import { useMeStore } from '/@/store/domain/me'
 import { useGroupsStore } from '/@/store/entities/groups'
 import { useUsersStore } from '/@/store/entities/users'
 
@@ -65,6 +66,13 @@ const users = computed((): UserGroupMemberOrAdmin[] => {
       .filter(m => !adminIds.has(m.id))
       .map(m => ({ ...m, isMember: true, isAdmin: false }))
   ].filter(m => activeUsersMap.value.has(m.id))
+})
+
+const { myId } = useMeStore()
+const isAdmin = computed(() => {
+  if (!group.value) return false
+  if (!myId.value) return false
+  return group.value.admins.includes(myId.value)
 })
 
 const { openLinkAndClearModal } = useOpenLinkAndClearModal()


### PR DESCRIPTION
## 概要

QSoC with rurun418

## なぜこの PR を入れたいのか

close: #5170 

## 動作確認の手順

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="970" height="384" alt="image" src="https://github.com/user-attachments/assets/4013f938-1252-47ca-a39f-a60a1de373b9" /> | <img width="954" height="366" alt="image" src="https://github.com/user-attachments/assets/5e7eb490-d5fc-4d7c-af67-c78b6e9273bd" /> |

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * グループ管理画面で、管理者のみ編集ボタンが表示・操作できるようになりました。
  * ユーザー情報やグループ情報が未取得の場合は、編集ボタンが誤って有効にならないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->