### PR TITLE
Feat/5171 already open group edit accordion

### DIFF
--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -61,6 +61,7 @@ const groups = computed(() =>
 )
 
 const selectedGroupElement = ref<HTMLElement | null>(null)
+const lastScrolledHash = ref<string | null>(null)
 
 const isSelectedGroup = (id: UserGroupId) => {
   return route.hash === `#${id}`
@@ -72,6 +73,10 @@ const setSelectedGroupElement = (
 ) => {
   if (isSelectedGroup(id) && el) {
     selectedGroupElement.value = el as HTMLElement
+    if (lastScrolledHash.value === route.hash) {
+      return
+    }
+    lastScrolledHash.value = route.hash
     nextTick(() => {
       ;(el as HTMLElement).scrollIntoView({ block: 'nearest' })
     })

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -1,13 +1,17 @@
 <template>
   <div>
-    <GroupListGroup
+    <div
       v-for="group in groups"
       :key="group.id"
-      :group="group"
-      :class="$style.item"
-      :is-selected="route.hash === `#${group.id}`"
-      @select="onSelect"
-    />
+      :ref="el => setSelectedGroupElement(el, group.id)"
+    >
+      <GroupListGroup
+        :group="group"
+        :class="$style.item"
+        :is-selected="isSelectedGroup(group.id)"
+        @select="onSelect"
+      />
+    </div>
     <div v-if="groups.length <= 0" :class="$style.notFound">
       自分が管理者になっているユーザーグループはありません
     </div>
@@ -17,7 +21,7 @@
 <script lang="ts" setup>
 import { UserPermission } from '@traptitech/traq'
 
-import { computed } from 'vue'
+import { type ComponentPublicInstance, computed, nextTick, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { compareString } from '/@/lib/basic/string'
@@ -55,6 +59,29 @@ const groups = computed(() =>
     })
     .sort((a, b) => compareString(a.name, b.name))
 )
+
+const selectedGroupElement = ref<HTMLElement | null>(null)
+const lastScrolledHash = ref<string | null>(null)
+
+const isSelectedGroup = (id: UserGroupId) => {
+  return route.hash === `#${id}`
+}
+
+const setSelectedGroupElement = (
+  el: Element | ComponentPublicInstance | null,
+  id: UserGroupId
+) => {
+  if (isSelectedGroup(id) && el) {
+    selectedGroupElement.value = el as HTMLElement
+    const hash = route.hash
+    if (lastScrolledHash.value !== hash) {
+      lastScrolledHash.value = hash
+      nextTick(() => {
+        ;(el as HTMLElement).scrollIntoView({ block: 'nearest' })
+      })
+    }
+  }
+}
 </script>
 
 <style lang="scss" module>

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -39,7 +39,7 @@ fetchUsers()
 fetchUserGroups()
 
 const onSelect = (id: UserGroupId) => {
-  router.push(`#${id}`)
+  router.push({ hash: `#${id}` })
 }
 const isAllUserGroupsAdmin = computed(() =>
   detail.value?.permissions.includes(UserPermission.AllUserGroupsAdmin)

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -18,8 +18,7 @@
 import { UserPermission } from '@traptitech/traq'
 
 import { computed } from 'vue'
-import { useRoute } from 'vue-router'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 import { compareString } from '/@/lib/basic/string'
 import { useMeStore } from '/@/store/domain/me'
@@ -39,7 +38,7 @@ fetchUsers()
 fetchUserGroups()
 
 const onSelect = (id: UserGroupId) => {
-  router.push({ hash: `#${id}` })
+  router.replace({ hash: `#${id}` })
 }
 const isAllUserGroupsAdmin = computed(() =>
   detail.value?.permissions.includes(UserPermission.AllUserGroupsAdmin)

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -61,7 +61,6 @@ const groups = computed(() =>
 )
 
 const selectedGroupElement = ref<HTMLElement | null>(null)
-const lastScrolledHash = ref<string | null>(null)
 
 const isSelectedGroup = (id: UserGroupId) => {
   return route.hash === `#${id}`
@@ -73,13 +72,9 @@ const setSelectedGroupElement = (
 ) => {
   if (isSelectedGroup(id) && el) {
     selectedGroupElement.value = el as HTMLElement
-    const hash = route.hash
-    if (lastScrolledHash.value !== hash) {
-      lastScrolledHash.value = hash
-      nextTick(() => {
-        ;(el as HTMLElement).scrollIntoView({ block: 'nearest' })
-      })
-    }
+    nextTick(() => {
+      ;(el as HTMLElement).scrollIntoView({ block: 'nearest' })
+    })
   }
 }
 </script>

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -5,7 +5,7 @@
       :key="group.id"
       :group="group"
       :class="$style.item"
-      :is-selected="selectedId === group.id"
+      :is-selected="route.hash === `#${group.id}`"
       @select="onSelect"
     />
     <div v-if="groups.length <= 0" :class="$style.notFound">
@@ -17,7 +17,8 @@
 <script lang="ts" setup>
 import { UserPermission } from '@traptitech/traq'
 
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { useRouter } from 'vue-router'
 
 import { compareString } from '/@/lib/basic/string'
@@ -28,6 +29,7 @@ import type { UserGroupId } from '/@/types/entity-ids'
 
 import GroupListGroup from './GroupListGroup.vue'
 
+const route = useRoute()
 const router = useRouter()
 const { detail, myId } = useMeStore()
 const { fetchUsers } = useUsersStore()
@@ -36,7 +38,6 @@ const { userGroupsMap, fetchUserGroups } = useGroupsStore()
 fetchUsers()
 fetchUserGroups()
 
-const selectedId = ref<UserGroupId>()
 const onSelect = (id: UserGroupId) => {
   router.push(`#${id}`)
 }

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -18,6 +18,7 @@
 import { UserPermission } from '@traptitech/traq'
 
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 import { compareString } from '/@/lib/basic/string'
 import { useMeStore } from '/@/store/domain/me'
@@ -27,6 +28,7 @@ import type { UserGroupId } from '/@/types/entity-ids'
 
 import GroupListGroup from './GroupListGroup.vue'
 
+const router = useRouter()
 const { detail, myId } = useMeStore()
 const { fetchUsers } = useUsersStore()
 const { userGroupsMap, fetchUserGroups } = useGroupsStore()
@@ -36,7 +38,7 @@ fetchUserGroups()
 
 const selectedId = ref<UserGroupId>()
 const onSelect = (id: UserGroupId) => {
-  selectedId.value = id
+  router.push(`#${id}`)
 }
 const isAllUserGroupsAdmin = computed(() =>
   detail.value?.permissions.includes(UserPermission.AllUserGroupsAdmin)

--- a/src/components/GroupManager/GroupList.vue
+++ b/src/components/GroupManager/GroupList.vue
@@ -4,12 +4,12 @@
       v-for="group in groups"
       :key="group.id"
       :ref="el => setSelectedGroupElement(el, group.id)"
+      :class="$style.item"
     >
       <GroupListGroup
         :group="group"
-        :class="$style.item"
-        :is-selected="isSelectedGroup(group.id)"
-        @select="onSelect"
+        :is-selected="selectedGroupId === group.id"
+        @select="selectedGroupId = $event"
       />
     </div>
     <div v-if="groups.length <= 0" :class="$style.notFound">
@@ -21,7 +21,7 @@
 <script lang="ts" setup>
 import { UserPermission } from '@traptitech/traq'
 
-import { type ComponentPublicInstance, computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { compareString } from '/@/lib/basic/string'
@@ -41,9 +41,6 @@ const { userGroupsMap, fetchUserGroups } = useGroupsStore()
 fetchUsers()
 fetchUserGroups()
 
-const onSelect = (id: UserGroupId) => {
-  router.replace({ hash: `#${id}` })
-}
 const isAllUserGroupsAdmin = computed(() =>
   detail.value?.permissions.includes(UserPermission.AllUserGroupsAdmin)
 )
@@ -61,27 +58,48 @@ const groups = computed(() =>
 )
 
 const selectedGroupElement = ref<HTMLElement | null>(null)
-const lastScrolledHash = ref<string | null>(null)
 
-const isSelectedGroup = (id: UserGroupId) => {
-  return route.hash === `#${id}`
-}
+const selectedGroupId = computed<UserGroupId | undefined>({
+  get: () => {
+    const id = route.hash.slice(1) as UserGroupId
 
-const setSelectedGroupElement = (
-  el: Element | ComponentPublicInstance | null,
-  id: UserGroupId
-) => {
-  if (isSelectedGroup(id) && el) {
-    selectedGroupElement.value = el as HTMLElement
-    if (lastScrolledHash.value === route.hash) {
-      return
-    }
-    lastScrolledHash.value = route.hash
-    nextTick(() => {
-      ;(el as HTMLElement).scrollIntoView({ block: 'nearest' })
+    return groups.value.some(group => group.id === id) ? id : undefined
+  },
+  set: id => {
+    void router.replace({
+      hash: id ? `#${id}` : ''
     })
   }
+})
+
+const setSelectedGroupElement = (el: unknown | null, id: UserGroupId) => {
+  if (!(el instanceof HTMLElement)) {
+    return
+  }
+  if (selectedGroupId.value !== id) {
+    return
+  }
+  selectedGroupElement.value = el
 }
+
+watch(
+  selectedGroupId,
+  async id => {
+    if (!id) {
+      selectedGroupElement.value = null
+      return
+    }
+
+    await nextTick()
+    selectedGroupElement.value?.scrollIntoView({
+      block: 'nearest'
+    })
+  },
+  {
+    immediate: true,
+    flush: 'post'
+  }
+)
 </script>
 
 <style lang="scss" module>

--- a/src/components/GroupManager/GroupListGroup.vue
+++ b/src/components/GroupManager/GroupListGroup.vue
@@ -1,10 +1,14 @@
 <template>
-  <GroupListGroupEdit v-if="isSelected" :group="group" />
-  <GroupListGroupView v-else :group="group" @click-edit="onSelect" />
+  <div ref="rootRef">
+    <GroupListGroupEdit v-if="isSelected" :group="group" />
+    <GroupListGroupView v-else :group="group" @click-edit="onSelect" />
+  </div>
 </template>
 
 <script lang="ts" setup>
 import type { UserGroup } from '@traptitech/traq'
+
+import { nextTick, ref, watch } from 'vue'
 
 import type { UserGroupId } from '/@/types/entity-ids'
 
@@ -25,7 +29,25 @@ const emit = defineEmits<{
   (e: 'select', _groupId: UserGroupId): void
 }>()
 
+const rootRef = ref<HTMLElement | null>(null)
+
 const onSelect = () => {
   emit('select', props.group.id)
 }
+
+watch(
+  () => props.isSelected,
+  async isSelected => {
+    if (!isSelected) return
+
+    await nextTick()
+
+    rootRef.value?.scrollIntoView({
+      block: 'nearest'
+    })
+  },
+  {
+    immediate: true
+  }
+)
 </script>

--- a/src/components/GroupManager/GroupListGroup.vue
+++ b/src/components/GroupManager/GroupListGroup.vue
@@ -1,14 +1,10 @@
 <template>
-  <div ref="rootRef">
-    <GroupListGroupEdit v-if="isSelected" :group="group" />
-    <GroupListGroupView v-else :group="group" @click-edit="onSelect" />
-  </div>
+  <GroupListGroupEdit v-if="isSelected" :group="group" />
+  <GroupListGroupView v-else :group="group" @click-edit="onSelect" />
 </template>
 
 <script lang="ts" setup>
 import type { UserGroup } from '@traptitech/traq'
-
-import { nextTick, ref, watch } from 'vue'
 
 import type { UserGroupId } from '/@/types/entity-ids'
 
@@ -29,25 +25,7 @@ const emit = defineEmits<{
   (e: 'select', _groupId: UserGroupId): void
 }>()
 
-const rootRef = ref<HTMLElement | null>(null)
-
 const onSelect = () => {
   emit('select', props.group.id)
 }
-
-watch(
-  () => props.isSelected,
-  async isSelected => {
-    if (!isSelected) return
-
-    await nextTick()
-
-    rootRef.value?.scrollIntoView({
-      block: 'nearest'
-    })
-  },
-  {
-    immediate: true
-  }
-)
 </script>

--- a/src/components/Modal/GroupModal/GroupModal.vue
+++ b/src/components/Modal/GroupModal/GroupModal.vue
@@ -70,7 +70,7 @@ const users = computed((): UserGroupMemberOrAdmin[] => {
 const { openLinkAndClearModal } = useOpenLinkAndClearModal()
 
 const onGroupEdit = (event: MouseEvent) => {
-  openLinkAndClearModal(event, '/group-manager')
+  openLinkAndClearModal(event, `/group-manager#${group.value?.id}`)
 }
 </script>
 


### PR DESCRIPTION
## 概要

- GroupManagerとGroupModalのどちらの編集ボタンからもhashがつく。
- GroupListGroupが編集中であることをhashで表現。
- 自動でその場所にスクロールされるように。

## なぜこの PR を入れたいのか

close #5171 

## 動作確認の手順

GroupManagerで編集ボタンを押したり、GroupModalから編集ボタンを押したりする。

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="1930" height="1354" alt="image" src="https://github.com/user-attachments/assets/17fd0da3-ec88-41ab-aef8-d1ab34940a29" /> | <img width="1906" height="1362" alt="image" src="https://github.com/user-attachments/assets/72d20177-1b2d-4cdb-9185-10f40005a95c" /> |

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

scrollIntoViewで、behaviorとblockをいろいろ指定できるが、これでいいのか
https://developer.mozilla.org/ja/docs/Web/API/Element/scrollIntoView


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * グループ一覧で、選択状態がURLのハッシュと連動するようになりました。
  * グループ編集画面へ移動する際、対象グループがURLに反映されるようになりました。
  * 画面内のスクロール表示は、URLの状態と一致する場合にのみ自動実行されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->