### PR TITLE
fix: メッセージ送信中に添付ファイルを削除できないようにする

### DIFF
--- a/src/components/Main/MainView/MessageInput/MessageInput.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInput.vue
@@ -20,7 +20,11 @@
       :class="$style.preview"
       :text="state.text"
     />
-    <MessageInputFileList :class="$style.fileList" :channel-id="channelId" />
+    <MessageInputFileList
+      :class="$style.fileList"
+      :channel-id="channelId"
+      :is-posting="isPosting"
+    />
     <div v-if="isArchived" :class="$style.inputContainer" data-is-archived>
       <AIcon :class="$style.controls" name="archive" mdi />
       <div>アーカイブチャンネルのため、投稿できません</div>

--- a/src/components/Main/MainView/MessageInput/MessageInputFileList.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileList.vue
@@ -5,6 +5,7 @@
       :key="i"
       :attachment="attachment"
       :class="$style.element"
+      :is-posting="isPosting"
       @item-remove="removeAttachmentAt(i)"
     />
   </div>
@@ -20,9 +21,15 @@ import type { ChannelId } from '/@/types/entity-ids'
 
 import MessageInputFileListItem from './MessageInputFileListItem.vue'
 
-const props = defineProps<{
-  channelId: ChannelId | VirtualChannelId
-}>()
+const props = withDefaults(
+  defineProps<{
+    channelId: ChannelId | VirtualChannelId
+    isPosting?: boolean
+  }>(),
+  {
+    isPosting: false
+  }
+)
 
 const { addErrorToast } = useToastStore()
 const { attachments, removeAttachmentAt } = useMessageInputStateAttachment(

--- a/src/components/Main/MainView/MessageInput/MessageInputFileListItem.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileListItem.vue
@@ -2,6 +2,7 @@
   <div :class="$style.container">
     <MessageInputFileListItemCloseButton
       :class="$style.closeButton"
+      :is-posting="isPosting"
       @click="emit('itemRemove')"
     />
     <MessageInputFileListItemImage
@@ -28,9 +29,15 @@ import type { Attachment } from '/@/store/ui/messageInputStateStore'
 import MessageInputFileListItemCloseButton from './MessageInputFileListItemCloseButton.vue'
 import MessageInputFileListItemImage from './MessageInputFileListItemImage.vue'
 
-const props = defineProps<{
-  attachment: Attachment
-}>()
+const props = withDefaults(
+  defineProps<{
+    attachment: Attachment
+    isPosting?: boolean
+  }>(),
+  {
+    isPosting: false
+  }
+)
 
 const emit = defineEmits<{
   (e: 'itemRemove'): void

--- a/src/components/Main/MainView/MessageInput/MessageInputFileListItemCloseButton.vue
+++ b/src/components/Main/MainView/MessageInput/MessageInputFileListItemCloseButton.vue
@@ -1,6 +1,7 @@
 <template>
   <button
     :class="$style.container"
+    :disabled="props.isPosting"
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
   >
@@ -20,6 +21,15 @@ import { computed } from 'vue'
 import CircleIcon from '/@/components/UI/CircleIcon.vue'
 import useHover from '/@/composables/dom/useHover'
 import { useThemeSettings } from '/@/store/app/themeSettings'
+
+const props = withDefaults(
+  defineProps<{
+    isPosting?: boolean
+  }>(),
+  {
+    isPosting: false
+  }
+)
 
 const { currentTheme } = useThemeSettings()
 const { isHovered, onMouseEnter, onMouseLeave } = useHover()
@@ -48,5 +58,9 @@ const iconColor = computed(
   justify-content: center;
   cursor: pointer;
   z-index: $z-index-message-input-file-close-button;
+  &[disabled] {
+    @include color-ui-secondary-inactive;
+    cursor: not-allowed;
+  }
 }
 </style>

--- a/src/components/ShareTarget/ShareTargetForm.vue
+++ b/src/components/ShareTarget/ShareTargetForm.vue
@@ -6,7 +6,10 @@
       label="投稿先チャンネル"
       :options="channelOptions"
     />
-    <ShareTargetMessageInput :class="[$style.item, $style.input]" />
+    <ShareTargetMessageInput
+      :class="[$style.item, $style.input]"
+      :is-posting="isPosting"
+    />
     <FormButton
       :class="[$style.item, $style.button]"
       label="送信"

--- a/src/components/ShareTarget/ShareTargetMessageInput.vue
+++ b/src/components/ShareTarget/ShareTargetMessageInput.vue
@@ -29,6 +29,7 @@
       <MessageInputFileList
         :class="$style.fileList"
         channel-id="share-target"
+        :is-posting="props.isPosting"
       />
     </div>
   </div>
@@ -50,6 +51,15 @@ import { useToastStore } from '/@/store/ui/toast'
 
 import useAttachments from '../Main/MainView/MessageInput/composables/useAttachments'
 import useTextStampPickerInvoker from '../Main/MainView/composables/useTextStampPickerInvoker'
+
+const props = withDefaults(
+  defineProps<{
+    isPosting?: boolean
+  }>(),
+  {
+    isPosting: false
+  }
+)
 
 const { fetchStampHistory } = useStampHistory()
 const { fetchStampRecommendations } = useStampRecommendations()


### PR DESCRIPTION
## 概要
メッセージ送信中に×ボタンを押せなくすることで添付ファイルを削除できないようにする

## なぜこの PR を入れたいのか

fix: #5033

## 動作確認の手順
1. 画像を添付する
2. 送信ボタンを押す
3. 送信中に×ボタンを押そうとして押せないことを確認する

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
propsを沢山使ったので、方針として正しいか確認してほしいです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 投稿中の状態に応じて、メッセージ入力欄の添付ファイル表示や操作を制御できるようになりました。
  * 共有送信画面でも同じ投稿中ステータスが反映され、入力体験が統一されました。

* **改善**
  * 投稿中は添付ファイルの削除ボタンが無効になり、誤操作しにくくなりました。
  * 未指定時の動作はこれまで通りで、既存の利用方法への影響を抑えています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->