### PR TITLE
fix: rename 'regist' to 'registration' for consistency

### DIFF
--- a/src/assets/icons/README.md
+++ b/src/assets/icons/README.md
@@ -4,5 +4,5 @@ Place svg files here, then you can use the icon with `/@/components/UI/Icon.vue`
 
 ## Note
 
-- Viewbox and fills on `path` are removed by svgo, then overriden by icon component.
+- Viewbox and fills on `path` are removed by svgo, then overridden by icon component.
 - We recommend placing icons in 24x24 box.

--- a/src/components/Main/PopupNavigatior/PopupNavigator.vue
+++ b/src/components/Main/PopupNavigatior/PopupNavigator.vue
@@ -157,7 +157,7 @@ const useNavigator = (emit: (name: 'clickIcon') => void) => {
       },
       onPointerUp
     },
-    // capture=trueなのはstopPropergationでスワイプを無効化するため
+    // capture=trueなのはstopPropagationでスワイプを無効化するため
     { capture: true, passive: true }
   )
 

--- a/src/composables/media/useAudio.ts
+++ b/src/composables/media/useAudio.ts
@@ -79,7 +79,7 @@ const useIsPlaying = (
 export const useCurrentTime = (audio: Ref<HTMLAudioElement | undefined>) => {
   const nativeCurrentTime = ref(toFinite(audio.value?.currentTime, 0))
 
-  const onTimeupdated = () => {
+  const onTimeUpdated = () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     nativeCurrentTime.value = toFinite(audio.value!.currentTime, 0)
   }
@@ -88,11 +88,11 @@ export const useCurrentTime = (audio: Ref<HTMLAudioElement | undefined>) => {
     audio,
     (newAudio, oldAudio) => {
       if (oldAudio) {
-        oldAudio.removeEventListener('timeupdate', onTimeupdated)
+        oldAudio.removeEventListener('timeupdate', onTimeUpdated)
       }
       if (newAudio) {
         nativeCurrentTime.value = toFinite(newAudio.currentTime, 0)
-        newAudio.addEventListener('timeupdate', onTimeupdated)
+        newAudio.addEventListener('timeupdate', onTimeUpdated)
       }
     },
     { immediate: true }

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -242,7 +242,7 @@ const useChannelPath = () => {
         replaceInitialChannels.join('/').length > MAX_SHORT_PATH_LENGTH &&
         replaceInitialIndex < channelsLength - 2
       ) {
-        const indexinitial = channelShortenedNames[replaceInitialIndex]
+        const initialIndex = channelShortenedNames[replaceInitialIndex]
         if (indexinitial !== undefined) {
           replaceInitialChannels[replaceInitialIndex] = indexinitial
         }

--- a/src/composables/useChannelPath.ts
+++ b/src/composables/useChannelPath.ts
@@ -243,8 +243,8 @@ const useChannelPath = () => {
         replaceInitialIndex < channelsLength - 2
       ) {
         const initialIndex = channelShortenedNames[replaceInitialIndex]
-        if (indexinitial !== undefined) {
-          replaceInitialChannels[replaceInitialIndex] = indexinitial
+        if (initialIndex !== undefined) {
+          replaceInitialChannels[replaceInitialIndex] = initialIndex
         }
         replaceInitialIndex++
       }

--- a/src/lib/dom/browser.ts
+++ b/src/lib/dom/browser.ts
@@ -16,7 +16,7 @@ export const isSafari = () => {
 
 /** 特定の条件のiPadだとuaに'ipad'の文字列を含まない
  *  https://qiita.com/ShingoFukuyama/items/ef573a8e3e23ef12542e
- *  'macinstosh'だとmacOSも含まれてしまうため、含まないように`'ontouchend' in document`の条件も追加
+ *  'macintosh'だとmacOSも含まれてしまうため、含まないように`'ontouchend' in document`の条件も追加
  *  https://jsnotice.com/posts/2019-09-08/index.html
  */
 export const isIOS = () => {

--- a/src/lib/notification/notification.ts
+++ b/src/lib/notification/notification.ts
@@ -44,10 +44,10 @@ const notify = async (
   )
 
   if (navigator.serviceWorker) {
-    const regist = await navigator.serviceWorker.ready
+    const registration = await navigator.serviceWorker.ready
     // mac SafariだとshowNotificationが存在しない
-    if (regist.showNotification) {
-      return regist.showNotification(notificationTitle, notificationOptions)
+    if (registration.showNotification) {
+      return registration.showNotification(notificationTitle, notificationOptions)
     }
   }
   if (Notification?.permission === 'granted') {

--- a/tests/unit/lib/basic/async.spec.ts
+++ b/tests/unit/lib/basic/async.spec.ts
@@ -31,7 +31,7 @@ describe('createSingleFlight', () => {
     expect(f).toHaveBeenCalledTimes(1)
   })
 
-  it('can be called twice parallely (1)', async () => {
+  it('can be called twice in parallel (1)', async () => {
     const { sff, f } = createSff()
 
     const [res1, res2] = await Promise.all([sff('1'), sff('1')])
@@ -42,7 +42,7 @@ describe('createSingleFlight', () => {
     expect(f).toHaveBeenCalledTimes(1)
   })
 
-  it('can be called twice parallely (2)', async () => {
+  it('can be called twice in parallel (2)', async () => {
     const { sff, f } = createSff()
 
     const [res1, res2] = await Promise.all([sff('1'), sff('2')])

--- a/tests/unit/lib/markdown/turndown.spec.ts
+++ b/tests/unit/lib/markdown/turndown.spec.ts
@@ -69,7 +69,7 @@ describe('turndown', () => {
       output: 'https://trap.jp'
     },
     {
-      name: 'should convert link with titile',
+      name: 'should convert link with title',
       input: '<a href="https://trap.jp">traP公式サイト</a>',
       output: '[traP公式サイト](https://trap.jp)'
     },


### PR DESCRIPTION
Fixes #5311 - Rename the inconsistent variable name `regist` to `registration` to match the rest of the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - ドキュメントやコメント内のスペルミスを修正し、表記を正確にしました。

- **リファクタリング**
  - 内部的な変数名やイベントハンドラー名を、より一貫性のある表記に整理しました。動作への影響はありません。

- **テスト**
  - テストケース名の誤字や不自然な表現を修正し、内容を分かりやすくしました。テストロジックや検証結果に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->