### PR TITLE
feat: サイドバーにスレッド一覧画面を作成

### DIFF
--- a/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebar.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebar.vue
@@ -11,12 +11,18 @@
             :channel-id="channelId"
             :viewer-ids="activeViewingUsers"
             :inactive-viewer-ids="inactiveViewingUsers"
+            :threads-count="0"
             :pinned-messages-count="pinnedMessages.length"
+            @move-to-threads="moveToThreadsPage"
             @move-to-pinned="moveToPinnedPage"
             @move-to-events="moveToEventsPage"
           />
         </template>
       </PrimaryViewSidebarPage>
+      <SidebarThreadsPage
+        v-else-if="page === 'threads'"
+        @move-back="moveToDefaultPage"
+      />
       <SidebarPinnedPage
         v-else-if="page === 'pinned'"
         :pinned-messages="pinnedMessages"
@@ -49,6 +55,7 @@ import PrimaryViewSidebarPage from '/@/components/Main/MainView/PrimaryViewSideb
 import SidebarEventsPage from '/@/components/Main/MainView/PrimaryViewSidebar/SidebarEventsPage.vue'
 import SidebarHeader from '/@/components/Main/MainView/PrimaryViewSidebar/SidebarHeader.vue'
 import SidebarPinnedPage from '/@/components/Main/MainView/PrimaryViewSidebar/SidebarPinnedPage.vue'
+import SidebarThreadsPage from '/@/components/Main/MainView/PrimaryViewSidebar/SidebarThreadsPage.vue'
 import useChannelSidebarCommon from '/@/components/Main/MainView/composables/useChannelSidebarCommon'
 import useToggle from '/@/composables/utils/useToggle'
 import { useChannelsStore } from '/@/store/entities/channels'
@@ -69,6 +76,7 @@ const { channelsMap } = useChannelsStore()
 const {
   page,
   moveToDefaultPage,
+  moveToThreadsPage,
   moveToPinnedPage,
   moveToEventsPage,
   openSidebar

--- a/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarContent.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarContent.vue
@@ -12,6 +12,11 @@
       :class="$style.sidebarItem"
     />
     <ChannelSidebarTopic :class="$style.sidebarItem" :channel-id="channelId" />
+    <ChannelSidebarThreads
+      :threads-length="threadsCount"
+      :class="$style.sidebarItem"
+      @click-link="emit('moveToThreads')"
+    />
     <ChannelSidebarPinned
       :pinned-message-length="pinnedMessagesCount"
       :class="$style.sidebarItem"
@@ -49,6 +54,7 @@ import ChannelSidebarMember from './ChannelSidebarMember.vue'
 import ChannelSidebarPinned from './ChannelSidebarPinned.vue'
 import ChannelSidebarQall from './ChannelSidebarQall.vue'
 import ChannelSidebarRelation from './ChannelSidebarRelation.vue'
+import ChannelSidebarThreads from './ChannelSidebarThreads.vue'
 import ChannelSidebarTopic from './ChannelSidebarTopic.vue'
 import ChannelSidebarViewers from './ChannelSidebarViewers.vue'
 
@@ -61,14 +67,17 @@ const props = withDefaults(
     channelId: ChannelId
     viewerIds: readonly UserId[]
     inactiveViewerIds: readonly UserId[]
+    threadsCount?: number
     pinnedMessagesCount?: number
   }>(),
   {
+    threadsCount: 0,
     pinnedMessagesCount: 0
   }
 )
 
 const emit = defineEmits<{
+  (e: 'moveToThreads'): void
   (e: 'moveToPinned'): void
   (e: 'moveToEvents'): void
 }>()

--- a/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarThreads.vue
+++ b/src/components/Main/MainView/ChannelView/ChannelSidebar/ChannelSidebarThreads.vue
@@ -1,0 +1,24 @@
+<template>
+  <SidebarContentContainerLink
+    title="スレッド"
+    :count="threadsLength"
+    @click-link="emit('clickLink')"
+  />
+</template>
+
+<script lang="ts" setup>
+import SidebarContentContainerLink from '/@/components/Main/MainView/PrimaryViewSidebar/SidebarContentContainerLink.vue'
+
+withDefaults(
+  defineProps<{
+    threadsLength?: number
+  }>(),
+  {
+    threadsLength: 0
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'clickLink'): void
+}>()
+</script>

--- a/src/components/Main/MainView/PrimaryViewSidebar/SidebarThreadsPage.vue
+++ b/src/components/Main/MainView/PrimaryViewSidebar/SidebarThreadsPage.vue
@@ -4,7 +4,7 @@
       <SidebarHeader text="スレッド" />
     </template>
     <template #content>
-      <!-- ここに中身を入れる -->
+      <!-- TODO:#4820 ここに中身を入れる -->
     </template>
   </PrimaryViewSidebarPage>
 </template>

--- a/src/components/Main/MainView/PrimaryViewSidebar/SidebarThreadsPage.vue
+++ b/src/components/Main/MainView/PrimaryViewSidebar/SidebarThreadsPage.vue
@@ -1,0 +1,20 @@
+<template>
+  <PrimaryViewSidebarPage show-back-button @back="emit('moveBack')">
+    <template #header>
+      <SidebarHeader text="スレッド" />
+    </template>
+    <template #content>
+      <!-- ここに中身を入れる -->
+    </template>
+  </PrimaryViewSidebarPage>
+</template>
+
+<script lang="ts" setup>
+import PrimaryViewSidebarPage from '/@/components/Main/MainView/PrimaryViewSidebar/PrimaryViewSidebarPage.vue'
+
+import SidebarHeader from './SidebarHeader.vue'
+
+const emit = defineEmits<{
+  (e: 'moveBack'): void
+}>()
+</script>

--- a/src/components/Main/MainView/composables/useChannelSidebarCommon.ts
+++ b/src/components/Main/MainView/composables/useChannelSidebarCommon.ts
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import useSidebar from '/@/composables/mainView/useSidebar'
 import { useBrowserSettings } from '/@/store/app/browserSettings'
 
-type ChannelSidebarPage = 'default' | 'pinned' | 'events'
+type ChannelSidebarPage = 'default' | 'threads' | 'pinned' | 'events'
 
 const useChannelSidebarCommon = () => {
   const { lastOpenChannelId } = useBrowserSettings()
@@ -11,6 +11,9 @@ const useChannelSidebarCommon = () => {
   const page = ref<ChannelSidebarPage>('default')
   const moveToDefaultPage = () => {
     page.value = 'default'
+  }
+  const moveToThreadsPage = () => {
+    page.value = 'threads'
   }
   const moveToPinnedPage = () => {
     page.value = 'pinned'
@@ -28,6 +31,7 @@ const useChannelSidebarCommon = () => {
   return {
     page,
     moveToDefaultPage,
+    moveToThreadsPage,
     moveToPinnedPage,
     moveToEventsPage,
     openSidebar,


### PR DESCRIPTION
## 概要

* サイドバーにスレッド一覧ページへのリンクを追加
* 押すと、何もないスレッド一覧ページが開くように

## なぜこの PR を入れたいのか

close: #5234

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="322" height="497" alt="image" src="https://github.com/user-attachments/assets/3eecb220-e310-4eca-b3df-618c1eb614bf" /> | <img width="304" height="642" alt="image" src="https://github.com/user-attachments/assets/e3ca7d8e-6dbb-481a-90cc-493d35ea83bc" /><img width="323" height="751" alt="image" src="https://github.com/user-attachments/assets/a276e402-4f5e-4843-a1bc-7e1356348c3d" /> |

## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど

* 追加したリンクボタンの位置
* 変数名

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チャンネルサイドバーに「スレッド」へのリンクを追加しました。
  * スレッド件数をサイドバー上で確認できるようになりました。
  * スレッド専用ページへの移動と、サイドバーへ戻る操作に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->