### PR TITLE
fix: プロフィール設定画面で未保存の警告が必要でないときにも出る問題を修正

### DIFF
--- a/src/components/Settings/composables/useStateDiff.ts
+++ b/src/components/Settings/composables/useStateDiff.ts
@@ -1,23 +1,24 @@
-import { type MaybeRef, toValue } from 'vue'
+import { type MaybeRefOrGetter, toValue } from 'vue'
 
 import { dequal } from 'dequal'
 
 const useStateDiff = <T>() => {
   const getDiffKeys = (
     state: Readonly<Partial<T>>,
-    storeState: Readonly<MaybeRef<T>>
+    storeStateRef: MaybeRefOrGetter<T>
   ) => {
+    const storeState = toValue(storeStateRef)
     return (Object.keys(state) as Array<keyof T>).filter(key => {
       const k = key as keyof T
-      return !dequal(state[k], toValue(storeState)[k])
+      return !dequal(state[k], storeState[k])
     })
   }
 
   const hasDiff = (
     state: Readonly<Partial<T>>,
-    storeState: Readonly<MaybeRef<T>>
+    storeStateRef: MaybeRefOrGetter<T>
   ): boolean => {
-    return getDiffKeys(state, storeState).length > 0
+    return getDiffKeys(state, storeStateRef).length > 0
   }
 
   return { getDiffKeys, hasDiff }

--- a/src/components/Settings/composables/useStateDiff.ts
+++ b/src/components/Settings/composables/useStateDiff.ts
@@ -1,21 +1,21 @@
-import type { Ref } from 'vue'
+import { type MaybeRef, toValue } from 'vue'
 
 import { dequal } from 'dequal'
 
 const useStateDiff = <T>() => {
   const getDiffKeys = (
     state: Readonly<Partial<T>>,
-    storeState: Readonly<Ref<T>>
+    storeState: Readonly<MaybeRef<T>>
   ) => {
     return (Object.keys(state) as Array<keyof T>).filter(key => {
       const k = key as keyof T
-      return !dequal(state[k], storeState.value[k])
+      return !dequal(state[k], toValue(storeState)[k])
     })
   }
 
   const hasDiff = (
     state: Readonly<Partial<T>>,
-    storeState: Readonly<Ref<T>>
+    storeState: Readonly<MaybeRef<T>>
   ): boolean => {
     return getDiffKeys(state, storeState).length > 0
   }

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -84,13 +84,12 @@ const useState = (detail: Ref<UserDetail>) => {
   const state = reactive({ ...profile.value })
 
   const { hasDiff } = useStateDiff<UserDetail>()
-  const isStateChanged = computed(() => {
-    const stateForDiff = {
-      ...state,
-      homeChannel: state.homeChannel === nullUuid ? null : state.homeChannel
-    }
-    return hasDiff(stateForDiff, detail)
-  })
+  const isStateChanged = computed(() => 
+    hasDiff(state, {
+      ...detail.value,
+      homeChannel: detail.value.homeChannel ?? nullUuid
+    })
+  )
 
   const handleReset = () => {
     if (!confirm('変更をリセットしますか？')) return

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -84,7 +84,7 @@ const useState = (detail: Ref<UserDetail>) => {
   const state = reactive({ ...profile.value })
 
   const { hasDiff } = useStateDiff<UserDetail>()
-  const isStateChanged = computed(() => 
+  const isStateChanged = computed(() =>
     hasDiff(state, {
       ...detail.value,
       homeChannel: detail.value.homeChannel ?? nullUuid

--- a/src/views/Settings/ProfileTab.vue
+++ b/src/views/Settings/ProfileTab.vue
@@ -84,7 +84,13 @@ const useState = (detail: Ref<UserDetail>) => {
   const state = reactive({ ...profile.value })
 
   const { hasDiff } = useStateDiff<UserDetail>()
-  const isStateChanged = computed(() => hasDiff(state, detail))
+  const isStateChanged = computed(() => {
+    const stateForDiff = {
+      ...state,
+      homeChannel: state.homeChannel === nullUuid ? null : state.homeChannel
+    }
+    return hasDiff(stateForDiff, detail)
+  })
 
   const handleReset = () => {
     if (!confirm('変更をリセットしますか？')) return


### PR DESCRIPTION
## 概要

プロフィール設定画面において、ホームチャンネルを"未設定"に設定した場合にのみ、設定画面を閉じた際に保存したにもかかわらず未保存である旨の警告が出る問題を修正しました。

その過程で、``useStateDiff``内の関数``getDiffKeys``・``hasDiff``の第二引数に``ref``でない生の値を与える必要が生じたため、後方互換性を保つために``Ref``ではなく``MaybeRef``と``toValue``を用いて関数の引数の型と内部処理に変更を加えました。

## なぜこの PR を入れたいのか

fix: #4948

## 動作確認の手順

1. プロフィール設定画面を開く
2. ホームチャンネルを"未設定"に設定する
3. プロフィールを更新する
4. ×ボタンで設定画面を閉じる

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

チャンネルIDがnullUuidになるのは、rootチャンネルを指定した場合のみですか？修正の途中で、未選択の場合などでもnullUuidが返されることに気づきました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * プロフィール編集画面で、チャンネル設定の差分判定をより正確にし、更新可否の判定ズレを改善しました。
  * 差分判定の比較対象の値を適切に実体化して比較することで、不要な更新判定を抑えました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->