### PR TITLE
feat: スタンプパレットの説明をMarkdownにする

### DIFF
--- a/src/components/Settings/StampPaletteTab/StampPaletteListItemHeader.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteListItemHeader.vue
@@ -16,17 +16,23 @@
       @click="showStampPaletteDeleteToast"
     />
   </div>
-  <p :class="$style.description">
-    {{ palette.description }}
-  </p>
+  <MarkdownPreview
+    :class="$style.description"
+    :content="palette.description"
+    accept-action
+  />
 </template>
 
 <script lang="ts" setup>
 import AIcon from '/@/components/UI/AIcon.vue'
 import IconButton from '/@/components/UI/IconButton.vue'
+import MarkdownPreview from '/@/components/UI/MarkdownPreview.vue'
 import useExecWithToast from '/@/composables/toast/useExecWithToast'
 import { constructSettingsStampPaletteDetailPath } from '/@/router/settingsStampPalette'
+import { useChannelsStore } from '/@/store/entities/channels'
+import { useGroupsStore } from '/@/store/entities/groups'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
+import { useUsersStore } from '/@/store/entities/users'
 import type { StampPalette } from '/@/types/entity'
 
 const { palette } = defineProps<{
@@ -44,6 +50,14 @@ const showStampPaletteDeleteToast = async () => {
     async () => await deleteStampPalette(palette.id)
   )
 }
+
+// 説明のレンダリングに必要
+const { fetchChannels } = useChannelsStore()
+fetchChannels()
+const { fetchUsers } = useUsersStore()
+fetchUsers()
+const { fetchUserGroups } = useGroupsStore()
+fetchUserGroups()
 </script>
 
 <style lang="scss" module>
@@ -80,6 +94,5 @@ const showStampPaletteDeleteToast = async () => {
 .description {
   @include color-ui-secondary;
   @include size-body2;
-  white-space: pre-wrap;
 }
 </style>

--- a/src/components/Settings/StampPaletteTab/StampPaletteListItemHeader.vue
+++ b/src/components/Settings/StampPaletteTab/StampPaletteListItemHeader.vue
@@ -29,10 +29,7 @@ import IconButton from '/@/components/UI/IconButton.vue'
 import MarkdownPreview from '/@/components/UI/MarkdownPreview.vue'
 import useExecWithToast from '/@/composables/toast/useExecWithToast'
 import { constructSettingsStampPaletteDetailPath } from '/@/router/settingsStampPalette'
-import { useChannelsStore } from '/@/store/entities/channels'
-import { useGroupsStore } from '/@/store/entities/groups'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
-import { useUsersStore } from '/@/store/entities/users'
 import type { StampPalette } from '/@/types/entity'
 
 const { palette } = defineProps<{
@@ -50,14 +47,6 @@ const showStampPaletteDeleteToast = async () => {
     async () => await deleteStampPalette(palette.id)
   )
 }
-
-// 説明のレンダリングに必要
-const { fetchChannels } = useChannelsStore()
-fetchChannels()
-const { fetchUsers } = useUsersStore()
-fetchUsers()
-const { fetchUserGroups } = useGroupsStore()
-fetchUserGroups()
 </script>
 
 <style lang="scss" module>

--- a/src/views/Settings/StampPaletteTab/StampPaletteTab.vue
+++ b/src/views/Settings/StampPaletteTab/StampPaletteTab.vue
@@ -11,8 +11,11 @@ import { useRoute } from 'vue-router'
 
 import StampPaletteList from '/@/components/Settings/StampPaletteTab/StampPaletteList.vue'
 import { settingsStampPaletteRouteName } from '/@/router/settings'
+import { useChannelsStore } from '/@/store/entities/channels'
+import { useGroupsStore } from '/@/store/entities/groups'
 import { useStampPalettesStore } from '/@/store/entities/stampPalettes'
 import { useStampsStore } from '/@/store/entities/stamps'
+import { useUsersStore } from '/@/store/entities/users'
 
 const route = useRoute()
 const isPathStampPalette = computed(
@@ -23,6 +26,13 @@ const { fetchStamps } = useStampsStore()
 fetchStamps()
 const { fetchStampPalettes } = useStampPalettesStore()
 fetchStampPalettes()
+// 説明のレンダリングに必要
+const { fetchChannels } = useChannelsStore()
+fetchChannels()
+const { fetchUsers } = useUsersStore()
+fetchUsers()
+const { fetchUserGroups } = useGroupsStore()
+fetchUserGroups()
 </script>
 
 <style lang="scss" module></style>


### PR DESCRIPTION
## 概要

/settings/stamp-palette の作成したスタンプパレットにつける説明を、Markdownに対応させました。

## なぜこの PR を入れたいのか

クリップフォルダの説明やチャンネルトピックなどと同様に、Markdownでも問題がなさそう。

#5286 で、pタグが扱いずらい。

長い文章は飛び出すようになっていた。(これに関しては overflow-wrap: anywhere; で対応できるが、Markdownにしてもいい気がする。)

close: #5345 

<!-- issue 番号だけでも OK / close: #123 とか fix: #123 の形で -->

## 動作確認の手順

スタンプパレットを作成し、markdown記法で説明を入力する

## UI 変更部分のスクリーンショット

| Before               | After                |
| -------------------- | -------------------- |
| <img width="1614" height="1268" alt="image" src="https://github.com/user-attachments/assets/3e07ae08-41b2-4598-908f-8b99dfe1348d" /> | <img width="1200" height="1400" alt="image" src="https://github.com/user-attachments/assets/4c894e98-1265-4f59-95b2-17d5904fbd15" /> |

## PR を出す前の確認事項

- [ ] （機能の追加なら）追加することの合意がチームで取れている
  - 取れていない場合はチェックを外して PR にすれば OK
- [x] 動作確認ができている
- [x] 自分で一度コードを眺めて自分的に問題はなさそう

## 見てほしいところ・聞きたいことなど
- CSS
- fetchの位置
- inline ではなくてもいいんじゃない？と思った

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * スタンプパレットの説明欄がMarkdown表示に対応しました。
  * 改行や書式を反映して、説明文をより見やすく表示できます。
  * 説明内のアクションにも対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->