### PR TITLE
text-autospace: normalを当てる

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -24,6 +24,7 @@ body {
   -webkit-overflow-scrolling: touch;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;
+  text-autospace: normal;
   text-rendering: optimizeLegibility;
   touch-action: manipulation;
   overscroll-behavior-y: contain;


### PR DESCRIPTION
## 概要
text-autospace: normalをglobal.scssに追加します。

## なぜこの PR を入れたいのか

## 動作確認の手順

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="590" height="285" alt="スクリーンショット 2026-07-29 013735" src="https://github.com/user-attachments/assets/680b1493-da23-48e5-9167-2c6ba21f4c47" />| <img width="587" height="332" alt="スクリーンショット 2026-07-29 014335" src="https://github.com/user-attachments/assets/43e03794-f9ce-4756-bd0d-a24833644dda" /> |



## PR を出す前の確認事項

- [x] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * テキスト間の自動スペース挿入を標準設定に調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->