### PR TITLE
fix: correct more typos in tts.ts, color.ts, useSwipeDrawer.ts, docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,7 @@ $ npm i
 $ npm run gen-fonts
 ```
 
-Vetur ではなく Vue (offical) を導入することを推奨しています。
+Vetur ではなく Vue (official) を導入することを推奨しています。
 
 ## コミット時の自動フォーマット・lint
 

--- a/src/composables/mainView/useSwipeDrawer.ts
+++ b/src/composables/mainView/useSwipeDrawer.ts
@@ -41,7 +41,7 @@ const useSwipeDrawer = (
   })
 
   /** 次はどちら向きへの操作か */
-  const supporsedDirection = computed((): Direction =>
+  const supportedDirection = computed((): Direction =>
     state.startPosition < destination / 2 ? direction : inverse(direction)
   )
 
@@ -60,12 +60,12 @@ const useSwipeDrawer = (
   const animatePosition = (to: number) => {
     const startTime = Date.now()
     const diffPerMs = (to - state.currentPosition) / animationDurationMs
-    const animationDirectonSign = diffPerMs / Math.abs(diffPerMs)
+    const animationDirectionSign = diffPerMs / Math.abs(diffPerMs)
     const animate = () => {
       const currentTime = Date.now()
       state.currentPosition += diffPerMs * (currentTime - startTime)
       state.startPosition = state.currentPosition
-      if (animationDirectonSign * (to - state.currentPosition) > 0) {
+      if (animationDirectionSign * (to - state.currentPosition) > 0) {
         state.requestId = requestAnimationFrame(animate)
       } else {
         state.currentPosition = to
@@ -108,15 +108,15 @@ const useSwipeDrawer = (
       if (inactive?.value) {
         return
       }
-      if (swipeDirection === supporsedDirection.value) {
+      if (swipeDirection === supportedDirection.value) {
         state.startPosition = state.currentPosition
         if (state.isInitial && onInteractionStart) {
-          onInteractionStart(supporsedDirection.value === direction)
+          onInteractionStart(supportedDirection.value === direction)
           state.isInitial = false
         }
       }
       if (
-        swipeDirection === supporsedDirection.value &&
+        swipeDirection === supportedDirection.value &&
         state.requestId !== -1
       ) {
         // スワイプ開始時にanimationFrameをキャンセル

--- a/src/lib/basic/color.ts
+++ b/src/lib/basic/color.ts
@@ -81,11 +81,11 @@ const mustConvertPercentage = (str: string) => {
 }
 
 const mustConvertPercentageOrNumber = (str: string, range = 1) => {
-  const trimed = str.trim()
-  if (trimed.endsWith('%')) {
-    return mustConvertPercentage(trimed) * range
+  const trimmed = str.trim()
+  if (trimmed.endsWith('%')) {
+    return mustConvertPercentage(trimmed) * range
   }
-  return mustConvertNumber(trimed)
+  return mustConvertNumber(trimmed)
 }
 
 const angleUnits = {

--- a/src/store/app/tts.ts
+++ b/src/store/app/tts.ts
@@ -9,7 +9,7 @@ import { useRtcSettings } from '/@/store/app/rtcSettings'
 import { convertToRefsStore } from '/@/store/utils/convertToRefsStore'
 import type { ChannelId } from '/@/types/entity-ids'
 
-interface Speach {
+interface Speech {
   channelId: ChannelId
   userDisplayName: string
   text: string
@@ -22,12 +22,12 @@ const MAX_CHAR_COUNT = 140
 
 const useTtsPinia = defineStore('ui/tts', () => {
   const rtcSettings = useRtcSettings()
-  let lastSpeachPromise = Promise.resolve()
-  const queue: Speach[] = []
+  let lastSpeechPromise = Promise.resolve()
+  const queue: Speech[] = []
 
-  const addQueue = (speach: Speach) => {
-    queue.push(speach)
-    lastSpeachPromise = lastSpeachPromise.then(() => {
+  const addQueue = (speech: Speech) => {
+    queue.push(speech)
+    lastSpeechPromise = lastSpeechPromise.then(() => {
       const next = queue.shift()
       return next ? speak(next) : Promise.resolve()
     })
@@ -70,15 +70,15 @@ const useTtsPinia = defineStore('ui/tts', () => {
     return utter
   }
 
-  const speak = async ({ userDisplayName, text }: Speach) => {
+  const speak = async ({ userDisplayName, text }: Speech) => {
     const tokens = await parse(text)
-    let formatedText = format(tokens, embeddingOrigin)
+    let formattedText = format(tokens, embeddingOrigin)
 
-    if (formatedText.length > MAX_CHAR_COUNT) {
-      formatedText = `${formatedText.slice(0, MAX_CHAR_COUNT)} 。以下略`
+    if (formattedText.length > MAX_CHAR_COUNT) {
+      formattedText = `${formattedText.slice(0, MAX_CHAR_COUNT)} 。以下略`
     }
 
-    const utter = createUtter(`${userDisplayName}さん: ${formatedText}`)
+    const utter = createUtter(`${userDisplayName}さん: ${formattedText}`)
     speechSynthesis.speak(utter)
 
     return new Promise<void>(resolve => {


### PR DESCRIPTION
## Summary
Correct additional typos found after previous PR #5318:

- `Speach` → `Speech` (interface + variables in tts.ts)
- `formatedText` → `formattedText`
- `trimed` → `trimmed` (color.ts)
- `supporsedDirection` → `supportedDirection` + `animationDirectonSign` → `animationDirectionSign` (useSwipeDrawer.ts)
- `offical` → `official` (docs/development.md)

## Files changed
- `src/store/app/tts.ts` - Type and variable name corrections
- `src/lib/basic/color.ts` - Variable name correction
- `src/composables/mainView/useSwipeDrawer.ts` - Variable name corrections
- `docs/development.md` - Typo in Vue documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 開発環境構築ガイドの表記誤りを修正しました。

* **リファクタリング**
  * スワイプ操作、色変換、音声読み上げに関する内部名称を整理し、コードの可読性を向上しました。
  * 音声読み上げの型名や関連する名称を統一しました。

* **バグ修正**
  * 動作ロジックや機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->