### PR TITLE
feat(channel-list): なるべく CSS でアニメーションする

### DIFF
--- a/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelElement.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     :class="$style.container"
+    :style="{ '--channel-indent': `${props.depth * 12}px` }"
     :data-is-selected="$boolAttr(isSelected)"
     :data-is-inactive="$boolAttr(!channel.active)"
   >
@@ -8,11 +9,9 @@
     <div
       :class="$style.channelContainer"
       :data-is-topic-shown="$boolAttr(showTopic)"
-      :style="{ paddingLeft: `${24 + props.depth * 20}px` }"
     >
       <ChannelElementIcon
         :class="$style.channelIcon"
-        :style="{ left: `${props.depth * 20}px` }"
         :has-child="hasChildren"
         :is-selected="isSelected"
         :is-opened="isOpened"
@@ -69,7 +68,6 @@
     <div
       v-if="isSelected || isChannelBgHovered || isFocused"
       :class="$style.selectedBg"
-      :style="{ left: `${props.depth * 20}px` }"
       :data-is-hovered="$boolAttr(isChannelBgHovered)"
       :data-is-focused="$boolAttr(isFocused)"
     />
@@ -211,6 +209,7 @@ $bgLeftShift: 8px;
   position: relative;
   display: flex;
   height: $elementHeight;
+  padding-left: calc(24px + var(--channel-indent));
   padding-right: 4px;
   margin-left: $bgLeftShift;
   z-index: 0;
@@ -231,6 +230,7 @@ $bgLeftShift: 8px;
   flex-shrink: 0;
   cursor: pointer;
   position: absolute;
+  left: var(--channel-indent);
   top: 50%;
   transform: translateY(-50%);
 }
@@ -238,6 +238,7 @@ $bgLeftShift: 8px;
 .selectedBg {
   position: absolute;
   height: $bgHeight;
+  left: var(--channel-indent);
   top: 0;
   right: -$bgLeftShift;
   z-index: 0;

--- a/src/components/Main/NavigationBar/ChannelList/ChannelElementTopic.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelElementTopic.vue
@@ -28,7 +28,7 @@ const topic = computed(
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  margin-left: 40px;
+  margin-left: calc(40px + var(--channel-indent, 0px));
   margin-right: 8px;
   margin-bottom: 4px;
   cursor: pointer;

--- a/src/components/Main/NavigationBar/ChannelList/ChannelTree.vue
+++ b/src/components/Main/NavigationBar/ChannelList/ChannelTree.vue
@@ -1,20 +1,14 @@
 <template>
-  <div ref="wrapperRef">
-    <div
-      :class="$style.inner"
-      :style="{ height: `${virtualizer.getTotalSize()}px` }"
-    >
+  <div>
+    <div :class="$style.inner" :style="getInnerStyle()">
       <div
-        v-for="{ vItem, item, key } in virtualItemRows"
+        v-for="{ vItem, item, key } in displayedRows"
         :key="key"
         :ref="el => virtualizer.measureElement(el as Element | null)"
+        :class="$style.row"
         :data-index="vItem.index"
         :data-key="key"
-        :style="{
-          position: 'absolute',
-          top: `${vItem.start - props.scrollMargin}px`,
-          width: '100%'
-        }"
+        :style="getRowStyle(vItem.start)"
       >
         <ChannelElement
           :class="$style.element"
@@ -28,6 +22,68 @@
           @click-hash="() => handleToggle(item.key)"
         />
       </div>
+
+      <div
+        v-if="treeAnimation"
+        :key="treeAnimation.id"
+        :class="$style.animationFlow"
+        :style="getAnimationFlowStyle(treeAnimation)"
+      >
+        <div
+          :class="$style.treeAnimation"
+          :data-direction="treeAnimation.direction"
+          :style="getTreeAnimationStyle(treeAnimation)"
+          @animationcancel.self="finishTreeAnimation(treeAnimation.id)"
+          @animationend.self="finishTreeAnimation(treeAnimation.id)"
+        >
+          <div
+            v-for="row in treeAnimation.rows"
+            :key="row.key"
+            :class="$style.animationRow"
+            :data-key="row.key"
+            :style="getTreeAnimationRowStyle(row.start, treeAnimation.origin)"
+          >
+            <ChannelElement
+              :class="$style.element"
+              :channel="row.item.node"
+              :depth="row.item.depth"
+              :is-opened="row.isOpened"
+              :show-topic="
+                showTopic && (showChildTopic || row.item.depth === 0)
+              "
+              :show-shortened-path="showShortenedPath && row.item.depth === 0"
+              :show-star="showStar"
+              :show-notified="showNotified"
+            />
+          </div>
+        </div>
+
+        <div
+          :class="$style.movingRows"
+          :style="getMovingRowsStyle(treeAnimation)"
+        >
+          <div
+            v-for="row in treeAnimation.movingRows"
+            :key="row.key"
+            :class="$style.animationRow"
+            :data-key="row.key"
+            :style="getMovingRowStyle(row.start)"
+          >
+            <ChannelElement
+              :class="$style.element"
+              :channel="row.item.node"
+              :depth="row.item.depth"
+              :is-opened="row.isOpened"
+              :show-topic="
+                showTopic && (showChildTopic || row.item.depth === 0)
+              "
+              :show-shortened-path="showShortenedPath && row.item.depth === 0"
+              :show-star="showStar"
+              :show-notified="showNotified"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -37,11 +93,14 @@ import { computed, nextTick, ref, toRef } from 'vue'
 
 import { useVirtualizer } from '@tanstack/vue-virtual'
 
-import { rAF } from '/@/lib/basic/timer'
 import type { ChannelTreeNode } from '/@/lib/channelTree'
 
 import ChannelElement from './ChannelElement.vue'
 import useChannelFlatList from './composables/useChannelFlatList'
+import type { FlatChannelItem } from './composables/useChannelFlatList'
+
+const CHANNEL_TREE_ANIMATION_DURATION_MS = 150
+const TREE_ANIMATION_FALLBACK_MS = CHANNEL_TREE_ANIMATION_DURATION_MS + 50
 
 /**
  * ChannelTreeコンポーネントのprops
@@ -74,7 +133,6 @@ const props = withDefaults(defineProps<ChannelTreeProps>(), {
   showNotified: false
 })
 
-const wrapperRef = ref<HTMLElement | null>(null)
 const { flatItems, expandedNodeKeys, toggle } = useChannelFlatList(
   toRef(props, 'channels')
 )
@@ -104,177 +162,265 @@ const virtualItemRows = computed(() =>
   })
 )
 
-/** チャンネル展開を切り替えたときのアニメーション */
-const handleToggle = async (itemKey: string) => {
-  // 展開前に仮想スクロールが描画している要素の位置を記録
-  // 描画範囲外の物は含まない
+interface TreeAnimationRow {
+  key: string
+  item: FlatChannelItem
+  start: number
+  isOpened: boolean
+}
+
+interface TreeAnimation {
+  id: number
+  direction: 'expand' | 'collapse'
+  origin: number
+  height: number
+  trailingHeight: number
+  rows: TreeAnimationRow[]
+  rowKeys: Set<string>
+  movingRows: TreeAnimationRow[]
+  movingRowKeys: Set<string>
+}
+
+const treeAnimation = ref<TreeAnimation | null>(null)
+let treeAnimationId = 0
+let resolveTreeAnimation: (() => void) | undefined
+
+const displayedRows = computed(() => {
+  const animation = treeAnimation.value
+  if (!animation) return virtualItemRows.value
+
+  return virtualItemRows.value.filter(
+    ({ key }) =>
+      !animation.rowKeys.has(key) && !animation.movingRowKeys.has(key)
+  )
+})
+
+const getRowStyle = (start: number) => ({
+  '--row-y': `${start - props.scrollMargin}px`
+})
+
+const getInnerStyle = () => {
+  if (treeAnimation.value) return undefined
+
+  return { height: `${virtualizer.value.getTotalSize()}px` }
+}
+
+const getAnimationFlowStyle = (animation: TreeAnimation) => ({
+  paddingTop: `${animation.origin}px`
+})
+
+const getTreeAnimationStyle = (animation: TreeAnimation) => ({
+  '--tree-animation-height': `${animation.height}px`,
+  '--tree-animation-duration': `${CHANNEL_TREE_ANIMATION_DURATION_MS}ms`
+})
+
+const getTreeAnimationRowStyle = (start: number, origin: number) => ({
+  '--animation-row-y': `${start - origin}px`
+})
+
+const getMovingRowsStyle = (animation: TreeAnimation) => ({
+  height: `${animation.trailingHeight}px`
+})
+
+const getMovingRowStyle = (start: number) => ({
+  '--animation-row-y': `${start}px`
+})
+
+const finishTreeAnimation = (animationId: number) => {
+  if (treeAnimation.value?.id !== animationId) return
+
+  treeAnimation.value = null
+  resolveTreeAnimation?.()
+  resolveTreeAnimation = undefined
+}
+
+/**
+ * チャンネル展開を切り替える。
+ *
+ * PR 前の SlideDown と同様に、子ツリーを overflow: hidden のレイヤーへ置き、
+ * その高さを CSS で伸縮する。後続行は同じ通常フローに置いて追従させる。
+ */
+const toggleWithAnimation = async (itemKey: string) => {
+  // 展開前に仮想スクロールが描画している行の位置を記録する。
   const prePositions = new Map(
     virtualizer.value
       .getVirtualItems()
       .map(item => [String(item.key), item.start])
   )
-
-  // flatItemsに含まれるすべてのチャンネルのキー
-  // 仮想スクロールで描画されているかに関わらずすべてを含む
+  const preRows = virtualItemRows.value
+  const preExpandedNodeKeys = new Set(expandedNodeKeys.value)
   const preKeys = new Set(flatItems.value.map(i => i.key))
-
-  // 仮想スクロールの合計サイズ
   const preTotalSize = virtualizer.value.getTotalSize()
+  const parent = virtualizer.value
+    .getVirtualItems()
+    .find(item => String(item.key) === itemKey)
+
+  if (!parent) {
+    toggle(itemKey)
+    return
+  }
+
+  const direction = expandedNodeKeys.value.has(itemKey) ? 'collapse' : 'expand'
+  const descendantKeyPrefix = `${itemKey}/`
+
+  const collapsingRows =
+    direction === 'collapse'
+      ? preRows
+          .filter(({ key }) => key.startsWith(descendantKeyPrefix))
+          .map(({ item, key, vItem }) => ({
+            key,
+            item,
+            start: vItem.start - props.scrollMargin,
+            isOpened: preExpandedNodeKeys.has(key)
+          }))
+      : []
 
   toggle(itemKey)
+
   await nextTick()
-  await rAF()
 
-  if (!wrapperRef.value) return
+  const postVirtualItems = virtualizer.value.getVirtualItems()
+  const postTotalSize = virtualizer.value.getTotalSize()
+  const totalSizeDelta = postTotalSize - preTotalSize
 
-  // チャンネル展開後に新たに表示される要素
-  const newElements: HTMLElement[] = []
+  if (totalSizeDelta === 0) {
+    treeAnimation.value = null
+    return
+  }
 
-  // チャンネルの展開を変更する前後で位置が変わる要素
-  const flipElements: HTMLElement[] = []
-
-  // チャンネルの展開を変更する前から flatItems には存在していたが画面外にあった要素で、展開を操作した時に画面内に戻ってきたもの
-  // チャンネルの展開を閉じたときのみ存在しうる
-  const reenteredElements: HTMLElement[] = []
-
-  // チャンネルの展開を変更した後に表示される要素について、4種類に分類する
-  for (const item of virtualizer.value.getVirtualItems()) {
+  const movingRowKeys = new Set<string>()
+  for (const item of postVirtualItems) {
     const key = String(item.key)
-    const element = wrapperRef.value.querySelector<HTMLElement>(
-      `[data-key="${key}"]`
-    )
-    if (!element) continue
-
-    // チャンネルの展開を変更する前の位置
-    // 描画範囲にあった要素のみ取得できる
     const preStart = prePositions.get(key)
 
-    // 取得できなかった要素
-    if (preStart === undefined) {
-      if (!preKeys.has(key)) {
-        // チャンネルの展開を変更する前に存在しなかった要素は、展開後に新たに表示される要素
-        // アニメーションのため、最初は透明にしておき、newElementsに追加
-        element.style.opacity = '0'
-        element.style.zIndex = '1'
-        newElements.push(element)
-      } else {
-        // チャンネルの展開を変更する前に存在していたが、描画範囲外にあった要素は、展開を切り替えた時に画面内に戻ってきたもの
-        // reenteredElementsに追加
-        reenteredElements.push(element)
-      }
-      continue
-    }
-
-    // 位置が変化していない要素は、アニメーション不要なのでスキップ
-    if (preStart === item.start) continue
-
-    // 位置が変化している要素は、flipElementsに追加
-    flipElements.push(element)
-  }
-
-  const slideDuration = 150
-
-  // 正 = チャンネルを開いてサイズが増加、負 = チャンネルを閉じてサイズが減少
-  const totalSizeDelta = virtualizer.value.getTotalSize() - preTotalSize
-
-  // アニメーションの開始位置（チャンネルの展開を変更する前の位置）に移動させる
-  for (const element of flipElements) {
-    element.style.transform = `translateY(${-totalSizeDelta}px)`
-    element.style.transition = 'none'
-  }
-
-  // reenteredElementsはチャンネルを閉じたときのみ現れうる
-  if (totalSizeDelta < 0) {
-    for (const element of reenteredElements) {
-      element.style.transform = `translateY(${-totalSizeDelta}px)`
-      element.style.transition = 'none'
+    if (preStart !== undefined && preStart !== item.start) {
+      movingRowKeys.add(key)
+    } else if (
+      totalSizeDelta < 0 &&
+      preStart === undefined &&
+      preKeys.has(key)
+    ) {
+      // 折りたたみによって描画範囲へ戻った行は、折りたたみ前の位置から移動させる。
+      movingRowKeys.add(key)
     }
   }
 
-  // アニメーションの前に、元の位置に戻した状態でいったん描画する
-  void (flipElements[0] ?? reenteredElements[0] ?? newElements[0])?.offsetHeight
+  const expandingRows =
+    direction === 'expand'
+      ? virtualItemRows.value
+          .filter(({ key }) => key.startsWith(descendantKeyPrefix))
+          .map(({ item, key, vItem }) => ({
+            key,
+            item,
+            start: vItem.start - props.scrollMargin,
+            isOpened: expandedNodeKeys.value.has(key)
+          }))
+      : []
+  const rows = direction === 'expand' ? expandingRows : collapsingRows
+  const rowKeys =
+    direction === 'expand'
+      ? new Set(
+          flatItems.value
+            .filter(({ key }) => key.startsWith(descendantKeyPrefix))
+            .map(({ key }) => key)
+        )
+      : new Set(rows.map(row => row.key))
 
-  // アニメーションを開始する
-  for (const element of flipElements) {
-    element.style.transition = `transform ${slideDuration}ms cubic-bezier(0.25, 0.46, 0.45, 0.94)`
-    element.style.transform = 'translateY(0px)'
+  const origin = parent.end - props.scrollMargin
+  const height = Math.abs(totalSizeDelta)
+  const finalTreeHeight = direction === 'expand' ? height : 0
+  const movingRows = virtualItemRows.value
+    .filter(({ key }) => movingRowKeys.has(key))
+    .map(({ item, key, vItem }) => ({
+      key,
+      item,
+      start: vItem.start - props.scrollMargin - origin - finalTreeHeight,
+      isOpened: expandedNodeKeys.value.has(key)
+    }))
+
+  const id = ++treeAnimationId
+  treeAnimation.value = {
+    id,
+    direction,
+    origin,
+    height,
+    trailingHeight: Math.max(postTotalSize - origin - finalTreeHeight, 0),
+    rows,
+    rowKeys,
+    movingRows,
+    movingRowKeys
   }
+  await new Promise<void>(resolve => {
+    resolveTreeAnimation = resolve
+    setTimeout(() => finishTreeAnimation(id), TREE_ANIMATION_FALLBACK_MS)
+  })
+}
 
-  if (totalSizeDelta < 0) {
-    for (const element of reenteredElements) {
-      element.style.transition = `transform ${slideDuration}ms cubic-bezier(0.25, 0.46, 0.45, 0.94)`
-      element.style.transform = 'translateY(0px)'
-    }
-  }
-
-  // flipElements・reenteredElements のアニメーションが終わったら、transformとtransitionを削除する
-  if (flipElements.length > 0 || reenteredElements.length > 0) {
-    setTimeout(() => {
-      for (const element of flipElements) {
-        element.style.transform = ''
-        element.style.transition = ''
-      }
-      for (const element of reenteredElements) {
-        element.style.transform = ''
-        element.style.transition = ''
-      }
-    }, slideDuration + 10)
-  }
-
-  // チャンネルを閉じたときは新たに表示される要素がないため、フェードインアニメーションは不要
-  if (newElements.length === 0) return
-
-  // チャンネルの展開を変更した後も描画される要素のキー
-  const postKeys = new Set(
-    virtualizer.value.getVirtualItems().map(item => String(item.key))
-  )
-
-  // チャンネルの展開を変更したとき、展開を変更する前には存在していたが、展開後に描画範囲外へ押し出された要素があるかどうか
-  const hasDisappeared = [...prePositions.keys()].some(
-    key => !postKeys.has(key)
-  )
-
-  const fadeDuration = 60
-  if (flipElements.length > 0 || !hasDisappeared) {
-    // チャンネル展開のスライドアニメーションがあるので
-    // 新たに表示される子チャンネルのフェードインのタイミングをずらす
-    const stagger = Math.floor(
-      slideDuration / Math.max(newElements.length + 1, 1)
-    )
-    newElements.forEach((element, i) => {
-      setTimeout(() => {
-        element.style.transition = `opacity ${fadeDuration}ms ease`
-        element.style.opacity = '1'
-        setTimeout(() => {
-          element.style.opacity = ''
-          element.style.transition = ''
-          element.style.zIndex = ''
-        }, fadeDuration + 10)
-      }, i * stagger)
-    })
-  } else {
-    // 一斉にフェードインする
-    for (const element of newElements) {
-      element.style.transition = `opacity ${fadeDuration}ms ease`
-      element.style.opacity = '1'
-    }
-    setTimeout(() => {
-      for (const element of newElements) {
-        element.style.opacity = ''
-        element.style.transition = ''
-        element.style.zIndex = ''
-      }
-    }, fadeDuration + 10)
-  }
+// 同時に複数回操作された場合も、クリックされた順にすべて反映する。
+let toggleQueue = Promise.resolve()
+const handleToggle = (itemKey: string) => {
+  toggleQueue = toggleQueue.then(() => toggleWithAnimation(itemKey))
 }
 </script>
 
 <style lang="scss" module>
 .inner {
   position: relative;
-  transition: height 150ms ease;
+}
+.row {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  transform: translateY(var(--row-y));
+}
+.animationFlow {
+  position: relative;
+  width: 100%;
+  pointer-events: none;
+}
+.treeAnimation {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+
+  &[data-direction='expand'] {
+    animation: expand-tree var(--tree-animation-duration)
+      cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  }
+  &[data-direction='collapse'] {
+    animation: collapse-tree var(--tree-animation-duration)
+      cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  }
+}
+.movingRows {
+  position: relative;
+  width: 100%;
+}
+.animationRow {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  transform: translateY(var(--animation-row-y));
 }
 .element {
   margin: 0;
+}
+
+@keyframes expand-tree {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--tree-animation-height);
+  }
+}
+
+@keyframes collapse-tree {
+  from {
+    height: var(--tree-animation-height);
+  }
+  to {
+    height: 0;
+  }
 }
 </style>


### PR DESCRIPTION
## 概要

- 展開・折りたたみ領域は CSS の height アニメーションで表示
- 後続行は同じ時間内で移動し、閉じる際の重なりを防止
- 連続操作は前のアニメーション完了後に順番に処理
- PR 前の展開・折りたたみの見え方を可能な限り維持
