### PR TITLE
refactor: fix typos in identifiers, comments, and tests

### DIFF
--- a/src/assets/icons/README.md
+++ b/src/assets/icons/README.md
@@ -4,5 +4,5 @@ Place svg files here, then you can use the icon with `/@/components/UI/Icon.vue`
 
 ## Note
 
-- Viewbox and fills on `path` are removed by svgo, then overriden by icon component.
+- Viewbox and fills on `path` are removed by svgo, then overridden by icon component.
 - We recommend placing icons in 24x24 box.

--- a/src/components/Main/NavigationBar/NavigationContent/UserList.vue
+++ b/src/components/Main/NavigationBar/NavigationContent/UserList.vue
@@ -11,10 +11,10 @@
     </div>
     <template v-else>
       <UsersGradeList
-        v-for="userListbyGrade in userListsByGrade"
-        :key="userListbyGrade.gradeName"
-        :name="userListbyGrade.gradeName"
-        :users="userListbyGrade.users"
+        v-for="userListByGrade in userListsByGrade"
+        :key="userListByGrade.gradeName"
+        :name="userListByGrade.gradeName"
+        :users="userListByGrade.users"
         :class="$style.list"
       />
     </template>

--- a/src/components/Main/PopupNavigatior/PopupNavigator.vue
+++ b/src/components/Main/PopupNavigatior/PopupNavigator.vue
@@ -157,7 +157,7 @@ const useNavigator = (emit: (name: 'clickIcon') => void) => {
       },
       onPointerUp
     },
-    // capture=trueなのはstopPropergationでスワイプを無効化するため
+    // capture=trueなのはstopPropagationでスワイプを無効化するため
     { capture: true, passive: true }
   )
 

--- a/src/composables/media/useAudio.ts
+++ b/src/composables/media/useAudio.ts
@@ -79,7 +79,7 @@ const useIsPlaying = (
 export const useCurrentTime = (audio: Ref<HTMLAudioElement | undefined>) => {
   const nativeCurrentTime = ref(toFinite(audio.value?.currentTime, 0))
 
-  const onTimeupdated = () => {
+  const onTimeUpdated = () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     nativeCurrentTime.value = toFinite(audio.value!.currentTime, 0)
   }
@@ -88,11 +88,11 @@ export const useCurrentTime = (audio: Ref<HTMLAudioElement | undefined>) => {
     audio,
     (newAudio, oldAudio) => {
       if (oldAudio) {
-        oldAudio.removeEventListener('timeupdate', onTimeupdated)
+        oldAudio.removeEventListener('timeupdate', onTimeUpdated)
       }
       if (newAudio) {
         nativeCurrentTime.value = toFinite(newAudio.currentTime, 0)
-        newAudio.addEventListener('timeupdate', onTimeupdated)
+        newAudio.addEventListener('timeupdate', onTimeUpdated)
       }
     },
     { immediate: true }

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -242,9 +242,9 @@ const useChannelPath = () => {
         replaceInitialChannels.join('/').length > MAX_SHORT_PATH_LENGTH &&
         replaceInitialIndex < channelsLength - 2
       ) {
-        const indexinitial = channelShortenedNames[replaceInitialIndex]
-        if (indexinitial !== undefined) {
-          replaceInitialChannels[replaceInitialIndex] = indexinitial
+        const initialIndex = channelShortenedNames[replaceInitialIndex]
+        if (initialIndex !== undefined) {
+          replaceInitialChannels[replaceInitialIndex] = initialIndex
         }
         replaceInitialIndex++
       }

--- a/src/lib/basic/trieTree.ts
+++ b/src/lib/basic/trieTree.ts
@@ -95,9 +95,9 @@ class TrieNode {
   }: SearchOptions = {}): number[] {
     const results: number[] = []
 
-    const childrens: TrieNode[] = [this]
-    while (childrens.length > 0) {
-      const child = childrens.pop() as TrieNode
+    const children: TrieNode[] = [this]
+    while (children.length > 0) {
+      const child = children.pop() as TrieNode
       if (child.isWord) {
         results.push(child.id)
       }
@@ -106,7 +106,7 @@ class TrieNode {
         continue
       }
 
-      childrens.push(...Object.values(child.children))
+      children.push(...Object.values(child.children))
     }
 
     return results

--- a/src/lib/dom/browser.ts
+++ b/src/lib/dom/browser.ts
@@ -16,7 +16,7 @@ export const isSafari = () => {
 
 /** 特定の条件のiPadだとuaに'ipad'の文字列を含まない
  *  https://qiita.com/ShingoFukuyama/items/ef573a8e3e23ef12542e
- *  'macinstosh'だとmacOSも含まれてしまうため、含まないように`'ontouchend' in document`の条件も追加
+ *  'macintosh'だとmacOSも含まれてしまうため、含まないように`'ontouchend' in document`の条件も追加
  *  https://jsnotice.com/posts/2019-09-08/index.html
  */
 export const isIOS = () => {

--- a/tests/unit/lib/basic/async.spec.ts
+++ b/tests/unit/lib/basic/async.spec.ts
@@ -31,7 +31,7 @@ describe('createSingleFlight', () => {
     expect(f).toHaveBeenCalledTimes(1)
   })
 
-  it('can be called twice parallely (1)', async () => {
+  it('can be called twice in parallel (1)', async () => {
     const { sff, f } = createSff()
 
     const [res1, res2] = await Promise.all([sff('1'), sff('1')])
@@ -42,7 +42,7 @@ describe('createSingleFlight', () => {
     expect(f).toHaveBeenCalledTimes(1)
   })
 
-  it('can be called twice parallely (2)', async () => {
+  it('can be called twice in parallel (2)', async () => {
     const { sff, f } = createSff()
 
     const [res1, res2] = await Promise.all([sff('1'), sff('2')])

--- a/tests/unit/lib/markdown/turndown.spec.ts
+++ b/tests/unit/lib/markdown/turndown.spec.ts
@@ -69,7 +69,7 @@ describe('turndown', () => {
       output: 'https://trap.jp'
     },
     {
-      name: 'should convert link with titile',
+      name: 'should convert link with title',
       input: '<a href="https://trap.jp">traP公式サイト</a>',
       output: '[traP公式サイト](https://trap.jp)'
     },


### PR DESCRIPTION
## Summary

Correct 9 typos in traQ_S-UI (variable naming, comments, and tests):

1. `userListbyGrade` → `userListByGrade` (src/components/Main/NavigationBar/NavigationContent/UserList.vue:14-17)
2. `childrens` → `children` (src/lib/basic/trieTree.ts:98-100)
3. `override` → `overridden` (src/assets/icons/README.md:7)
4. `onTimeupdated` → `onTimeUpdated` (src/composables/media/useAudio.ts:82,91,94)
5. `stopPropergation` → `stopPropagation` (src/components/Main/PopupNavigatior/PopupNavigator.vue:160)
6. `macinstosh` → `macintosh` (src/lib/dom/browser.ts:19)
7. `parallely` → `in parallel` (tests/unit/lib/basic/async.spec.ts:34,44)
8. `title` → `title` (tests/unit/lib/markdown/turndown.spec.ts:72)
9. `indexinitial` → `initialIndex` (src/composables/useChannelPath.ts:245-247, bug found and fixed during review)

## Files changed
9 files (see diff)

## Testing
- No functional changes, purely cosmetic fixes
- ESLint failed due to missing dev dependencies (not introduced by this PR)

## References
- traQ_S-UI#5309, #5303, #5311, #5307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * アイコン、ブラウザー判定、ポップアップ設定、開発環境に関する説明の誤字を修正しました。

* **リファクタリング**
  * コード内の変数名・関数名・型名を一貫した表記に整理しました。動作への影響はありません。

* **テスト**
  * 並列処理、タイトル変換、コマンドパレットに関するテスト名の誤字・表現を修正しました。テスト内容は変更ありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

close: #5303
close: #5304
close: #5305
close: #5306
close: #5308
close: #5309
close: #5310
close: #5312
close: #5313