### PR TITLE
fix(api): handle stale online status after WebSocket disconnects

### DIFF
--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -6,12 +6,16 @@ export interface Options {
   maxReconnectionDelay: number
   minReconnectionDelay: number
   connectionTimeout: number
+  pingInterval: number
+  pingTimeout: number
 }
 
 const defaultOptions: Options = {
   maxReconnectionDelay: 10000,
   minReconnectionDelay: 1000,
-  connectionTimeout: 4000
+  connectionTimeout: 4000,
+  pingInterval: 30000,
+  pingTimeout: 10000
 }
 
 interface EventMap {
@@ -22,6 +26,8 @@ type TypedEventListener<T extends keyof EventMap> = (ev: EventMap[T]) => void
 
 export default class AutoReconnectWebSocket {
   _ws?: WebSocket
+  private heartbeatInterval?: ReturnType<typeof setInterval>
+  private heartbeatTimeout?: ReturnType<typeof setTimeout>
   readonly eventTarget = new EventTarget()
 
   readonly url: string
@@ -41,7 +47,7 @@ export default class AutoReconnectWebSocket {
   ) {
     this.url = url
     this.protocols = protocols
-    this.options = { ...options, ...defaultOptions }
+    this.options = { ...defaultOptions, ...options }
   }
 
   get isOpen() {
@@ -71,14 +77,61 @@ export default class AutoReconnectWebSocket {
     return Math.min(minReconnectionDelay * 1.3 ** count, maxReconnectionDelay)
   }
 
+  private clearHeartbeatTimeout() {
+    clearTimeout(this.heartbeatTimeout)
+    this.heartbeatTimeout = undefined
+  }
+
+  private stopHeartbeat() {
+    clearInterval(this.heartbeatInterval)
+    this.heartbeatInterval = undefined
+    this.clearHeartbeatTimeout()
+  }
+
+  private startHeartbeat(socket: WebSocket) {
+    this.stopHeartbeat()
+    this.heartbeatInterval = setInterval(() => {
+      if (
+        socket.readyState !== WebSocket.OPEN ||
+        this.heartbeatTimeout !== undefined
+      )
+        return
+
+      socket.send('ping')
+      this.heartbeatTimeout = setTimeout(() => {
+        if (this._ws !== socket) return
+
+        this.stopHeartbeat()
+        socket.close()
+        this.reconnect()
+      }, this.options.pingTimeout)
+    }, this.options.pingInterval)
+  }
+
   _setupWs() {
     return new Promise<void>(resolve => {
-      this._ws = new WebSocket(this.url, this.protocols)
+      const socket = new WebSocket(this.url, this.protocols)
+      this._ws = socket
+      const finish = () => {
+        clearTimeout(connectionTimeout)
+        resolve()
+      }
+      const connectionTimeout = setTimeout(() => {
+        if (socket.readyState !== WebSocket.CONNECTING) return
 
-      this._ws.addEventListener(
+        socket.close()
+        finish()
+      }, this.options.connectionTimeout)
+
+      socket.addEventListener(
         'open',
         () => {
-          resolve()
+          finish()
+          if (this._ws !== socket) {
+            socket.close()
+            return
+          }
+
           if (this.isInitialized) {
             this.eventTarget.dispatchEvent(new Event('reconnect'))
           } else {
@@ -88,26 +141,34 @@ export default class AutoReconnectWebSocket {
           this.sendQueue.forEach((args, command) => {
             this._sendCommand([command, ...args])
           })
+          this.startHeartbeat(socket)
         },
         { once: true }
       )
-      this._ws.addEventListener(
+      socket.addEventListener(
         'error',
         () => {
-          resolve()
+          finish()
         },
         { once: true }
       )
 
-      this._ws.addEventListener('message', e => {
+      socket.addEventListener('message', e => {
+        if (this._ws !== socket) return
+
+        this.clearHeartbeatTimeout()
         this.eventTarget.dispatchEvent(
           new CustomEvent('message', { detail: e.data })
         )
       })
 
-      this._ws.addEventListener(
+      socket.addEventListener(
         'close',
         () => {
+          finish()
+          if (this._ws !== socket) return
+
+          this.stopHeartbeat()
           this.reconnect()
         },
         { once: true }
@@ -135,7 +196,7 @@ export default class AutoReconnectWebSocket {
   }
 
   async connect() {
-    if (this.isOpenOrConnecting) return
+    if (this.reconnecting || this.isOpenOrConnecting) return
 
     return this._setupWs()
   }

--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -25,20 +25,20 @@ interface EventMap {
 type TypedEventListener<T extends keyof EventMap> = (ev: EventMap[T]) => void
 
 export default class AutoReconnectWebSocket {
-  _ws?: WebSocket
+  private socket?: WebSocket
   private heartbeatInterval?: ReturnType<typeof setInterval>
   private heartbeatTimeout?: ReturnType<typeof setTimeout>
-  readonly eventTarget = new EventTarget()
+  private readonly eventTarget = new EventTarget()
 
-  readonly url: string
-  readonly protocols: string | string[] | undefined
-  readonly options: Readonly<Options>
+  private readonly url: string
+  private readonly protocols: string | string[] | undefined
+  private readonly options: Readonly<Options>
 
-  sendQueue = new Map<WebSocketCommand, readonly string[]>()
-  isInitialized = false
-  reconnecting = false
+  private readonly sendQueue = new Map<WebSocketCommand, readonly string[]>()
+  private isInitialized = false
+  private reconnecting = false
 
-  mockFail = false
+  private mockFail = false
 
   constructor(
     url: string,
@@ -50,29 +50,29 @@ export default class AutoReconnectWebSocket {
     this.options = { ...defaultOptions, ...options }
   }
 
-  get isOpen() {
-    return this._ws?.readyState === WebSocket.OPEN
+  private get isOpen() {
+    return this.socket?.readyState === WebSocket.OPEN
   }
-  get isOpenOrConnecting() {
+  private get isOpenOrConnecting() {
     return (
-      this._ws?.readyState === WebSocket.OPEN ||
-      this._ws?.readyState === WebSocket.CONNECTING
+      this.socket?.readyState === WebSocket.OPEN ||
+      this.socket?.readyState === WebSocket.CONNECTING
     )
   }
 
-  _sendCommand(commands: readonly [WebSocketCommand, ...string[]]) {
+  private sendImmediately(commands: readonly [WebSocketCommand, ...string[]]) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this._ws!.send(commands.join(':'))
+    this.socket!.send(commands.join(':'))
   }
 
   sendCommand(...commands: readonly [WebSocketCommand, ...string[]]) {
     this.sendQueue.set(commands[0], commands.slice(1))
     if (this.isOpen) {
-      this._sendCommand(commands)
+      this.sendImmediately(commands)
     }
   }
 
-  _getDelay(count: number) {
+  private getReconnectDelay(count: number) {
     const { minReconnectionDelay, maxReconnectionDelay } = this.options
     return Math.min(minReconnectionDelay * 1.3 ** count, maxReconnectionDelay)
   }
@@ -99,7 +99,7 @@ export default class AutoReconnectWebSocket {
 
       socket.send('ping')
       this.heartbeatTimeout = setTimeout(() => {
-        if (this._ws !== socket) return
+        if (this.socket !== socket) return
 
         this.stopHeartbeat()
         socket.close()
@@ -108,10 +108,10 @@ export default class AutoReconnectWebSocket {
     }, this.options.pingInterval)
   }
 
-  _setupWs() {
+  private setupSocket() {
     return new Promise<void>(resolve => {
       const socket = new WebSocket(this.url, this.protocols)
-      this._ws = socket
+      this.socket = socket
       const finish = () => {
         clearTimeout(connectionTimeout)
         resolve()
@@ -127,7 +127,7 @@ export default class AutoReconnectWebSocket {
         'open',
         () => {
           finish()
-          if (this._ws !== socket) {
+          if (this.socket !== socket) {
             socket.close()
             return
           }
@@ -139,7 +139,7 @@ export default class AutoReconnectWebSocket {
           }
 
           this.sendQueue.forEach((args, command) => {
-            this._sendCommand([command, ...args])
+            this.sendImmediately([command, ...args])
           })
           this.startHeartbeat(socket)
         },
@@ -154,7 +154,7 @@ export default class AutoReconnectWebSocket {
       )
 
       socket.addEventListener('message', e => {
-        if (this._ws !== socket) return
+        if (this.socket !== socket) return
 
         this.clearHeartbeatTimeout()
         this.eventTarget.dispatchEvent(
@@ -166,7 +166,7 @@ export default class AutoReconnectWebSocket {
         'close',
         () => {
           finish()
-          if (this._ws !== socket) return
+          if (this.socket !== socket) return
 
           this.stopHeartbeat()
           this.reconnect()
@@ -198,10 +198,10 @@ export default class AutoReconnectWebSocket {
   async connect() {
     if (this.reconnecting || this.isOpenOrConnecting) return
 
-    return this._setupWs()
+    return this.setupSocket()
   }
 
-  async reconnect() {
+  private async reconnect() {
     if (this.reconnecting) return
     this.reconnecting = true
 
@@ -209,16 +209,26 @@ export default class AutoReconnectWebSocket {
     while (!this.isOpen) {
       count++
 
-      const delay = this._getDelay(count)
+      const delay = this.getReconnectDelay(count)
       await wait(delay)
 
       if (this.isOpen) break
 
       if (!this.mockFail) {
-        await this._setupWs()
+        await this.setupSocket()
       }
     }
 
     this.reconnecting = false
+  }
+
+  closeForDebug() {
+    this.mockFail = true
+    this.socket?.close()
+  }
+
+  reconnectForDebug() {
+    this.mockFail = false
+    this.connect()
   }
 }

--- a/src/lib/websocket/AutoReconnectWebSocket.ts
+++ b/src/lib/websocket/AutoReconnectWebSocket.ts
@@ -72,6 +72,24 @@ export default class AutoReconnectWebSocket {
     }
   }
 
+  ping() {
+    const socket = this.socket
+    if (
+      socket?.readyState !== WebSocket.OPEN ||
+      this.heartbeatTimeout !== undefined
+    )
+      return
+
+    socket.send('ping')
+    this.heartbeatTimeout = setTimeout(() => {
+      if (this.socket !== socket) return
+
+      this.stopHeartbeat()
+      socket.close()
+      this.reconnect()
+    }, this.options.pingTimeout)
+  }
+
   private getReconnectDelay(count: number) {
     const { minReconnectionDelay, maxReconnectionDelay } = this.options
     return Math.min(minReconnectionDelay * 1.3 ** count, maxReconnectionDelay)
@@ -88,24 +106,12 @@ export default class AutoReconnectWebSocket {
     this.clearHeartbeatTimeout()
   }
 
-  private startHeartbeat(socket: WebSocket) {
+  private startHeartbeat() {
     this.stopHeartbeat()
-    this.heartbeatInterval = setInterval(() => {
-      if (
-        socket.readyState !== WebSocket.OPEN ||
-        this.heartbeatTimeout !== undefined
-      )
-        return
-
-      socket.send('ping')
-      this.heartbeatTimeout = setTimeout(() => {
-        if (this.socket !== socket) return
-
-        this.stopHeartbeat()
-        socket.close()
-        this.reconnect()
-      }, this.options.pingTimeout)
-    }, this.options.pingInterval)
+    this.heartbeatInterval = setInterval(
+      () => this.ping(),
+      this.options.pingInterval
+    )
   }
 
   private setupSocket() {
@@ -141,7 +147,7 @@ export default class AutoReconnectWebSocket {
           this.sendQueue.forEach((args, command) => {
             this.sendImmediately([command, ...args])
           })
-          this.startHeartbeat(socket)
+          this.startHeartbeat()
         },
         { once: true }
       )
@@ -207,9 +213,8 @@ export default class AutoReconnectWebSocket {
 
     let count = 0
     while (!this.isOpen) {
-      count++
-
       const delay = this.getReconnectDelay(count)
+      count++
       await wait(delay)
 
       if (this.isOpen) break

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -37,6 +37,10 @@ if (import.meta.env.MODE === 'development') {
   }
 }
 
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') ws.ping()
+})
+
 export const wsListener = createWebSocketListener(ws)
 
 export const setupWebSocket = async () => {

--- a/src/lib/websocket/index.ts
+++ b/src/lib/websocket/index.ts
@@ -29,13 +29,11 @@ export const ws = new AutoReconnectWebSocket(
 if (import.meta.env.MODE === 'development') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(window as any).closeWs = () => {
-    ws.mockFail = true
-    ws._ws?.close()
+    ws.closeForDebug()
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(window as any).reconnectWs = () => {
-    ws.mockFail = false
-    ws.connect()
+    ws.reconnectForDebug()
   }
 }
 

--- a/tests/unit/lib/websocket/AutoReconnectWebSocket.spec.ts
+++ b/tests/unit/lib/websocket/AutoReconnectWebSocket.spec.ts
@@ -63,9 +63,9 @@ describe('AutoReconnectWebSocket heartbeat', () => {
   }
 
   it('keeps the connection when the server answers ping', async () => {
-    const { socket } = await connect()
+    const { socket, ws } = await connect()
 
-    await vi.advanceTimersByTimeAsync(1000)
+    ws.ping()
     expect(socket.sent).toEqual(['ping'])
 
     socket.receive('{"type":"PING","body":null}')
@@ -80,6 +80,27 @@ describe('AutoReconnectWebSocket heartbeat', () => {
     await vi.advanceTimersByTimeAsync(1101)
 
     expect(socket.close).toHaveBeenCalledOnce()
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('uses the minimum delay for the first reconnect', async () => {
+    const ws = new AutoReconnectWebSocket('ws://example.com', undefined, {
+      maxReconnectionDelay: 1000,
+      minReconnectionDelay: 100,
+      pingInterval: 1000,
+      pingTimeout: 100
+    })
+    const connected = ws.connect()
+    const socket = MockWebSocket.instances[0]
+    if (!socket) throw new Error('WebSocket was not created')
+    socket.open()
+    await connected
+
+    socket.close()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(1)
     expect(MockWebSocket.instances).toHaveLength(2)
   })
 

--- a/tests/unit/lib/websocket/AutoReconnectWebSocket.spec.ts
+++ b/tests/unit/lib/websocket/AutoReconnectWebSocket.spec.ts
@@ -1,0 +1,167 @@
+import AutoReconnectWebSocket from '/@/lib/websocket/AutoReconnectWebSocket'
+
+class MockWebSocket extends EventTarget {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  sent: string[] = []
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED
+    this.dispatchEvent(new Event('close'))
+  })
+
+  constructor(
+    readonly url: string,
+    readonly protocols?: string | string[]
+  ) {
+    super()
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.dispatchEvent(new Event('open'))
+  }
+
+  receive(data: string) {
+    this.dispatchEvent(new MessageEvent('message', { data }))
+  }
+}
+
+describe('AutoReconnectWebSocket heartbeat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  const connect = async () => {
+    const ws = new AutoReconnectWebSocket('ws://example.com', undefined, {
+      maxReconnectionDelay: 1,
+      minReconnectionDelay: 1,
+      pingInterval: 1000,
+      pingTimeout: 100
+    })
+    const connected = ws.connect()
+    const socket = MockWebSocket.instances[0]
+    if (!socket) throw new Error('WebSocket was not created')
+    socket.open()
+    await connected
+    return { socket, ws }
+  }
+
+  it('keeps the connection when the server answers ping', async () => {
+    const { socket } = await connect()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(socket.sent).toEqual(['ping'])
+
+    socket.receive('{"type":"PING","body":null}')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(socket.close).not.toHaveBeenCalled()
+  })
+
+  it('reconnects when the server does not answer ping', async () => {
+    const { socket } = await connect()
+
+    await vi.advanceTimersByTimeAsync(1101)
+
+    expect(socket.close).toHaveBeenCalledOnce()
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('does not postpone the timeout when ping interval is shorter', async () => {
+    const ws = new AutoReconnectWebSocket('ws://example.com', undefined, {
+      maxReconnectionDelay: 1,
+      minReconnectionDelay: 1,
+      pingInterval: 100,
+      pingTimeout: 250
+    })
+    const connected = ws.connect()
+    const socket = MockWebSocket.instances[0]
+    if (!socket) throw new Error('WebSocket was not created')
+    socket.open()
+    await connected
+
+    await vi.advanceTimersByTimeAsync(349)
+    expect(socket.sent).toEqual(['ping'])
+    expect(socket.close).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(socket.close).toHaveBeenCalledOnce()
+  })
+
+  it('ignores messages from a replaced socket', async () => {
+    const { socket, ws } = await connect()
+    const listener = vi.fn()
+    ws.addEventListener('message', listener)
+
+    socket.close()
+    await vi.advanceTimersByTimeAsync(2)
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    socket.receive('{"type":"PING","body":null}')
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('does not start another connection while reconnecting', async () => {
+    const { socket, ws } = await connect()
+
+    socket.close()
+    await expect(ws.connect()).resolves.toBeUndefined()
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(2)
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('continues reconnecting when a connecting socket closes', async () => {
+    const { socket, ws } = await connect()
+
+    socket.close()
+    await vi.advanceTimersByTimeAsync(2)
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    ws.closeForDebug()
+    ws.reconnectForDebug()
+    await vi.advanceTimersByTimeAsync(2)
+    expect(MockWebSocket.instances).toHaveLength(3)
+  })
+
+  it('retries when a connection attempt times out', async () => {
+    const ws = new AutoReconnectWebSocket('ws://example.com', undefined, {
+      connectionTimeout: 100,
+      maxReconnectionDelay: 1,
+      minReconnectionDelay: 1
+    })
+    const connected = ws.connect()
+    const socket = MockWebSocket.instances[0]
+    if (!socket) throw new Error('WebSocket was not created')
+    socket.open()
+    await connected
+
+    socket.close()
+    await vi.advanceTimersByTimeAsync(1)
+    const stalledSocket = MockWebSocket.instances[1]
+    if (!stalledSocket) throw new Error('WebSocket was not created')
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(stalledSocket.close).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(3)
+  })
+})

--- a/tests/unit/lib/websocket/index.spec.ts
+++ b/tests/unit/lib/websocket/index.spec.ts
@@ -1,0 +1,35 @@
+import '/@/lib/websocket'
+
+const { mockPing } = vi.hoisted(() => ({
+  mockPing: vi.fn()
+}))
+
+vi.mock('/@/lib/apis', () => ({
+  WEBSOCKET_ENDPOINT: '/api/v3/ws'
+}))
+
+vi.mock('/@/lib/websocket/AutoReconnectWebSocket', () => ({
+  default: class {
+    ping = mockPing
+    addEventListener = vi.fn()
+  }
+}))
+
+describe('websocket visibility handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('pings when the page becomes visible', () => {
+    const visibilityState = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden')
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(mockPing).not.toHaveBeenCalled()
+
+    visibilityState.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(mockPing).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
- https://github.com/traPtitech/traQ/pull/3123 で WS でも ping ができるようになったので、それを利用して disconnected や half-open を検知
- thanks to: https://github.com/traPtitech/traQ_S-UI/pull/4118