### PR TITLE
feat: グループ作成時に、そのグループidのハッシュへ飛ぶ

### DIFF
--- a/src/components/Modal/GroupCreateModal/GroupCreateModal.vue
+++ b/src/components/Modal/GroupCreateModal/GroupCreateModal.vue
@@ -89,7 +89,7 @@ const create = async () => {
       await apis.addUserGroupMember(group.id, { id: myIdV, role: '' })
     }
     await popModal()
-    router.replace({
+    void router.replace({
       hash: group.id ? `#${group.id}` : ''
     })
   } catch (e) {

--- a/src/components/Modal/GroupCreateModal/GroupCreateModal.vue
+++ b/src/components/Modal/GroupCreateModal/GroupCreateModal.vue
@@ -90,7 +90,7 @@ const create = async () => {
     }
     await popModal()
     void router.replace({
-      hash: group.id ? `#${group.id}` : ''
+      hash: `#${group.id}`
     })
   } catch (e) {
     if (e instanceof AxiosError && e.response?.status === 409) {

--- a/src/components/Modal/GroupCreateModal/GroupCreateModal.vue
+++ b/src/components/Modal/GroupCreateModal/GroupCreateModal.vue
@@ -39,6 +39,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 import { AxiosError } from 'axios'
 
@@ -66,6 +67,8 @@ const type = ref('')
 const addMember = ref(true)
 const errorMessage = ref<string | null>(null)
 
+const router = useRouter()
+
 const validateName = () => {
   errorMessage.value = isValidGroupName(name.value)
     ? null
@@ -86,6 +89,9 @@ const create = async () => {
       await apis.addUserGroupMember(group.id, { id: myIdV, role: '' })
     }
     await popModal()
+    router.replace({
+      hash: group.id ? `#${group.id}` : ''
+    })
   } catch (e) {
     if (e instanceof AxiosError && e.response?.status === 409) {
       addErrorToast('既に同じ名前のグループが存在しています')


### PR DESCRIPTION
## 概要

グループ作成時、グループマネージャーの作成したグループのhashへ飛びます。

## なぜこの PR を入れたいのか

作成時にそのグループまでスクロールされたい。
また、グループ作成の後、ユーザーの追加等をするだろうなので、編集画面も開かれてほしいです。

## 動作確認の手順

グループを作成する。

## UI 変更部分のスクリーンショット

UI変更なし。

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * グループ作成後に、作成したグループに紐づくURLハッシュへ自動的に同期するようになりました。
  * グループIDが取得できない場合は、URLハッシュがクリアされます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->