### PR TITLE
fix: AIconのsizeパラメータをsvgのviewBoxに使わないようにする

### DIFF
--- a/src/components/Main/MainView/QallView/CallControlButton.vue
+++ b/src/components/Main/MainView/QallView/CallControlButton.vue
@@ -24,6 +24,10 @@ const props = defineProps({
     type: Boolean,
     default: true
   },
+  viewBoxSize: {
+    type: Number,
+    default: 24
+  },
   onBackgroundColor: {
     type: String,
     default: 'white'
@@ -53,7 +57,14 @@ function handleClick() {
 
 <template>
   <button :class="buttonClass" :style="buttonStyle" @click="handleClick">
-    <AIcon v-if="icon" :name="icon" :mdi="mdi" :size="32" :class="iconClass" />
+    <AIcon
+      v-if="icon"
+      :name="icon"
+      :mdi="mdi"
+      :size="32"
+      :view-box-size="viewBoxSize"
+      :class="iconClass"
+    />
   </button>
 </template>
 

--- a/src/components/Main/MainView/QallView/CallControlButtonSmall.vue
+++ b/src/components/Main/MainView/QallView/CallControlButtonSmall.vue
@@ -16,6 +16,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  viewBoxSize: {
+    type: Number,
+    default: 24
+  },
   inverted: {
     type: Boolean,
     default: false
@@ -36,7 +40,14 @@ function handleClick() {
 
 <template>
   <button :class="style.callControlBtnSmall" @click="handleClick">
-    <AIcon v-if="icon" :name="icon" :mdi="mdi" :size="32" :class="iconClass" />
+    <AIcon
+      v-if="icon"
+      :name="icon"
+      :mdi="mdi"
+      :size="32"
+      :view-box-size="viewBoxSize"
+      :class="iconClass"
+    />
   </button>
 </template>
 

--- a/src/components/Main/MainView/QallView/QallView.vue
+++ b/src/components/Main/MainView/QallView/QallView.vue
@@ -215,6 +215,7 @@ const toggleDanmaku = () => {
                 <CallControlButtonSmall
                   icon="sound_detection_loud_sound"
                   :on-click="handleSound"
+                  :view-box-size="32"
                 />
                 <ClickOutside @click-outside="showSoundBoard = false">
                   <SoundBoard v-if="showSoundBoard" />
@@ -224,6 +225,7 @@ const toggleDanmaku = () => {
                 <CallControlButtonSmall
                   icon="add_reaction"
                   :on-click="handleReaction"
+                  :view-box-size="32"
                 />
               </div>
             </div>
@@ -234,6 +236,7 @@ const toggleDanmaku = () => {
                 :is-on="isScreenSharing"
                 :on-click="toggleScreen"
                 :mdi="false"
+                :view-box-size="32"
                 :inverted="isScreenSharing"
               />
               <DetailButton @click="showShareScreenSettingDetail = true" />

--- a/src/components/UI/AIcon.vue
+++ b/src/components/UI/AIcon.vue
@@ -15,7 +15,7 @@
     v-else
     :width="size"
     :height="size"
-    :viewBox="`0 0 ${size} ${size}`"
+    :viewBox="`0 0 ${viewBoxSize} ${viewBoxSize}`"
     v-bind="$attrs"
     role="img"
     :class="$style.icon"
@@ -55,11 +55,19 @@ const props = withDefaults(
     name: string
     title?: string
     desc?: string
+    /**
+     * 表示サイズ. 拡大縮小される.
+     */
     size?: number
+    /**
+     * もとのSVGのviewBoxサイズ. デフォルトは24だが, SVGによっては異なることがあるのでその場合は指定する
+     */
+    viewBoxSize?: number
     mdi?: boolean
   }>(),
   {
     size: 24,
+    viewBoxSize: 24,
     mdi: false
   }
 )


### PR DESCRIPTION
resolve #5179

## Summary

- 1年位前から `<AIcon>` が壊れていて, `size` を指定すると元画像がクリッピングされてしまう問題があった
- これを修正したことで #5179 も解決


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - アイコン表示のスケールを個別に調整できるようになりました。
  - 通話操作ボタンのアイコンサイズが明示的に設定され、表示の一貫性が向上しました。

- **Bug Fixes**
  - 一部アイコンの表示がコンポーネント間でずれにくくなり、見た目の差異が抑えられました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->