### PR TITLE
fix(auth): sanitize post-login redirect URLs

### DIFF
--- a/src/components/Authenticate/composables/useRedirectParam.ts
+++ b/src/components/Authenticate/composables/useRedirectParam.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
-import { isServerRequestUrl } from '/@/lib/apis'
+import { getServerRequestUrl } from '/@/lib/apis'
 import { getFirstQuery } from '/@/lib/basic/url'
 import { sessionStorageRedirectKey } from '/@/lib/dom/storage'
 import router, { RouteName } from '/@/router'
@@ -16,8 +16,9 @@ const useRedirectParam = () => {
       return
     }
 
-    if (isServerRequestUrl(url.value)) {
-      location.href = url.value
+    const serverRequestUrl = getServerRequestUrl(url.value)
+    if (serverRequestUrl) {
+      location.href = serverRequestUrl
       return
     }
 

--- a/src/lib/apis.ts
+++ b/src/lib/apis.ts
@@ -64,23 +64,24 @@ export const buildUserIconPathPublic = (userName: string) =>
 export const OAuthDecidePath = `${BASE_PATH}/oauth2/authorize/decide`
 
 /**
- * サーバーでの処理が必要なURLかどうかを判定する
+ * サーバーでの処理が必要な安全なURLを返す
  *
  * 例えば、`/api/v3/oauth2/authorize`は`router.replace`ではなくサーバーへのGETが必要
  * ([詳細](https://github.com/traPtitech/traQ/pull/1413))
  *
  * @param url 判定するURL (相対URLだった場合はlocation.hrefをbaseとして絶対URLに変換して判定する)
  */
-export const isServerRequestUrl = (url: string) => {
+export const getServerRequestUrl = (url: string) => {
   try {
     const u = new URL(url, location.href)
-    if (u.origin === location.origin) {
-      if (u.pathname === '/api/v3/oauth2/authorize') {
-        return true
-      }
+    if (
+      u.origin === location.origin &&
+      u.pathname === '/api/v3/oauth2/authorize'
+    ) {
+      return `/api/v3/oauth2/authorize${u.search}${u.hash}`
     }
   } catch {}
-  return false
+  return undefined
 }
 
 export const formatResizeError = (e: unknown, defaultMessage: string) => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { createRouter, createWebHistory } from 'vue-router'
 
-import { isServerRequestUrl } from '/@/lib/apis'
+import { getServerRequestUrl } from '/@/lib/apis'
 import { sessionStorageRedirectKey } from '/@/lib/dom/storage'
 
 import { settingsRoutes } from './settings'
@@ -145,8 +145,9 @@ const removeSessionStorageRedirect = router.beforeResolve(() => {
   if (redirectTo) {
     sessionStorage.removeItem(sessionStorageRedirectKey)
 
-    if (isServerRequestUrl(redirectTo)) {
-      location.href = redirectTo
+    const serverRequestUrl = getServerRequestUrl(redirectTo)
+    if (serverRequestUrl) {
+      location.href = serverRequestUrl
       return undefined
     }
     return redirectTo

--- a/tests/unit/lib/apis.spec.ts
+++ b/tests/unit/lib/apis.spec.ts
@@ -1,0 +1,22 @@
+import { getServerRequestUrl } from '/@/lib/apis'
+
+describe('getServerRequestUrl', () => {
+  it('returns a same-origin OAuth authorization URL as a relative URL', () => {
+    const url = new URL(
+      '/api/v3/oauth2/authorize?client_id=test#fragment',
+      location.origin
+    )
+
+    expect(getServerRequestUrl(url.href)).toBe(
+      '/api/v3/oauth2/authorize?client_id=test#fragment'
+    )
+  })
+
+  it.each([
+    'https://example.com/api/v3/oauth2/authorize',
+    'javascript:alert(1)',
+    '/channels/general'
+  ])('rejects %s', url => {
+    expect(getServerRequestUrl(url)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

- リダイレクト時のサニタイズ

## WHy

- fix: https://github.com/traPtitech/traQ_S-UI/security/code-scanning/150, https://github.com/traPtitech/traQ_S-UI/security/code-scanning/151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 外部認証からのリダイレクト処理を改善し、正しい認証URLへ遷移できるようになりました。
  * 認証URLに含まれる検索条件やハッシュ情報を維持してリダイレクトします。
  * OAuth認証以外のURLや外部オリジン、危険な形式のURLへの不正な遷移を防止します。

* **テスト**
  * 認証URLの変換と、不正なURLが拒否されるケースを追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->