### PR TITLE
スタンプ・チャンネル名・メンションの補完時に前後に空白を追加

### DIFF
--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
@@ -1,0 +1,51 @@
+import { type MaybeRefOrGetter, type Ref, computed, toValue } from 'vue'
+
+import type { Target, Word, WordWithId } from '/@/lib/suggestion/basic'
+
+const insertSpaceOverride = <
+  Params extends {
+    onSelect: (word: Word) => void
+    confirmedPart: MaybeRefOrGetter<string>
+    textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>
+    target: Ref<Target>
+  }
+>(
+  input: Params
+) => {
+  const isStampSuggestion = computed(() =>
+    toValue(input.confirmedPart).startsWith(':')
+  )
+  const isChannelSuggestion = computed(() =>
+    toValue(input.confirmedPart).startsWith('#')
+  )
+
+  const onSelect = (word: WordWithId) => {
+    const textarea = toValue(input.textareaRef)
+    const target = input.target
+    if (!textarea) return
+    let insertingText: string
+    if (!textarea.value || target.value.begin === 0) {
+      insertingText = word.text + ' '
+    } else {
+      const prevChar = textarea.value[target.value.begin - 1]
+      if (prevChar === ' ' || prevChar === '\n') {
+        insertingText = word.text + ' '
+      } else {
+        insertingText = ' ' + word.text + ' '
+      }
+    }
+
+    input.onSelect({ ...word, text: insertingText })
+  }
+
+  return {
+    condition: computed(
+      () => isStampSuggestion.value || isChannelSuggestion.value
+    ),
+    overrides: {
+      onSelect
+    }
+  }
+}
+
+export default insertSpaceOverride

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
@@ -2,6 +2,27 @@ import { type MaybeRefOrGetter, type Ref, computed, toValue } from 'vue'
 
 import type { Target, Word, WordWithId } from '/@/lib/suggestion/basic'
 
+const insertSpaces = (
+  textInTextarea: string,
+  word: string,
+  beginIndex: number
+) => {
+  if (!textInTextarea || beginIndex === 0) {
+    return word + ' '
+  } else {
+    const prevChar = textInTextarea[beginIndex - 1]
+    if (prevChar === ' ' || prevChar === '\n') {
+      return word + ' '
+    }
+    //アイコンを打とうとしているときにはスペースを入れない
+    else if (prevChar === ':' && word[0] === '@') {
+      return word
+    } else {
+      return ' ' + word + ' '
+    }
+  }
+}
+
 const insertSpaceOverride = <
   Params extends {
     onSelect: (word: Word) => void
@@ -12,37 +33,25 @@ const insertSpaceOverride = <
 >(
   input: Params
 ) => {
-  const confirmed = toValue(input.confirmedPart) 
-  const shouldInsertSpaces = computed(
-    () =>
+  const shouldInsertSpaces = computed(() => {
+    const confirmed = toValue(input.confirmedPart)
+    return (
       confirmed.startsWith(':') ||
       confirmed.startsWith('#') ||
       confirmed.startsWith('@')
-  )
+    )
+  })
 
   const onSelect = (word: WordWithId) => {
     const textarea = toValue(input.textareaRef)
     const target = input.target
     if (!textarea) return
 
-    const insertSpaces = () => {
-      if (!textarea.value || target.value.begin === 0) {
-        return word.text + ' '
-      } else {
-        const prevChar = textarea.value[target.value.begin - 1]
-        if (prevChar === ' ' || prevChar === '\n') {
-          return word.text + ' '
-        }
-        //アイコンを打とうとしているときにはスペースを入れない
-        else if (prevChar === ':' && word.text[0] === '@') {
-          return word.text
-        } else {
-          return ' ' + word.text + ' '
-        }
-      }
-    }
-
-    const insertingText = insertSpaces()
+    const insertingText = insertSpaces(
+      textarea.value,
+      word.text,
+      target.value.begin
+    )
     input.onSelect({ ...word, text: insertingText })
   }
 

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
@@ -12,11 +12,12 @@ const insertSpaceOverride = <
 >(
   input: Params
 ) => {
+  const confirmed = toValue(input.confirmedPart) 
   const shouldInsertSpaces = computed(
     () =>
-      toValue(input.confirmedPart).startsWith(':') ||
-      toValue(input.confirmedPart).startsWith('#') ||
-      toValue(input.confirmedPart).startsWith('@')
+      confirmed.startsWith(':') ||
+      confirmed.startsWith('#') ||
+      confirmed.startsWith('@')
   )
 
   const onSelect = (word: WordWithId) => {

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/insertSpace.ts
@@ -12,36 +12,41 @@ const insertSpaceOverride = <
 >(
   input: Params
 ) => {
-  const isStampSuggestion = computed(() =>
-    toValue(input.confirmedPart).startsWith(':')
-  )
-  const isChannelSuggestion = computed(() =>
-    toValue(input.confirmedPart).startsWith('#')
+  const shouldInsertSpaces = computed(
+    () =>
+      toValue(input.confirmedPart).startsWith(':') ||
+      toValue(input.confirmedPart).startsWith('#') ||
+      toValue(input.confirmedPart).startsWith('@')
   )
 
   const onSelect = (word: WordWithId) => {
     const textarea = toValue(input.textareaRef)
     const target = input.target
     if (!textarea) return
-    let insertingText: string
-    if (!textarea.value || target.value.begin === 0) {
-      insertingText = word.text + ' '
-    } else {
-      const prevChar = textarea.value[target.value.begin - 1]
-      if (prevChar === ' ' || prevChar === '\n') {
-        insertingText = word.text + ' '
+
+    const insertSpaces = () => {
+      if (!textarea.value || target.value.begin === 0) {
+        return word.text + ' '
       } else {
-        insertingText = ' ' + word.text + ' '
+        const prevChar = textarea.value[target.value.begin - 1]
+        if (prevChar === ' ' || prevChar === '\n') {
+          return word.text + ' '
+        }
+        //アイコンを打とうとしているときにはスペースを入れない
+        else if (prevChar === ':' && word.text[0] === '@') {
+          return word.text
+        } else {
+          return ' ' + word.text + ' '
+        }
       }
     }
 
+    const insertingText = insertSpaces()
     input.onSelect({ ...word, text: insertingText })
   }
 
   return {
-    condition: computed(
-      () => isStampSuggestion.value || isChannelSuggestion.value
-    ),
+    condition: shouldInsertSpaces,
     overrides: {
       onSelect
     }

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
@@ -1,6 +1,11 @@
-import { type MaybeRefOrGetter, computed, toValue } from 'vue'
+import { type MaybeRefOrGetter, type Ref, computed, toValue } from 'vue'
 
-import type { Candidate, Word, WordWithId } from '/@/lib/suggestion/basic'
+import type {
+  Candidate,
+  Target,
+  Word,
+  WordWithId
+} from '/@/lib/suggestion/basic'
 import { useStampHistory } from '/@/store/domain/stampHistory'
 import { useStampRecommendations } from '/@/store/domain/stampRecommendations'
 
@@ -9,6 +14,8 @@ const stampSuggestionOverride = <
     onSelect: (word: Word) => void
     confirmedPart: MaybeRefOrGetter<string>
     suggestedCandidates: MaybeRefOrGetter<Candidate[]>
+    textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>
+    target: Ref<Target>
   }
 >(
   input: Params
@@ -32,7 +39,23 @@ const stampSuggestionOverride = <
   const onSelect = (word: WordWithId) => {
     upsertLocalStampHistory(word.id, new Date())
     recordStampUsage(word.id)
-    input.onSelect({ ...word, text: `${word.text}:` })
+
+    const textarea = toValue(input.textareaRef)
+    const target = input.target
+    if (!textarea) return
+    let insertingText: string
+    if (!textarea.value || target.value.begin === 0) {
+      insertingText = `${word.text}: `
+    } else {
+      const prevChar = textarea.value[target.value.begin - 1]
+      if (prevChar === ' ' || prevChar === '\n') {
+        insertingText = `${word.text}: `
+      } else {
+        insertingText = ` ${word.text}: `
+      }
+    }
+    
+    input.onSelect({ ...word, text: insertingText })
   }
 
   return {

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
@@ -37,9 +37,6 @@ const stampSuggestionOverride = <
   })
 
   const onSelect = (word: WordWithId) => {
-    upsertLocalStampHistory(word.id, new Date())
-    recordStampUsage(word.id)
-
     const textarea = toValue(input.textareaRef)
     const target = input.target
     if (!textarea) return
@@ -55,6 +52,9 @@ const stampSuggestionOverride = <
       }
     }
     
+    upsertLocalStampHistory(word.id, new Date())
+    recordStampUsage(word.id)
+
     input.onSelect({ ...word, text: insertingText })
   }
 

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
@@ -1,11 +1,6 @@
-import { type MaybeRefOrGetter, type Ref, computed, toValue } from 'vue'
+import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
-import type {
-  Candidate,
-  Target,
-  Word,
-  WordWithId
-} from '/@/lib/suggestion/basic'
+import type { Candidate, Word, WordWithId } from '/@/lib/suggestion/basic'
 import { useStampHistory } from '/@/store/domain/stampHistory'
 import { useStampRecommendations } from '/@/store/domain/stampRecommendations'
 
@@ -14,8 +9,6 @@ const stampSuggestionOverride = <
     onSelect: (word: Word) => void
     confirmedPart: MaybeRefOrGetter<string>
     suggestedCandidates: MaybeRefOrGetter<Candidate[]>
-    textareaRef: MaybeRefOrGetter<HTMLTextAreaElement | undefined>
-    target: Ref<Target>
   }
 >(
   input: Params
@@ -37,25 +30,10 @@ const stampSuggestionOverride = <
   })
 
   const onSelect = (word: WordWithId) => {
-    const textarea = toValue(input.textareaRef)
-    const target = input.target
-    if (!textarea) return
-    let insertingText: string
-    if (!textarea.value || target.value.begin === 0) {
-      insertingText = `${word.text}: `
-    } else {
-      const prevChar = textarea.value[target.value.begin - 1]
-      if (prevChar === ' ' || prevChar === '\n') {
-        insertingText = `${word.text}: `
-      } else {
-        insertingText = ` ${word.text}: `
-      }
-    }
-    
     upsertLocalStampHistory(word.id, new Date())
     recordStampUsage(word.id)
 
-    input.onSelect({ ...word, text: insertingText })
+    input.onSelect({ ...word, text: `${word.text}:` })
   }
 
   return {

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/overrides/stampSuggestion.ts
@@ -32,7 +32,6 @@ const stampSuggestionOverride = <
   const onSelect = (word: WordWithId) => {
     upsertLocalStampHistory(word.id, new Date())
     recordStampUsage(word.id)
-
     input.onSelect({ ...word, text: `${word.text}:` })
   }
 

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useSuggester.ts
@@ -1,11 +1,13 @@
 import { toOverridable } from '/@/lib/suggestion/applier'
 
 import channelSuggestionOverride from './overrides/channelSuggestion'
+import insertSpaceOverride from './overrides/insertSpace'
 import stampSuggestionOverride from './overrides/stampSuggestion'
 import useWordSuggester from './useWordSuggester'
 
 const useSuggester = (...input: Parameters<typeof useWordSuggester>) => {
   return toOverridable(useWordSuggester(...input))
+    .overrides(insertSpaceOverride)
     .overrides(channelSuggestionOverride)
     .overrides(stampSuggestionOverride)
 }

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
@@ -161,21 +161,7 @@ const useWordSuggester = (
   }
 
   const onSelect = (word: Word) => {
-    const textarea = toValue(textareaRef)
-
-    if (!textarea) return
-    let insertingText: string
-    if (!textarea.value || target.value.begin === 0) {
-      insertingText = word.text + ' '
-    } else {
-      const prevChar = textarea.value[target.value.begin - 1]
-      if (prevChar === ' ' || prevChar === '\n') {
-        insertingText = word.text + ' '
-      } else {
-        insertingText = ' ' + word.text + ' '
-      }
-    }
-    insertText(insertingText)
+    insertText(word.text)
     isSuggesterShown.value = false
   }
 
@@ -199,7 +185,9 @@ const useWordSuggester = (
     position,
     suggestedCandidates,
     selectedIndex,
-    confirmedPart
+    confirmedPart,
+    target,
+    textareaRef
   }
 }
 

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
@@ -161,7 +161,23 @@ const useWordSuggester = (
   }
 
   const onSelect = (word: Word) => {
-    insertText(word.text)
+    const textarea = toValue(textareaRef)
+    
+    if(!textarea) return
+    let insertingText :string;
+    if(!textarea.value || target.value.begin === 0){
+      insertingText = word.text + " "
+    }
+    else{
+      const prevChar = textarea.value[target.value.begin - 1]
+      if(prevChar === " " || prevChar === "\n"){
+        insertingText = word.text + " "
+      }
+      else{
+        insertingText = " " + word.text + " "
+      }
+    }
+    insertText(insertingText)
     isSuggesterShown.value = false
   }
 

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
@@ -164,7 +164,7 @@ const useWordSuggester = (
     const textarea = toValue(textareaRef)
     
     if(!textarea) return
-    let insertingText :string;
+    let insertingText: string;
     if(!textarea.value || target.value.begin === 0){
       insertingText = word.text + " "
     }

--- a/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
+++ b/src/components/Main/MainView/MessageInput/composables/suggestion/useWordSuggester.ts
@@ -162,19 +162,17 @@ const useWordSuggester = (
 
   const onSelect = (word: Word) => {
     const textarea = toValue(textareaRef)
-    
-    if(!textarea) return
-    let insertingText: string;
-    if(!textarea.value || target.value.begin === 0){
-      insertingText = word.text + " "
-    }
-    else{
+
+    if (!textarea) return
+    let insertingText: string
+    if (!textarea.value || target.value.begin === 0) {
+      insertingText = word.text + ' '
+    } else {
       const prevChar = textarea.value[target.value.begin - 1]
-      if(prevChar === " " || prevChar === "\n"){
-        insertingText = word.text + " "
-      }
-      else{
-        insertingText = " " + word.text + " "
+      if (prevChar === ' ' || prevChar === '\n') {
+        insertingText = word.text + ' '
+      } else {
+        insertingText = ' ' + word.text + ' '
       }
     }
     insertText(insertingText)


### PR DESCRIPTION
（行頭・空白の後には追加しない）

## 概要
予測変換から挿入したスタンプ・チャンネル・メンションの前後にスペースを入れる
ただし、直前が行頭もしくはスペースの時、直前にスペースを挿入しない

## なぜこの PR を入れたいのか
見た目を整える
https://q.trap.jp/messages/019e2441-2a39-795d-baf5-8deb2f963305
fix: #5168

## 動作確認の手順
スタンプやチャンネル、メンションを入力して候補を選択して補完してみる

## UI 変更部分のスクリーンショット
変更なし
| Before               | After                |
| -------------------- | -------------------- |
| <!-- Paste image --> | <!-- Paste image --> |

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * 候補語（スタンプ／チャンネル）の選択時、カーソル位置の前後文字（スペース／改行）に応じて挿入テキストの前後の空白を自動調整しました。
  * 補完対象の参照（挿入位置やターゲット）をより正確に行えるようになり、意図しない挿入を防ぎます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->