### PR TITLE
hot-fix(dependabot): remove unsupported cooldown property for docker/github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 7
-      semver-major-days: 30
+      default-days: 14
     open-pull-requests-limit: 10
     groups:
       non-majors:
@@ -45,8 +44,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 7
-      semver-major-days: 30
+      default-days: 14
     open-pull-requests-limit: 10
     groups:
       non-majors:


### PR DESCRIPTION
## Summary
- `semver-major-days` under `cooldown` is only supported for ecosystems with semver versioning; Dependabot rejected it for `docker` and `github-actions`.
- Removed `semver-major-days` from those two entries and raised `default-days` to 14 to keep a reasonable cooldown.

## Test plan
- [ ] Confirm Dependabot config validates (no more "not supported for the package ecosystem" errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の更新を確認する待機期間を7日から14日に延長しました。
  * npmおよびGitHub Actionsの更新に適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->