### PR TITLE
fix: clickOutside をドラッグでも反応するように変更

### DIFF
--- a/src/components/UI/ClickOutside.ts
+++ b/src/components/UI/ClickOutside.ts
@@ -78,8 +78,6 @@ export default defineComponent({
     }
 
     const onPointerDown = (e: PointerEvent) => {
-      resetPointerDown()
-
       if (!element.value) return
       if (props.unableWhileModalOpen && shouldShowModal.value) return
       if (isInside(e)) return

--- a/src/components/UI/ClickOutside.ts
+++ b/src/components/UI/ClickOutside.ts
@@ -5,7 +5,6 @@ import {
   cloneVNode,
   computed,
   defineComponent,
-  ref,
   shallowRef
 } from 'vue'
 
@@ -27,7 +26,7 @@ const filterChildren = <T extends VNode>(vnodes: T[]) =>
   })
 
 /**
- * そのデフォルトスロットに指定した要素の外でクリックされたときにclickOutsideイベントを発火する
+ * そのデフォルトスロットに指定した要素の外でポインターが動いたかクリックが離されたときにclickOutsideイベントを発火する
  */
 export default defineComponent({
   name: 'ClickOutside',
@@ -58,12 +57,19 @@ export default defineComponent({
     const element = shallowRef<HTMLElement | ComponentPublicInstance>()
 
     const { shouldShowModal } = useModalStore()
-    const isPointerDownOutside = ref(false)
-    const pointerDownPosition = ref<{ x: number; y: number } | null>(null)
+    type PointerState = Pick<PointerEvent, 'pointerId' | 'clientX' | 'clientY'>
+    let pointerDown: PointerState | undefined
 
     const resetPointerDown = () => {
-      isPointerDownOutside.value = false
-      pointerDownPosition.value = null
+      pointerDown = undefined
+    }
+
+    const emitClickOutside = (e: PointerEvent) => {
+      resetPointerDown()
+
+      setTimeout(() => emit('clickOutside', e), 0)
+
+      if (props.stop) e.stopPropagation()
     }
 
     const isInside = (e: PointerEvent) => {
@@ -75,53 +81,49 @@ export default defineComponent({
       resetPointerDown()
 
       if (!element.value) return
-
       if (props.unableWhileModalOpen && shouldShowModal.value) return
+      if (isInside(e)) return
 
-      if (isInside(e)) {
-        return
+      pointerDown = {
+        pointerId: e.pointerId,
+        clientX: e.clientX,
+        clientY: e.clientY
       }
 
-      isPointerDownOutside.value = true
-      pointerDownPosition.value = { x: e.clientX, y: e.clientY }
-      if (props.stop) {
-        e.stopPropagation()
-      }
+      if (props.stop) e.stopPropagation()
     }
 
     const onPointerMove = (e: PointerEvent) => {
-      if (!isPointerDownOutside.value || !pointerDownPosition.value) return
+      if (!pointerDown) return
+      if (pointerDown.pointerId !== e.pointerId) return
+
+      if (e.buttons === 0) {
+        resetPointerDown()
+        return
+      }
 
       if (
-        e.clientX === pointerDownPosition.value.x &&
-        e.clientY === pointerDownPosition.value.y
+        e.clientX === pointerDown.clientX &&
+        e.clientY === pointerDown.clientY
       ) {
         return
       }
 
-      resetPointerDown()
-
-      setTimeout(() => {
-        emit('clickOutside', e)
-      }, 0)
-
-      if (props.stop) {
-        e.stopPropagation()
-      }
+      emitClickOutside(e)
     }
 
     const onPointerUp = (e: PointerEvent) => {
-      if (!isPointerDownOutside.value) return
+      if (!pointerDown) return
+      if (pointerDown.pointerId !== e.pointerId) return
+
+      emitClickOutside(e)
+    }
+
+    const onPointerCancel = (e: PointerEvent) => {
+      if (!pointerDown) return
+      if (pointerDown.pointerId !== e.pointerId) return
 
       resetPointerDown()
-
-      setTimeout(() => {
-        emit('clickOutside', e)
-      }, 0)
-
-      if (props.stop) {
-        e.stopPropagation()
-      }
     }
 
     const target = computed(() => (props.enabled ? window : null))
@@ -130,7 +132,7 @@ export default defineComponent({
     useEventListener(target, 'pointerdown', onPointerDown, listenerOptions)
     useEventListener(target, 'pointermove', onPointerMove, listenerOptions)
     useEventListener(target, 'pointerup', onPointerUp, listenerOptions)
-    useEventListener(target, 'pointercancel', resetPointerDown, listenerOptions)
+    useEventListener(target, 'pointercancel', onPointerCancel, listenerOptions)
 
     return () => {
       if (!slots['default']) {

--- a/src/components/UI/ClickOutside.ts
+++ b/src/components/UI/ClickOutside.ts
@@ -58,32 +58,62 @@ export default defineComponent({
     const element = shallowRef<HTMLElement | ComponentPublicInstance>()
 
     const { shouldShowModal } = useModalStore()
-    const isMouseDown = ref(false)
+    const isPointerDownOutside = ref(false)
+    const pointerDownPosition = ref<{ x: number; y: number } | null>(null)
+
+    const resetPointerDown = () => {
+      isPointerDownOutside.value = false
+      pointerDownPosition.value = null
+    }
+
+    const isInside = (e: PointerEvent) => {
+      const ele = unrefElement(element)
+      return ele === e.target || e.composedPath().includes(ele)
+    }
 
     const onPointerDown = (e: PointerEvent) => {
+      resetPointerDown()
+
       if (!element.value) return
 
       if (props.unableWhileModalOpen && shouldShowModal.value) return
 
-      const ele = unrefElement(element)
-      if (ele === e.target || e.composedPath().includes(ele)) {
+      if (isInside(e)) {
         return
       }
 
-      isMouseDown.value = true
+      isPointerDownOutside.value = true
+      pointerDownPosition.value = { x: e.clientX, y: e.clientY }
+      if (props.stop) {
+        e.stopPropagation()
+      }
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!isPointerDownOutside.value || !pointerDownPosition.value) return
+
+      if (
+        e.clientX === pointerDownPosition.value.x &&
+        e.clientY === pointerDownPosition.value.y
+      ) {
+        return
+      }
+
+      resetPointerDown()
+
+      setTimeout(() => {
+        emit('clickOutside', e)
+      }, 0)
+
       if (props.stop) {
         e.stopPropagation()
       }
     }
 
     const onPointerUp = (e: PointerEvent) => {
-      if (!isMouseDown.value) return
-      isMouseDown.value = false
+      if (!isPointerDownOutside.value) return
 
-      const ele = unrefElement(element)
-      if (ele === e.target || e.composedPath().includes(ele)) {
-        return
-      }
+      resetPointerDown()
 
       setTimeout(() => {
         emit('clickOutside', e)
@@ -98,7 +128,9 @@ export default defineComponent({
     const listenerOptions = { capture: true }
 
     useEventListener(target, 'pointerdown', onPointerDown, listenerOptions)
+    useEventListener(target, 'pointermove', onPointerMove, listenerOptions)
     useEventListener(target, 'pointerup', onPointerUp, listenerOptions)
+    useEventListener(target, 'pointercancel', resetPointerDown, listenerOptions)
 
     return () => {
       if (!slots['default']) {


### PR DESCRIPTION
## 概要

- clickOutside の仕様を変更

- 「外側でクリックして外側で離されてた時に反応」から、「外側でクリックしてポインターが移動したときまたはクリックを話したときに反応」するように変更

## なぜこの PR を入れたいのか

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

fix: #5000

## 動作確認の手順

- チャンネルヘッダーのチャンネルのモーダルを開いて、外側をクリック
- スタンプパレットを開いて、外側をクリック

## UI 変更部分のスクリーンショット

UI変更がないため省略

| Before               | After                |
| -------------------- | -------------------- |
| <!-- Paste image --> | <!-- Paste image --> |

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
  - uni-kakurenbo に方針を見てもらいはしました
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

- traQ_S-UI に PR 出すの初めてなので全体的によくわかってません。
- 非同期 QSoC なのでメンターとそんなにコミュニケーションが取れてません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * クリック外判定の精度を改善し、要素外で押下した後に移動しても正しく反応するようになりました。  
  * 押下開始位置と `pointerId` の追跡により、座標が変わったときのみ適切に発火し、誤検知・取りこぼしを減らしました。  
  * `pointerup` / `pointercancel` を含む終了時処理を整理し、状態リセットとイベント抑制の挙動を安定化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->