### PR TITLE
fix: include suspended users in initial cache

### DIFF
--- a/src/store/entities/users.ts
+++ b/src/store/entities/users.ts
@@ -121,7 +121,7 @@ const useUsersStorePinia = defineStore('entities/users', () => {
       return usersMap.value
     }
 
-    const [{ data: users }, shared] = await getUsers()
+    const [{ data: users }, shared] = await getUsers(true)
     const newUsersMap = arrayToMap(users, 'id')
     if (!shared) {
       usersMap.value = newUsersMap

--- a/tests/unit/store/entities/users.spec.ts
+++ b/tests/unit/store/entities/users.spec.ts
@@ -31,6 +31,7 @@ describe('useUsersStore', () => {
   it('includes suspended users in the initial user cache', async () => {
     const users = [
       createUser('active-user', UserAccountState.active),
+      createUser('deactivated-user', UserAccountState.deactivated),
       createUser('suspended-user', UserAccountState.suspended)
     ]
     mockGetUsers.mockResolvedValue({ data: users })

--- a/tests/unit/store/entities/users.spec.ts
+++ b/tests/unit/store/entities/users.spec.ts
@@ -1,0 +1,55 @@
+import type { User } from '@traptitech/traq'
+import { UserAccountState } from '@traptitech/traq'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useUsersStore } from '/@/store/entities/users'
+
+const { mockGetUser, mockGetUsers, mockWsOn } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockGetUsers: vi.fn(),
+  mockWsOn: vi.fn()
+}))
+
+vi.mock('/@/lib/apis', () => ({
+  default: {
+    getUser: mockGetUser,
+    getUsers: mockGetUsers
+  }
+}))
+
+vi.mock('/@/lib/websocket', () => ({
+  wsListener: { on: mockWsOn }
+}))
+
+describe('useUsersStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('includes suspended users in the initial user cache', async () => {
+    const users = [
+      createUser('active-user', UserAccountState.active),
+      createUser('suspended-user', UserAccountState.suspended)
+    ]
+    mockGetUsers.mockResolvedValue({ data: users })
+
+    const { fetchUsers, usersMap } = useUsersStore()
+    await fetchUsers()
+
+    expect(mockGetUsers).toHaveBeenCalledOnce()
+    expect(mockGetUsers).toHaveBeenCalledWith(true)
+    expect([...usersMap.value.values()]).toEqual(users)
+  })
+})
+
+const createUser = (id: string, state: UserAccountState): User => ({
+  id,
+  name: id,
+  displayName: id,
+  iconFileId: `${id}-icon`,
+  state,
+  bot: false,
+  updatedAt: '2026-01-01T00:00:00Z'
+})


### PR DESCRIPTION
## Description

Include suspended users when populating the initial user cache. This makes their metadata, including icon file IDs, available on first render instead of only after a later individual fetch.

Add a focused users-store test that verifies the API request includes suspended accounts and that both active and suspended users enter the cache.

## Why do you want to merge this PR?

Closes #5332.

The initial `getUsers()` request uses the API default, which excludes suspended users. Components resolving a suspended user's icon therefore cannot find that user in the initial cache.

## Verification Steps

- `npm run lint:no-fix -- --max-warnings=0`
- `npx prettier --cache --check .`
- `npm run type-check`
- `npm run test:unit` (63 files, 783 tests)
- `npm run build:may-with-font`

## ScreenShots of UI Changes

Not applicable; this changes the initial cache contents without changing layout or styling.

## Pre-PR Check-List

- [x] I have confirmed that it works.
- [x] I have looked over the code myself, and it seems fine.

## Questions / Memo

Implementation and test preparation were completed with AI assistance. The focused regression was observed failing before the source change and passing afterward, followed by the full checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ユーザー一覧の初期取得時に、アクティブ、停止、無効化されたユーザーを正しく取得できるようになりました。

* **テスト**
  * 各状態のユーザー取得と、取得結果がキャッシュに正しく保存されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->